### PR TITLE
update: addon components update

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -459,7 +459,7 @@ setup_cilium() {
         *"cluster-init"*) info "Installing cilium network cni/operator"
         $SUDO chmod 644 /etc/${SYSTEM_NAME}/${SYSTEM_NAME}.yaml
         # cilium helm values https://github.com/cilium/cilium/tree/master/install/kubernetes/cilium
-        $SUDO KUBECONFIG=/etc/${SYSTEM_NAME}/${SYSTEM_NAME}.yaml $BIN_DIR/cilium install --version=1.12.3 --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=["10.42.0.0/16"];;
+        $SUDO KUBECONFIG=/etc/${SYSTEM_NAME}/${SYSTEM_NAME}.yaml $BIN_DIR/cilium install --version=1.14.1 --helm-set ipam.operator.clusterPoolIPv4PodCIDRList=["10.42.0.0/16"];;
     esac
 }
 

--- a/hack/airgap/image-list.txt
+++ b/hack/airgap/image-list.txt
@@ -4,5 +4,5 @@ docker.io/rancher/mirrored-coredns-coredns:1.10.1
 docker.io/rancher/mirrored-library-busybox:1.34.1
 docker.io/rancher/mirrored-metrics-server:v0.6.3
 docker.io/rancher/mirrored-pause:3.6
-quay.io/cilium/cilium:v1.12.7
-quay.io/cilium/operator-generic:v1.12.7
+quay.io/cilium/cilium:v1.14.1
+quay.io/cilium/operator-generic:v1.14.1

--- a/hack/download
+++ b/hack/download
@@ -8,9 +8,8 @@ RUNC_DIR=build/src/github.com/opencontainers/runc
 CONTAINERD_DIR=build/src/github.com/containerd/containerd
 DATA_DIR=build/data
 CHARTS_DIR=build/static/charts
-NERDCTL_VERSION=1.2.1
-CILIUMCLI_VERSION=v0.13.1
-OSMEDGE_VERSION=v1.3.3
+NERDCTL_VERSION=1.5.0
+CILIUMCLI_VERSION=v0.15.7
 
 umask 022
 rm -rf ${CHARTS_DIR}
@@ -42,15 +41,5 @@ download_and_package_cilium() {
   fi
 }
 
-download_and_package_osm() {
-  echo "Downloading OSM Edge..."
-  if [ ${ARCH} = amd64 ]; then
-    curl --compressed -sfL https://github.com/flomesh-io/osm-edge/releases/download/${OSMEDGE_VERSION}/osm-edge-${OSMEDGE_VERSION}-linux-amd64.tar.gz | tar -zxf - -C bin --strip-components 1 --exclude=LICENSE --exclude=README.md
-  elif [ ${ARCH} = aarch64 ] || [ ${ARCH} = arm64 ]; then
-    curl --compressed -sfL https://github.com/flomesh-io/osm-edge/releases/download/${OSMEDGE_VERSION}/osm-edge-${OSMEDGE_VERSION}-linux-arm64.tar.gz | tar -zxf - -C bin --strip-components 1 --exclude=LICENSE --exclude=README.md
-  fi
-}
-
 download_and_package_nerdctl
 download_and_package_cilium
-download_and_package_osm


### PR DESCRIPTION
cilium-cli to v0.15.7
nerdctl to v1.5.0

offload lightweight service mesh:
remove osm-edge