### PR TITLE
fix: Method name differs only by capitalization

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -37,7 +37,7 @@ const (
 
 func Get(ctx context.Context, agent cmds.Agent, proxy proxy.Proxy) *config.Node {
 	for {
-		agentConfig, err := get(ctx, &agent, proxy)
+		agentConfig, err := getFunc(ctx, &agent, proxy)
 		if err != nil {
 			logrus.Errorf("Failed to configure agent: %v", err)
 			select {
@@ -301,7 +301,7 @@ func locateOrGenerateResolvConf(envInfo *cmds.Agent) string {
 	return tmpConf
 }
 
-func get(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
+func getFunc(ctx context.Context, envInfo *cmds.Agent, proxy proxy.Proxy) (*config.Node, error) {
 	if envInfo.Debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -73,7 +73,7 @@ func setupCriCtlConfig(cfg cmds.Agent, nodeConfig *daemonconfig.Node) error {
 	return ioutil.WriteFile(agentConfDir+"/crictl.yaml", []byte(crp), 0600)
 }
 
-func run(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
+func runFunc(ctx context.Context, cfg cmds.Agent, proxy proxy.Proxy) error {
 	nodeConfig := config.Get(ctx, cfg, proxy)
 
 	dualCluster, err := utilsnet.IsDualStackCIDRs(nodeConfig.AgentConfig.ClusterCIDRs)
@@ -240,7 +240,7 @@ func Run(ctx context.Context, cfg cmds.Agent) error {
 		break
 	}
 
-	return run(ctx, cfg, proxy)
+	return runFunc(ctx, cfg, proxy)
 }
 
 func validate() error {

--- a/pkg/cli/etcdsnapshot/etcd_snapshot.go
+++ b/pkg/cli/etcdsnapshot/etcd_snapshot.go
@@ -58,10 +58,10 @@ func Run(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	return run(app, &cmds.ServerConfig)
+	return runFunc(app, &cmds.ServerConfig)
 }
 
-func run(app *cli.Context, cfg *cmds.Server) error {
+func runFunc(app *cli.Context, cfg *cmds.Server) error {
 	var serverConfig server.Config
 
 	dataDir, err := commandSetup(app, cfg, &serverConfig)
@@ -111,10 +111,10 @@ func Delete(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	return delete(app, &cmds.ServerConfig)
+	return deleteFunc(app, &cmds.ServerConfig)
 }
 
-func delete(app *cli.Context, cfg *cmds.Server) error {
+func deleteFunc(app *cli.Context, cfg *cmds.Server) error {
 	var serverConfig server.Config
 
 	dataDir, err := commandSetup(app, cfg, &serverConfig)
@@ -147,10 +147,10 @@ func List(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	return list(app, &cmds.ServerConfig)
+	return listFunc(app, &cmds.ServerConfig)
 }
 
-func list(app *cli.Context, cfg *cmds.Server) error {
+func listFunc(app *cli.Context, cfg *cmds.Server) error {
 	var serverConfig server.Config
 
 	dataDir, err := commandSetup(app, cfg, &serverConfig)
@@ -187,10 +187,10 @@ func Prune(app *cli.Context) error {
 	if err := cmds.InitLogging(); err != nil {
 		return err
 	}
-	return prune(app, &cmds.ServerConfig)
+	return pruneFunc(app, &cmds.ServerConfig)
 }
 
-func prune(app *cli.Context, cfg *cmds.Server) error {
+func pruneFunc(app *cli.Context, cfg *cmds.Server) error {
 	var serverConfig server.Config
 
 	dataDir, err := commandSetup(app, cfg, &serverConfig)

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -38,14 +38,14 @@ import (
 )
 
 func Run(app *cli.Context) error {
-	return run(app, &cmds.ServerConfig, server.CustomControllers{}, server.CustomControllers{})
+	return runFunc(app, &cmds.ServerConfig, server.CustomControllers{}, server.CustomControllers{})
 }
 
 func RunWithControllers(app *cli.Context, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
-	return run(app, &cmds.ServerConfig, leaderControllers, controllers)
+	return runFunc(app, &cmds.ServerConfig, leaderControllers, controllers)
 }
 
-func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
+func runFunc(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
 	var (
 		err error
 	)

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -107,7 +107,7 @@ func (c *Cluster) Bootstrap(ctx context.Context, snapshot bool) error {
 	}
 
 	if c.shouldBootstrap {
-		return c.bootstrap(ctx)
+		return c.bootstrapFunc(ctx)
 	}
 
 	return nil
@@ -556,7 +556,7 @@ func (c *Cluster) retrieveInitializedDBdata(ctx context.Context) (*bytes.Buffer,
 }
 
 // bootstrap performs cluster bootstrapping, either via HTTP (for managed databases) or direct load from datastore.
-func (c *Cluster) bootstrap(ctx context.Context) error {
+func (c *Cluster) bootstrapFunc(ctx context.Context) error {
 	c.joining = true
 
 	// bootstrap managed database via HTTPS

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -940,10 +940,10 @@ type SnapshotFile struct {
 	S3        *s3Config    `json:"s3Config,omitempty"`
 }
 
-// listSnapshots provides a list of the currently stored
+// listSnapshotsFunc provides a list of the currently stored
 // snapshots on disk or in S3 along with their relevant
 // metadata.
-func (e *ETCD) listSnapshots(ctx context.Context, snapshotDir string) ([]SnapshotFile, error) {
+func (e *ETCD) listSnapshotsFunc(ctx context.Context, snapshotDir string) ([]SnapshotFile, error) {
 	var snapshots []SnapshotFile
 
 	if e.config.EtcdS3 {
@@ -1061,7 +1061,7 @@ func (e *ETCD) ListSnapshots(ctx context.Context) ([]SnapshotFile, error) {
 		return nil, errors.Wrap(err, "failed to get the snapshot dir")
 	}
 
-	return e.listSnapshots(ctx, snapshotDir)
+	return e.listSnapshotsFunc(ctx, snapshotDir)
 }
 
 // deleteSnapshots removes the given snapshots from
@@ -1178,7 +1178,7 @@ func (e *ETCD) StoreSnapshotData(ctx context.Context) error {
 
 		snapshotConfigMap, getErr := e.config.Runtime.Core.Core().V1().ConfigMap().Get(metav1.NamespaceSystem, snapshotConfigMapName, metav1.GetOptions{})
 
-		snapshotFiles, err := e.listSnapshots(ctx, snapshotDir)
+		snapshotFiles, err := e.listSnapshotsFunc(ctx, snapshotDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/netutil/iface.go
+++ b/pkg/netutil/iface.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetIPFromInterface(ifaceName string) string {
-	ip, err := getIPFromInterface(ifaceName)
+	ip, err := getIPFromInterfaceFunc(ifaceName)
 	if err != nil {
 		logrus.Warn(errors.Wrap(err, "unable to get global unicast ip from interface name"))
 	} else {
@@ -18,7 +18,7 @@ func GetIPFromInterface(ifaceName string) string {
 	return ip
 }
 
-func getIPFromInterface(ifaceName string) (string, error) {
+func getIPFromInterfaceFunc(ifaceName string) (string, error) {
 	iface, err := net.InterfaceByName(ifaceName)
 	if err != nil {
 		return "", err

--- a/pkg/untar/untar.go
+++ b/pkg/untar/untar.go
@@ -36,10 +36,10 @@ const (
 
 // Untar reads the zstd-compressed tar file from r and writes it into dir.
 func Untar(r io.Reader, dir string) error {
-	return untar(r, dir)
+	return untarFunc(r, dir)
 }
 
-func untar(r io.Reader, dir string) (err error) {
+func untarFunc(r io.Reader, dir string) (err error) {
 	t0 := time.Now()
 	nFiles := 0
 	madeDir := map[string]bool{}


### PR DESCRIPTION
Methods or fields of struct that have names different only by
capitalization could be confusing.

https://github.com/xiaods/k8e/issues/185

Signed-off-by: Deshi Xiao <xiaods@gmail.com>