### PR TITLE
bugfix: prevent snapshot save when snapshots are disabled

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -122,25 +122,26 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.DisableControllerManager = cfg.DisableControllerManager
 	serverConfig.ControlConfig.ClusterInit = cfg.ClusterInit
 	serverConfig.ControlConfig.EncryptSecrets = cfg.EncryptSecrets
-	serverConfig.ControlConfig.EtcdSnapshotName = cfg.EtcdSnapshotName
-	serverConfig.ControlConfig.EtcdSnapshotCron = cfg.EtcdSnapshotCron
-	serverConfig.ControlConfig.EtcdSnapshotDir = cfg.EtcdSnapshotDir
-	serverConfig.ControlConfig.EtcdSnapshotRetention = cfg.EtcdSnapshotRetention
+	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
+	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots
 
-	if cfg.EtcdDisableSnapshots {
+	if !cfg.EtcdDisableSnapshots {
+		serverConfig.ControlConfig.EtcdSnapshotName = cfg.EtcdSnapshotName
+		serverConfig.ControlConfig.EtcdSnapshotCron = cfg.EtcdSnapshotCron
+		serverConfig.ControlConfig.EtcdSnapshotDir = cfg.EtcdSnapshotDir
+		serverConfig.ControlConfig.EtcdSnapshotRetention = cfg.EtcdSnapshotRetention
+		serverConfig.ControlConfig.EtcdS3 = cfg.EtcdS3
+		serverConfig.ControlConfig.EtcdS3Endpoint = cfg.EtcdS3Endpoint
+		serverConfig.ControlConfig.EtcdS3EndpointCA = cfg.EtcdS3EndpointCA
+		serverConfig.ControlConfig.EtcdS3SkipSSLVerify = cfg.EtcdS3SkipSSLVerify
+		serverConfig.ControlConfig.EtcdS3AccessKey = cfg.EtcdS3AccessKey
+		serverConfig.ControlConfig.EtcdS3SecretKey = cfg.EtcdS3SecretKey
+		serverConfig.ControlConfig.EtcdS3BucketName = cfg.EtcdS3BucketName
+		serverConfig.ControlConfig.EtcdS3Region = cfg.EtcdS3Region
+		serverConfig.ControlConfig.EtcdS3Folder = cfg.EtcdS3Folder
+	} else {
 		logrus.Info("ETCD snapshots are disabled")
 	}
-	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots
-	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
-	serverConfig.ControlConfig.EtcdS3 = cfg.EtcdS3
-	serverConfig.ControlConfig.EtcdS3Endpoint = cfg.EtcdS3Endpoint
-	serverConfig.ControlConfig.EtcdS3EndpointCA = cfg.EtcdS3EndpointCA
-	serverConfig.ControlConfig.EtcdS3SkipSSLVerify = cfg.EtcdS3SkipSSLVerify
-	serverConfig.ControlConfig.EtcdS3AccessKey = cfg.EtcdS3AccessKey
-	serverConfig.ControlConfig.EtcdS3SecretKey = cfg.EtcdS3SecretKey
-	serverConfig.ControlConfig.EtcdS3BucketName = cfg.EtcdS3BucketName
-	serverConfig.ControlConfig.EtcdS3Region = cfg.EtcdS3Region
-	serverConfig.ControlConfig.EtcdS3Folder = cfg.EtcdS3Folder
 
 	if cfg.ClusterResetRestorePath != "" && !cfg.ClusterReset {
 		return errors.New("invalid flag use. --cluster-reset required with --cluster-reset-restore-path")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -110,8 +110,10 @@ func (c *Cluster) Start(ctx context.Context) (<-chan struct{}, error) {
 						panic(err)
 					}
 
-					if err := c.managedDB.StoreSnapshotData(ctx); err != nil {
-						logrus.Errorf("Failed to record snapshots for cluster: %v", err)
+					if !c.config.EtcdDisableSnapshots {
+						if err := c.managedDB.StoreSnapshotData(ctx); err != nil {
+							logrus.Errorf("Failed to record snapshots for cluster: %v", err)
+						}
 					}
 
 					return


### PR DESCRIPTION
porting from upstream pr:
https://github.com/k3s-io/k3s/pull/3475/

Wraps the snapshot save call in a check of whether snapshots are
disabled or not.

Signed-off-by: Deshi Xiao <xiaods@gmail.com>