### PR TITLE
restore go 1.15

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-ARG GOLANG=golang:1.17.0-alpine3.14
+ARG GOLANG=golang:1.15.14-alpine3.13
 FROM ${GOLANG}
 
 ARG http_proxy=$http_proxy


### PR DESCRIPTION
Remove incorrect zero value check
https://github.com/kubernetes/kube-openapi/pull/230

spec.bpfLogLevel in body must be of type string: "null"

only go1.15 can handle it.

Signed-off-by: Deshi Xiao <xiaods@gmail.com>