### PR TITLE
fix: remove useless Flannel variables

### DIFF
--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -50,7 +50,6 @@ type Server struct {
 	AdvertisePort            int
 	DisableScheduler         bool
 	ServerURL                string
-	FlannelBackend           string
 	DefaultLocalStoragePath  string
 	DisableCCM               bool
 	DisableNPC               bool
@@ -156,12 +155,6 @@ func NewServerCommand(action func(*cli.Context) error) cli.Command {
 				Usage:       "(networking) Cluster Domain",
 				Destination: &ServerConfig.ClusterDomain,
 				Value:       "cluster.local",
-			},
-			cli.StringFlag{
-				Name:        "flannel-backend",
-				Usage:       "(networking) One of 'none', 'vxlan', 'ipsec', 'host-gw', or 'wireguard'",
-				Destination: &ServerConfig.FlannelBackend,
-				Value:       "vxlan",
 			},
 			cli.StringFlag{
 				Name:        "token,t",

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -454,8 +454,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 
 // validateNetworkConfig ensures that the network configuration values make sense.
 func validateNetworkConfiguration(serverConfig server.Config) error {
-	// Dual-stack operation requires fairly extensive manual configuration at the moment - do some
-	// preflight checks to make sure that the user isn't trying to use flannel/npc, or trying to
+	// Dual-stack operation requires fairly extensive manual configuration at the moment -
 	// enable dual-stack DNS (which we don't currently support since it's not easy to template)
 	dualCluster, err := utilsnet.IsDualStackCIDRs(serverConfig.ControlConfig.ClusterIPRanges)
 	if err != nil {

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -23,12 +23,7 @@ const (
 type Node struct {
 	Docker                   bool
 	ContainerRuntimeEndpoint string
-	NoFlannel                bool
 	SELinux                  bool
-	FlannelBackend           string
-	FlannelConf              string
-	FlannelConfOverride      bool
-	FlannelIface             *net.Interface
 	Containerd               Containerd
 	Images                   string
 	AgentConfig              Agent
@@ -130,7 +125,6 @@ type Control struct {
 	ExtraSchedulerAPIArgs    []string
 	NoLeaderElect            bool
 	JoinURL                  string
-	FlannelBackend           string
 	IPSECPSK                 string
 	DefaultLocalStoragePath  string
 	SystemDefaultRegistry    string


### PR DESCRIPTION
default remove flannel component settings from k8e

by Xiao Deshi(xiaods@gmail.com)