### PR TITLE
Fix package-cli: remove hardcoded gcc dependency for go generate

### DIFF
--- a/hack/package-cli
+++ b/hack/package-cli
@@ -47,7 +47,7 @@ fi
 
 CMD_NAME=dist/artifacts/k8e${BIN_SUFFIX}${BINARY_POSTFIX}
 
-GOOS=linux CC=gcc CXX=g++ "${GO}" generate
+CGO_ENABLED=0 GOOS=linux "${GO}" generate
 LDFLAGS="
     -X github.com/xiaods/k8e/pkg/version.Version=$VERSION
     -X github.com/xiaods/k8e/pkg/version.GitCommit=${COMMIT:0:8}


### PR DESCRIPTION
Replace `CC=gcc CXX=g++` with `CGO_ENABLED=0` since codegen tools (go-bindata, controller-gen) are pure Go and don't need cgo. Fixes arm64 self-hosted runner build failure where gcc is not installed.