### PR TITLE
Fix testing workflow: add permissions, libseccomp-dev, and reliable t…

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,8 +1,12 @@
+name: Build Test
 on:
   pull_request:
     branches:
       - main
-name: Build Test
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
 jobs:
   build:
     name: Build & Test
@@ -26,18 +30,20 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.13.0
-      - name: generate resources
+      - name: Install dependencies
+        run: sudo apt-get install -y libseccomp-dev
+      - name: Generate resources
         run: |
           mkdir -p build/data build/static
           zig build download
-          go generate ./...
+          make generate
       - name: Test
         id: gotest
         run: |
           export GOPATH="$HOME/go/"
           export PATH=$PATH:$GOPATH/bin
           go install github.com/jstemmer/go-junit-report/v2@latest
-          zig build test 2>&1 | go-junit-report -set-exit-code > report.xml
+          go test -v ./... 2>&1 | go-junit-report -set-exit-code > report.xml
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()


### PR DESCRIPTION
…est piping

- Add permissions (checks/pull-requests/contents) for publish-unit-test-result-action
- Install libseccomp-dev dependency consistent with release workflow
- Use make generate instead of go generate ./... for consistency
- Replace zig build test with direct go test for clean JUnit report output