### PR TITLE
merged upstream: Always use static ports for client load-balancers (#3026)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/opencontainers/selinux v1.6.0
 	github.com/pierrec/lz4 v2.5.2+incompatible
 	github.com/pkg/errors v0.9.1
-	github.com/rancher/dynamiclistener v0.2.2
+	github.com/rancher/dynamiclistener v0.2.3
 	github.com/k3s-io/helm-controller v0.8.3
 	github.com/rancher/kine v0.5.1
 	github.com/rancher/remotedialer v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -821,6 +821,8 @@ github.com/rancher/dynamiclistener v0.2.1 h1:QiY1jxs2TOLrKB04G36vE2ehEvPMPGiWp8z
 github.com/rancher/dynamiclistener v0.2.1/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
 github.com/rancher/dynamiclistener v0.2.2 h1:70dMwOr1sqb6mQqfU2nDb/fr5cv7HJjH+kFYzoxb8KU=
 github.com/rancher/dynamiclistener v0.2.2/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
+github.com/rancher/dynamiclistener v0.2.3 h1:FHn0Gkx+kIUqsFs3zMMR2QC9ufH/AoBLqO5zH5hbtqw=
+github.com/rancher/dynamiclistener v0.2.3/go.mod h1:9WusTANoiRr8cDWCTtf5txieulezHbpv4vhLADPp0zU=
 github.com/rancher/flannel v0.12.0-k3s1 h1:P23dWSk/9mGT1x2rDWW9JXNrF/0kjftiHwMau/+ZLGM=
 github.com/rancher/flannel v0.12.0-k3s1/go.mod h1:zQ/9Uhaw0yV4Wh6ljVwHVT1x5KuhenZA+6L8lRzOJEY=
 github.com/rancher/go-powershell v0.0.0-20200701182037-6845e6fcfa79 h1:UeC0rjrIel8hHz92cdVN09Cm4Hz+BhsPP/ZvQnPOr58=

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -167,7 +167,7 @@ func getServingCert(nodeName, nodeIP, servingCertFile, servingKeyFile, nodePassw
 
 func getHostFile(filename, keyFile string, info *clientaccess.Info) error {
 	basename := filepath.Base(filename)
-	fileBytes, err := clientaccess.Get("/v1-"+version.Program+"/"+basename, info)
+	fileBytes, err := info.Get("/v1-" + version.Program + "/" + basename)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 }
 
 func getConfig(info *clientaccess.Info) (*config.Control, error) {
-	data, err := clientaccess.Get("/v1-"+version.Program+"/config", info)
+	data, err := info.Get("/v1-" + version.Program + "/config")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -306,8 +306,9 @@ func get(envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 		return nil, err
 	}
 
+	// If the supervisor and externally-facing apiserver are not on the same port, tell the proxy where to find the apiserver.
 	if controlConfig.SupervisorPort != controlConfig.HTTPSPort {
-		if err := proxy.StartAPIServerProxy(controlConfig.HTTPSPort); err != nil {
+		if err := proxy.SetAPIServerPort(controlConfig.HTTPSPort); err != nil {
 			return nil, errors.Wrapf(err, "failed to setup access to API Server port %d on at %s", controlConfig.HTTPSPort, proxy.SupervisorURL())
 		}
 	}

--- a/pkg/agent/loadbalancer/loadbalancer.go
+++ b/pkg/agent/loadbalancer/loadbalancer.go
@@ -58,6 +58,11 @@ func New(dataDir, serviceName, serverURL string, lbServerPort int) (_lb *LoadBal
 		return nil, err
 	}
 
+	if serverURL == localServerURL {
+		logrus.Debugf("Initial server URL for load balancer points at local server URL - starting with empty original server address")
+		originalServerAddress = ""
+	}
+
 	lb := &LoadBalancer{
 		dialer:                &net.Dialer{},
 		configFile:            filepath.Join(dataDir, "etc", serviceName+".json"),

--- a/pkg/agent/proxy/apiproxy.go
+++ b/pkg/agent/proxy/apiproxy.go
@@ -13,16 +13,23 @@ import (
 
 type Proxy interface {
 	Update(addresses []string)
-	StartAPIServerProxy(port int) error
+	SetAPIServerPort(port int) error
 	SupervisorURL() string
 	SupervisorAddresses() []string
 	APIServerURL() string
 	IsAPIServerLBEnabled() bool
 }
 
-func NewAPIProxy(enabled bool, dataDir, supervisorURL string, lbServerPort int) (Proxy, error) {
+// NewSupervisorProxy sets up a new proxy for retrieving supervisor and apiserver addresses.  If
+// lbEnabled is true, a load-balancer is started on the requested port to connect to the supervisor
+// address, and the address of this local load-balancer is returned instead of the actual supervisor
+// and apiserver addresses.
+// NOTE: This is a proxy in the API sense - it returns either actual server URLs, or the URL of the
+// local load-balancer. It is not actually responsible for proxying requests at the network level;
+// this is handled by the load-balancers that the proxy optionally steers connections towards.
+func NewSupervisorProxy(lbEnabled bool, dataDir, supervisorURL string, lbServerPort int) (Proxy, error) {
 	p := proxy{
-		lbEnabled:            enabled,
+		lbEnabled:            lbEnabled,
 		dataDir:              dataDir,
 		initialSupervisorURL: supervisorURL,
 		supervisorURL:        supervisorURL,
@@ -30,7 +37,7 @@ func NewAPIProxy(enabled bool, dataDir, supervisorURL string, lbServerPort int) 
 		lbServerPort:         lbServerPort,
 	}
 
-	if enabled {
+	if lbEnabled {
 		lb, err := loadbalancer.New(dataDir, loadbalancer.SupervisorServiceName, supervisorURL, p.lbServerPort)
 		if err != nil {
 			return nil, err
@@ -51,20 +58,20 @@ func NewAPIProxy(enabled bool, dataDir, supervisorURL string, lbServerPort int) 
 }
 
 type proxy struct {
-	dataDir      string
-	lbEnabled    bool
-	lbServerPort int
+	dataDir          string
+	lbEnabled        bool
+	lbServerPort     int
+	apiServerEnabled bool
 
-	initialSupervisorURL      string
+	apiServerURL              string
 	supervisorURL             string
 	supervisorPort            string
+	initialSupervisorURL      string
 	fallbackSupervisorAddress string
 	supervisorAddresses       []string
-	supervisorLB              *loadbalancer.LoadBalancer
 
-	apiServerURL     string
-	apiServerLB      *loadbalancer.LoadBalancer
-	apiServerEnabled bool
+	apiServerLB  *loadbalancer.LoadBalancer
+	supervisorLB *loadbalancer.LoadBalancer
 }
 
 func (p *proxy) Update(addresses []string) {
@@ -98,7 +105,12 @@ func (p *proxy) setSupervisorPort(addresses []string) []string {
 	return newAddresses
 }
 
-func (p *proxy) StartAPIServerProxy(port int) error {
+// SetAPIServerPort configures the proxy to return a different set of addresses for the apiserver,
+// for use in cases where the apiserver is not running on the same port as the supervisor. If
+// load-balancing is enabled, another load-balancer is started on a port one below the supervisor
+// load-balancer, and the address of this load-balancer is returned instead of the actual apiserver
+// addresses.
+func (p *proxy) SetAPIServerPort(port int) error {
 	u, err := url.Parse(p.initialSupervisorURL)
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse server URL %s", p.initialSupervisorURL)
@@ -112,7 +124,7 @@ func (p *proxy) StartAPIServerProxy(port int) error {
 		lbServerPort := p.lbServerPort
 
 		if lbServerPort != 0 {
-			lbServerPort = lbServerPort + 1
+			lbServerPort = lbServerPort - 1
 		}
 		lb, err := loadbalancer.New(p.dataDir, loadbalancer.APIServerServiceName, p.apiServerURL, lbServerPort)
 		if err != nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -139,12 +139,12 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 		}
 	}
 
-	cfg.DataDir = filepath.Join(cfg.DataDir, "agent")
+	agentDir := filepath.Join(cfg.DataDir, "agent")
 	if err := os.MkdirAll(cfg.DataDir, 0700); err != nil {
 		return err
 	}
 
-	proxy, err := proxy.NewAPIProxy(!cfg.DisableLoadBalancer, cfg.DataDir, cfg.ServerURL, cfg.LBServerPort)
+	proxy, err := proxy.NewSupervisorProxy(!cfg.DisableLoadBalancer, agentDir, cfg.ServerURL, cfg.LBServerPort)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -158,7 +158,7 @@ var (
 		Destination: &AgentConfig.EnableSELinux,
 		EnvVar:      version.ProgramUpper + "_SELINUX",
 	}
-	LBServerPort = cli.IntFlag{
+	LBServerPortFlag = cli.IntFlag{
 		Name:        "lb-server-port",
 		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
 		Hidden:      false,
@@ -239,6 +239,7 @@ func NewAgentCommand(action func(ctx *cli.Context) error) cli.Command {
 				Destination: &AgentConfig.Rootless,
 			},
 			&SELinuxFlag,
+			LBServerPortFlag,
 
 			// Deprecated/hidden below
 

--- a/pkg/cli/cmds/agent.go
+++ b/pkg/cli/cmds/agent.go
@@ -160,11 +160,11 @@ var (
 	}
 	LBServerPort = cli.IntFlag{
 		Name:        "lb-server-port",
-		Usage:       "(agent/node) Internal Loadbalancer port",
+		Usage:       "(agent/node) Local port for supervisor client load-balancer. If the supervisor and apiserver are not colocated an additional port 1 less than this port will also be used for the apiserver client load-balancer.",
 		Hidden:      false,
 		Destination: &AgentConfig.LBServerPort,
 		EnvVar:      version.ProgramUpper + "_LB_SERVER_PORT",
-		Value:       0,
+		Value:       6444,
 	}
 )
 

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -350,6 +350,7 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Destination: &ServerConfig.EncryptSecrets,
 			},
 			&SELinuxFlag,
+			LBServerPortFlag,
 
 			// Hidden/Deprecated flags below
 

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -133,6 +133,10 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 		serverConfig.ControlConfig.SupervisorPort = serverConfig.ControlConfig.HTTPSPort
 	}
 
+	if serverConfig.ControlConfig.DisableETCD && serverConfig.ControlConfig.JoinURL == "" {
+		return errors.New("invalid flag use. --server required with --disable-etcd")
+	}
+
 	if serverConfig.ControlConfig.DisableAPIServer {
 		// Servers without a local apiserver need to connect to the apiserver via the proxy load-balancer.
 		serverConfig.ControlConfig.APIServerPort = cmds.AgentConfig.LBServerPort

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -33,10 +33,6 @@ import (
 	_ "github.com/mattn/go-sqlite3"    // ensure we have sqlite
 )
 
-const (
-	lbServerPort = 6444
-)
-
 func Run(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
@@ -138,9 +134,12 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	}
 
 	if serverConfig.ControlConfig.DisableAPIServer {
-		serverConfig.ControlConfig.APIServerPort = lbServerPort
+		// Servers without a local apiserver need to connect to the apiserver via the proxy load-balancer.
+		serverConfig.ControlConfig.APIServerPort = cmds.AgentConfig.LBServerPort
+		// If the supervisor and externally-facing apiserver are not on the same port, the proxy will
+		// have a separate load-balancer for the apiserver that we need to use instead.
 		if serverConfig.ControlConfig.SupervisorPort != serverConfig.ControlConfig.HTTPSPort {
-			serverConfig.ControlConfig.APIServerPort = lbServerPort + 1
+			serverConfig.ControlConfig.APIServerPort = cmds.AgentConfig.LBServerPort - 1
 		}
 	}
 
@@ -305,8 +304,6 @@ func run(app *cli.Context, cfg *cmds.Server) error {
 	}
 
 	if serverConfig.ControlConfig.DisableAPIServer {
-		// setting LBServerPort to a prespecified port to initialize the kubeconfigs with the right address
-		agentConfig.LBServerPort = lbServerPort
 		// initialize the apiAddress Channel for receiving the api address from etcd
 		agentConfig.APIAddressCh = make(chan string, 1)
 		setAPIAddressChannel(ctx, &serverConfig, &agentConfig)

--- a/pkg/clientaccess/token.go
+++ b/pkg/clientaccess/token.go
@@ -13,10 +13,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var (
-	defaultClientTimeout = 20 * time.Second
+	defaultClientTimeout = 10 * time.Second
 
 	defaultClient = &http.Client{
 		Timeout: defaultClientTimeout,
@@ -32,8 +33,9 @@ var (
 )
 
 const (
-	tokenPrefix = "K10"
-	tokenFormat = "%s%s::%s:%s"
+	tokenPrefix  = "K10"
+	tokenFormat  = "%s%s::%s:%s"
+	caHashLength = sha256.Size * 2
 )
 
 type OverrideURLCallback func(config []byte) (*url.URL, error)
@@ -59,14 +61,8 @@ func ParseAndValidateToken(server string, token string) (*Info, error) {
 		return nil, err
 	}
 
-	if err := info.setServer(server); err != nil {
+	if err := info.setAndValidateServer(server); err != nil {
 		return nil, err
-	}
-
-	if info.caHash != "" {
-		if err := info.validateCAHash(); err != nil {
-			return nil, err
-		}
 	}
 
 	return info, nil
@@ -82,26 +78,24 @@ func ParseAndValidateTokenForUser(server string, token string, username string) 
 
 	info.Username = username
 
-	if err := info.setServer(server); err != nil {
+	if err := info.setAndValidateServer(server); err != nil {
 		return nil, err
-	}
-
-	if info.caHash != "" {
-		if err := info.validateCAHash(); err != nil {
-			return nil, err
-		}
 	}
 
 	return info, nil
 }
 
+// setAndValidateServer updates the remote server's cert info, and validates it against the provided hash
+func (info *Info) setAndValidateServer(server string) error {
+	if err := info.setServer(server); err != nil {
+		return err
+	}
+	return info.validateCAHash()
+}
+
 // validateCACerts returns a boolean indicating whether or not a CA bundle matches the provided hash,
 // and a string containing the hash of the CA bundle.
 func validateCACerts(cacerts []byte, hash string) (bool, string) {
-	if len(cacerts) == 0 && hash == "" {
-		return true, ""
-	}
-
 	newHash := hashCA(cacerts)
 	return hash == newHash, newHash
 }
@@ -126,6 +120,10 @@ func ParseUsernamePassword(token string) (string, string, bool) {
 func parseToken(token string) (*Info, error) {
 	var info = &Info{}
 
+	if len(token) == 0 {
+		return nil, errors.New("token must not be empty")
+	}
+
 	if !strings.HasPrefix(token, tokenPrefix) {
 		token = fmt.Sprintf(tokenFormat, tokenPrefix, "", "", token)
 	}
@@ -136,13 +134,17 @@ func parseToken(token string) (*Info, error) {
 	parts := strings.SplitN(token, "::", 2)
 	token = parts[0]
 	if len(parts) > 1 {
+		hashLen := len(parts[0])
+		if hashLen > 0 && hashLen != caHashLength {
+			return nil, errors.New("invalid token CA hash length")
+		}
 		info.caHash = parts[0]
 		token = parts[1]
 	}
 
 	parts = strings.SplitN(token, ":", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid token format")
+	if len(parts) != 2 || len(parts[1]) == 0 {
+		return nil, errors.New("invalid token format")
 	}
 
 	info.Username = parts[0]
@@ -175,7 +177,7 @@ func GetHTTPClient(cacerts []byte) *http.Client {
 }
 
 // Get makes a request to a subpath of info's BaseURL
-func Get(path string, info *Info) ([]byte, error) {
+func (info *Info) Get(path string) ([]byte, error) {
 	u, err := url.Parse(info.BaseURL)
 	if err != nil {
 		return nil, err
@@ -212,10 +214,20 @@ func (info *Info) setServer(server string) error {
 
 // ValidateCAHash validates that info's caHash matches the CACerts hash.
 func (info *Info) validateCAHash() error {
-	if ok, serverHash := validateCACerts(info.CACerts, info.caHash); !ok {
-		return fmt.Errorf("token CA hash does not match the server CA hash: %s != %s", info.caHash, serverHash)
+	if len(info.caHash) > 0 && len(info.CACerts) == 0 {
+		// Warn if the user provided a CA hash but we're not going to validate because it's already trusted
+		logrus.Warn("Cluster CA certificate is trusted by the host CA bundle. " +
+			"Token CA hash will not be validated.")
+	} else if len(info.caHash) == 0 && len(info.CACerts) > 0 {
+		// Warn if the CA is self-signed but the user didn't provide a hash to validate it against
+		logrus.Warn("Cluster CA certificate is not trusted by the host CA bundle, but the token does not include a CA hash. " +
+			"Use the full token from the server's node-token file to enable Cluster CA validation.")
+	} else if len(info.CACerts) > 0 && len(info.caHash) > 0 {
+		// only verify CA hash if the server cert is not trusted by the OS CA bundle
+		if ok, serverHash := validateCACerts(info.CACerts, info.caHash); !ok {
+			return fmt.Errorf("token CA hash does not match the Cluster CA certificate hash: %s != %s", info.caHash, serverHash)
+		}
 	}
-
 	return nil
 }
 

--- a/pkg/clientaccess/token_test.go
+++ b/pkg/clientaccess/token_test.go
@@ -1,0 +1,401 @@
+package clientaccess
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rancher/dynamiclistener/cert"
+	"github.com/rancher/dynamiclistener/factory"
+	"github.com/stretchr/testify/assert"
+	"github.com/xiaods/k8e/pkg/bootstrap"
+	"github.com/xiaods/k8e/pkg/daemons/config"
+)
+
+var (
+	defaultUsername = "server"
+	defaultPassword = "token"
+)
+
+// TestTrustedCA confirms that tokens are validated when the server uses a cert (self-signed or otherwise)
+// that is trusted by the OS CA bundle. This test must be run first, since it mucks with the system root certs.
+func TestTrustedCA(t *testing.T) {
+	assert := assert.New(t)
+	server := newTLSServer(t, defaultUsername, defaultPassword, false)
+	defer server.Close()
+
+	testInfo := &Info{
+		CACerts:  getServerCA(server),
+		BaseURL:  server.URL,
+		Username: defaultUsername,
+		Password: defaultPassword,
+		caHash:   hashCA(getServerCA(server)),
+	}
+
+	testCases := []struct {
+		token    string
+		expected string
+	}{
+		{defaultPassword, ""},
+		{testInfo.String(), testInfo.Username},
+	}
+
+	// Point OS CA bundle at this test's CA cert to simulate a trusted CA cert.
+	// Note that this only works if the OS CA bundle has not yet been loaded in this process,
+	// as it is cached for the duration of the process lifetime.
+	// Ref: https://github.com/golang/go/issues/41888
+	path := t.TempDir() + "/ca.crt"
+	writeServerCA(server, path)
+	os.Setenv("SSL_CERT_FILE", path)
+
+	for _, testCase := range testCases {
+		info, err := ParseAndValidateToken(server.URL, testCase.token)
+		if assert.NoError(err, testCase) {
+			assert.Nil(info.CACerts, testCase)
+			assert.Equal(testCase.expected, info.Username, testCase.token)
+		}
+
+		info, err = ParseAndValidateTokenForUser(server.URL, testCase.token, "agent")
+		if assert.NoError(err, testCase) {
+			assert.Nil(info.CACerts, testCase)
+			assert.Equal("agent", info.Username, testCase)
+		}
+	}
+
+	// Confirm that the cert is actually trusted by the OS CA bundle by making a request
+	// with empty cert pool
+	testInfo.CACerts = nil
+	res, err := testInfo.Get("/v1-k8e/server-bootstrap")
+	assert.NoError(err)
+	assert.NotEmpty(res)
+}
+
+// TestUntrustedCA confirms that tokens are validated when the server uses a self-signed cert
+// that is NOT trusted by the OS CA bundle.
+func TestUntrustedCA(t *testing.T) {
+	assert := assert.New(t)
+	server := newTLSServer(t, defaultUsername, defaultPassword, false)
+	defer server.Close()
+
+	testInfo := &Info{
+		CACerts:  getServerCA(server),
+		BaseURL:  server.URL,
+		Username: defaultUsername,
+		Password: defaultPassword,
+		caHash:   hashCA(getServerCA(server)),
+	}
+
+	testCases := []struct {
+		token    string
+		expected string
+	}{
+		{defaultPassword, ""},
+		{testInfo.String(), testInfo.Username},
+	}
+
+	for _, testCase := range testCases {
+		info, err := ParseAndValidateToken(server.URL, testCase.token)
+		if assert.NoError(err, testCase) {
+			assert.Equal(testInfo.CACerts, info.CACerts, testCase)
+			assert.Equal(testCase.expected, info.Username, testCase)
+		}
+
+		info, err = ParseAndValidateTokenForUser(server.URL, testCase.token, "agent")
+		if assert.NoError(err, testCase) {
+			assert.Equal(testInfo.CACerts, info.CACerts, testCase)
+			assert.Equal("agent", info.Username, testCase)
+		}
+	}
+}
+
+// TestInvalidServers tests that invalid server URLs are properly rejected
+func TestInvalidServers(t *testing.T) {
+	assert := assert.New(t)
+	testCases := []struct {
+		server   string
+		token    string
+		expected string
+	}{
+		{" https://localhost:6443", "token", "Invalid server url, failed to parse:  https://localhost:6443: parse \" https://localhost:6443\": first path segment in URL cannot contain colon"},
+		{"http://localhost:6443", "token", "only https:// URLs are supported, invalid scheme: http://localhost:6443"},
+	}
+
+	for _, testCase := range testCases {
+		_, err := ParseAndValidateToken(testCase.server, testCase.token)
+		assert.EqualError(err, testCase.expected, testCase)
+
+		_, err = ParseAndValidateTokenForUser(testCase.server, testCase.token, defaultUsername)
+		assert.EqualError(err, testCase.expected, testCase)
+	}
+}
+
+// TestInvalidTokens tests that tokens which are empty, invalid, or incorrect are properly rejected
+func TestInvalidTokens(t *testing.T) {
+	assert := assert.New(t)
+	server := newTLSServer(t, defaultUsername, defaultPassword, false)
+	defer server.Close()
+
+	testCases := []struct {
+		server   string
+		token    string
+		expected string
+	}{
+		{server.URL, "", "token must not be empty"},
+		{server.URL, "K10::", "invalid token format"},
+		{server.URL, "K10::x", "invalid token format"},
+		{server.URL, "K10::x:", "invalid token format"},
+		{server.URL, "K10XX::x:y", "invalid token CA hash length"},
+		{server.URL,
+			"K10XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX::x:y",
+			"token CA hash does not match the Cluster CA certificate hash: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX != " + hashCA(getServerCA(server))},
+	}
+
+	for _, testCase := range testCases {
+		info, err := ParseAndValidateToken(testCase.server, testCase.token)
+		assert.EqualError(err, testCase.expected, testCase)
+		assert.Nil(info, testCase)
+
+		info, err = ParseAndValidateTokenForUser(testCase.server, testCase.token, defaultUsername)
+		assert.EqualError(err, testCase.expected, testCase)
+		assert.Nil(info, testCase)
+	}
+}
+
+// TestInvalidCredentials tests that tokens which don't have valid credentials are rejected
+func TestInvalidCredentials(t *testing.T) {
+	assert := assert.New(t)
+	server := newTLSServer(t, defaultUsername, defaultPassword, false)
+	defer server.Close()
+
+	testInfo := &Info{
+		CACerts:  getServerCA(server),
+		BaseURL:  server.URL,
+		Username: "nobody",
+		Password: "invalid",
+		caHash:   hashCA(getServerCA(server)),
+	}
+
+	testCases := []string{
+		testInfo.Password,
+		testInfo.String(),
+	}
+
+	for _, testCase := range testCases {
+		info, err := ParseAndValidateToken(server.URL, testCase)
+		assert.NoError(err, testCase)
+		if assert.NotNil(info) {
+			res, err := info.Get("/v1-k8e/server-bootstrap")
+			assert.Error(err, testCase)
+			assert.Empty(res, testCase)
+		}
+
+		info, err = ParseAndValidateTokenForUser(server.URL, testCase, defaultUsername)
+		assert.NoError(err, testCase)
+		if assert.NotNil(info) {
+			res, err := info.Get("/v1-k8e/server-bootstrap")
+			assert.Error(err, testCase)
+			assert.Empty(res, testCase)
+		}
+	}
+}
+
+// TestWrongCert tests that errors are returned when the server's cert isn't issued by its CA
+func TestWrongCert(t *testing.T) {
+	assert := assert.New(t)
+	server := newTLSServer(t, defaultUsername, defaultPassword, true)
+	defer server.Close()
+
+	info, err := ParseAndValidateToken(server.URL, defaultPassword)
+	assert.Error(err)
+	assert.Nil(info)
+
+	info, err = ParseAndValidateTokenForUser(server.URL, defaultPassword, defaultUsername)
+	assert.Error(err)
+	assert.Nil(info)
+}
+
+// TestConnectionFailures tests that connections are timed out properly
+func TestConnectionFailures(t *testing.T) {
+	testDuration := (defaultClientTimeout * 2) + time.Second
+	assert := assert.New(t)
+	testCases := []struct {
+		server string
+		token  string
+	}{
+		{"https://192.0.2.1:6443", "token"}, // RFC 5735 TEST-NET-1 for use in documentation and example code
+		{"https://localhost:1", "token"},
+	}
+
+	for _, testCase := range testCases {
+		startTime := time.Now()
+		info, err := ParseAndValidateToken(testCase.server, testCase.token)
+		assert.Error(err, testCase)
+		assert.Nil(info, testCase)
+		assert.WithinDuration(time.Now(), startTime, testDuration, testCase)
+
+		startTime = time.Now()
+		info, err = ParseAndValidateTokenForUser(testCase.server, testCase.token, defaultUsername)
+		assert.Error(err, testCase)
+		assert.Nil(info, testCase)
+		assert.WithinDuration(startTime, time.Now(), testDuration, testCase)
+	}
+}
+
+// TestUserPass tests that usernames and passwords are parsed or not parsed from token strings
+func TestUserPass(t *testing.T) {
+	assert := assert.New(t)
+	testCases := []struct {
+		token    string
+		username string
+		password string
+		expect   bool
+	}{
+		{"K10XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX::username:password", "username", "password", true},
+		{"password", "", "password", true},
+		{"K10X::x", "", "", false},
+	}
+
+	for _, testCase := range testCases {
+		username, password, ok := ParseUsernamePassword(testCase.token)
+		assert.Equal(testCase.expect, ok, testCase)
+		if ok {
+			assert.Equal(testCase.username, username, testCase)
+			assert.Equal(testCase.password, password, testCase)
+		}
+	}
+}
+
+// TestParseAndGet tests URL handling along some hard-to-reach code paths
+func TestParseAndGet(t *testing.T) {
+	assert := assert.New(t)
+	server := newTLSServer(t, defaultUsername, defaultPassword, false)
+	defer server.Close()
+
+	testCases := []struct {
+		extraBasePre  string
+		extraBasePost string
+		path          string
+		parseFail     bool
+		getFail       bool
+	}{
+		{"/", "", "/cacerts", false, false},
+		{"/%2", "", "/cacerts", true, false},
+		{"", "", "/%2", false, true},
+		{"", "/%2", "/cacerts", false, true},
+	}
+
+	for _, testCase := range testCases {
+		info, err := ParseAndValidateTokenForUser(server.URL+testCase.extraBasePre, defaultPassword, defaultUsername)
+		// Check for expected error when parsing server + token
+		if testCase.parseFail {
+			assert.Error(err, testCase)
+		} else if assert.NoError(err, testCase) {
+			info.BaseURL = server.URL + testCase.extraBasePost
+			_, err := info.Get(testCase.path)
+			// Check for expected error when making Get request
+			if testCase.getFail {
+				assert.Error(err, testCase)
+			} else {
+				assert.NoError(err, testCase)
+			}
+		}
+	}
+}
+
+// newTLSServer returns a HTTPS server that mocks the basic functionality required to validate K8e join tokens.
+// Each call to this function will generate new CA and server certificates unique to the returned server.
+func newTLSServer(t *testing.T, username, password string, sendWrongCA bool) *httptest.Server {
+	var server *httptest.Server
+	server = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1-k8e/server-bootstrap" {
+			if authUsername, authPassword, ok := r.BasicAuth(); ok != true || authPassword != password || authUsername != username {
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+			bootstrapData := &config.ControlRuntimeBootstrap{}
+			w.Header().Set("Content-Type", "application/json")
+			if err := bootstrap.Write(w, bootstrapData); err != nil {
+				t.Errorf("failed to write bootstrap: %v", err)
+			}
+			return
+		}
+
+		if r.URL.Path == "/cacerts" {
+			w.Header().Set("Content-Type", "text/plain")
+			if _, err := w.Write(getServerCA(server)); err != nil {
+				t.Errorf("Failed to write cacerts: %v", err)
+			}
+			return
+		}
+
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	}))
+
+	// Create new CA cert and key
+	caCert, caKey, err := factory.GenCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate new server cert; reuse the key from the CA
+	cfg := cert.Config{
+		CommonName:   "localhost",
+		Organization: []string{"testing"},
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		AltNames: cert.AltNames{
+			DNSNames: []string{"localhost"},
+			IPs:      []net.IP{net.IPv4(127, 0, 0, 1)},
+		},
+	}
+	serverCert, err := cert.NewSignedCert(cfg, caKey, caCert, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Bind server and CA certs into chain for TLS listener configuration
+	server.TLS = &tls.Config{}
+	server.TLS.Certificates = []tls.Certificate{
+		{Certificate: [][]byte{serverCert.Raw}, Leaf: serverCert, PrivateKey: caKey},
+		{Certificate: [][]byte{caCert.Raw}, Leaf: caCert},
+	}
+
+	if sendWrongCA {
+		// Create new CA cert and key and use that as the CA cert instead of the one that actually signed the server cert
+		badCert, _, err := factory.GenCA()
+		if err != nil {
+			t.Fatal(err)
+		}
+		server.TLS.Certificates[1].Certificate[0] = badCert.Raw
+		server.TLS.Certificates[1].Leaf = badCert
+	}
+
+	server.StartTLS()
+	return server
+}
+
+// getServerCA returns a byte slice containing the PEM encoding of the server's CA certificate
+func getServerCA(server *httptest.Server) []byte {
+	certLen := len(server.TLS.Certificates)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.TLS.Certificates[certLen-1].Certificate[0]})
+}
+
+// writeServerCA writes the PEM-encoded server certificate to a given path
+func writeServerCA(server *httptest.Server, path string) error {
+	certOut, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer certOut.Close()
+
+	if _, err := certOut.Write(getServerCA(server)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -120,7 +120,7 @@ func (c *Cluster) bootstrapped() error {
 // and loads it into the ControlRuntimeBootstrap struct. Unlike the storage bootstrap path,
 // this data does not need to be decrypted since it is generated on-demand by an existing server.
 func (c *Cluster) httpBootstrap() error {
-	content, err := clientaccess.Get("/v1-"+version.Program+"/server-bootstrap", c.clientAccessInfo)
+	content, err := c.clientAccessInfo.Get("/v1-" + version.Program + "/server-bootstrap")
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"

--- a/pkg/cluster/managed.go
+++ b/pkg/cluster/managed.go
@@ -142,8 +142,17 @@ func (c *Cluster) setupEtcdProxy(ctx context.Context, etcdProxy etcd.Proxy) {
 				logrus.Warnf("failed to get etcd client URLs: %v", err)
 				continue
 			}
-			etcdProxy.Update(newAddresses)
-
+			// client URLs are a full URI, but the proxy only wants host:port
+			var hosts []string
+			for _, address := range newAddresses {
+				u, err := url.Parse(address)
+				if err != nil {
+					logrus.Warnf("failed to parse etcd client URL: %v", err)
+					continue
+				}
+				hosts = append(hosts, u.Host)
+			}
+			etcdProxy.Update(hosts)
 		}
 	}()
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -674,7 +674,7 @@ func (e *ETCD) setLearnerProgress(ctx context.Context, status *learnerProgress) 
 // clientURLs returns a list of all non-learner etcd cluster member client access URLs
 func ClientURLs(ctx context.Context, clientAccessInfo *clientaccess.Info, selfIP string) ([]string, Members, error) {
 	var memberList Members
-	resp, err := clientaccess.Get("/db/info", clientAccessInfo)
+	resp, err := clientAccessInfo.Get("/db/info")
 	if err != nil {
 		return nil, memberList, err
 	}

--- a/pkg/etcd/etcdproxy.go
+++ b/pkg/etcd/etcdproxy.go
@@ -29,7 +29,7 @@ func NewETCDProxy(enabled bool, dataDir, etcdURL string) (Proxy, error) {
 	}
 
 	if enabled {
-		lb, err := loadbalancer.New(dataDir, loadbalancer.ETCDServerServiceName, u.Host, 2379)
+		lb, err := loadbalancer.New(dataDir, loadbalancer.ETCDServerServiceName, etcdURL, 2379)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/etcd.go
+++ b/pkg/server/etcd.go
@@ -28,11 +28,6 @@ func setETCDLabelsAndAnnotations(ctx context.Context, config *Config) error {
 			continue
 		}
 
-		if err := stageFiles(ctx, sc, controlConfig); err != nil {
-			logrus.Infof("Failed to set etcd role label: %v", err)
-			continue
-		}
-
 		if err := sc.Start(ctx); err != nil {
 			logrus.Infof("Failed to set etcd role label: %v", err)
 			continue

--- a/vendor/github.com/rancher/dynamiclistener/listener.go
+++ b/vendor/github.com/rancher/dynamiclistener/listener.go
@@ -347,7 +347,7 @@ func (l *listener) loadCert() (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	if l.cert != nil && l.version == secret.ResourceVersion {
+	if l.cert != nil && l.version == secret.ResourceVersion && secret.ResourceVersion != "" {
 		return l.cert, nil
 	}
 
@@ -360,7 +360,7 @@ func (l *listener) loadCert() (*tls.Certificate, error) {
 	if err != nil {
 		return nil, err
 	}
-	if l.cert != nil && l.version == secret.ResourceVersion {
+	if l.cert != nil && l.version == secret.ResourceVersion && secret.ResourceVersion != "" {
 		return l.cert, nil
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -823,7 +823,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0
 github.com/rakelkar/gonetsh/netroute
 github.com/rakelkar/gonetsh/netsh
-# github.com/rancher/dynamiclistener v0.2.2
+# github.com/rancher/dynamiclistener v0.2.3
 ## explicit
 github.com/rancher/dynamiclistener
 github.com/rancher/dynamiclistener/cert


### PR DESCRIPTION
* Always use static ports for the load-balancers

This fixes an issue where RKE2 kube-proxy daemonset pods were failing to
communicate with the apiserver when RKE2 was restarted because the
load-balancer used a different port every time it started up.

This also changes the apiserver load-balancer port to be 1 below the
supervisor port instead of 1 above it. This makes the apiserver port
consistent at 6443 across servers and agents on RKE2.

Additional fixes below were required to successfully test and use this change
on etcd-only nodes.

* Actually add lb-server-port flag to CLI
* Fix nil pointer when starting server with --disable-etcd but no --server
* Don't try to use full URI as initial load-balancer endpoint
* Fix etcd load-balancer pool updates
* Update dynamiclistener to fix cert updates on etcd-only nodes
* Handle recursive initial server URL in load balancer
* Don't run the deploy controller on etcd-only nodes