### PR TITLE
upgrade: cilium version to 1.21.1

### DIFF
--- a/hack/airgap/image-list.txt
+++ b/hack/airgap/image-list.txt
@@ -3,5 +3,5 @@ docker.io/rancher/mirrored-coredns-coredns:1.9.1
 docker.io/rancher/mirrored-library-busybox:1.34.1
 docker.io/rancher/mirrored-metrics-server:v0.5.2
 docker.io/rancher/mirrored-pause:3.6
-quay.io/cilium/cilium:v1.12.0
-quay.io/cilium/operator-generic:v1.12.0
+quay.io/cilium/cilium:v1.12.1
+quay.io/cilium/operator-generic:v1.12.1

--- a/hack/download
+++ b/hack/download
@@ -9,7 +9,7 @@ CONTAINERD_DIR=build/src/github.com/containerd/containerd
 DATA_DIR=build/data
 CHARTS_DIR=build/static/charts
 NERDCTL_VERSION=0.22.2
-CILIUMCLI_VERSION=v0.12.0
+CILIUMCLI_VERSION=v0.12.3
 OSMEDGE_VERSION=v1.1.0
 
 umask 022


### PR DESCRIPTION
This release fixes a moderate severity security issue GHSA-pfhr-pccp-hwmh, adds websockets support for Ingress, and fixes a range of bugs that have been recently reported in the community.

Signed-off-by: Deshi Xiao <xiaods@gmail.com>