### PR TITLE
fix: snapshot restore auto-inherits tenant from metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 ## Project Overview
 
-K8E is a CNCF-conformant Kubernetes distribution packaged as a single binary under 100MB, purpose-built for secure, isolated AI agent execution at scale. It provides built-in sandbox orchestration (warm pools, session management), a gRPC gateway for sandbox operations, an MCP server bridging AI agents to sandbox infrastructure, and client SDKs in Python and TypeScript.
+K8E is a CNCF-conformant Kubernetes distribution packaged as a single binary under 100MB, purpose-built for secure, isolated AI agent execution at scale. It provides built-in sandbox orchestration (warm pools, session management), a gRPC gateway for sandbox operations, a CLI command group (`k8e sandbox`) bridging AI agents to sandbox infrastructure, and client SDKs in Python and TypeScript.
 
 ## Architecture (Big Picture)
 
@@ -18,14 +18,13 @@ The repository is organized as a **Zig-based Go project**:
 │   ├── server/                    # Control plane + optional agent
 │   ├── agent/                     # Agent-only (kubelet + containerd)
 │   ├── kubectl/                   # kubectl wrapper
-│   ├── sandbox-mcp.go             # MCP stdio/HTTP bridge (cli/cmds)
 │   └── sandbox-gateway.go         # Sandbox gRPC gateway (cli/cmds)
 ├── pkg/
 │   ├── cli/cmds/                  # CLI flag definitions + command wiring
 │   │   ├── root.go                # App setup, global flags
 │   │   ├── server.go              # Server struct + all server flags
 │   │   ├── agent.go               # Agent struct + all agent flags
-│   │   ├── sandbox_mcp.go         # sandbox-mcp + sandbox-install-skill commands
+│   │   ├── sandbox.go             # sandbox CLI command group
 │   │   └── sandbox_gateway.go     # sandbox-gateway command
 │   ├── server/                    # Server daemon orchestration
 │   ├── agent/                     # Agent daemon orchestration
@@ -37,11 +36,14 @@ The repository is organized as a **Zig-based Go project**:
 │   │       ├── server.go          # gRPC SandboxService (create/destroy/exec sessions)
 │   │       ├── orchestrator.go    # Orchestration logic (sub-agents, confirm actions)
 │   │       └── pb/                # Generated protobuf Go code
-│   ├── sandboxmcp/                # MCP server bridging AI agents to sandbox
-│   │   ├── server.go              # JSON-RPC MCP server (stdio + SSE modes)
-│   │   ├── tools.go               # All 12 MCP tool implementations
+│   ├── sandboxmcp/                # gRPC client + skill installation
 │   │   ├── client.go              # gRPC client with TLS auto-discovery
-│   │   └── install.go             # Skill installation for Codex/kiro/gemini
+│   │   └── install.go             # Skill installation for codex/claude/pi/openclaw
+│   ├── sandboxcli/                # CLI command handlers for k8e sandbox
+│   │   ├── commands.go            # 10 sandbox command handlers
+│   │   ├── session.go             # Session state persistence + flock locking
+│   │   ├── snapshot.go            # Workspace snapshot save/restore
+│   │   └── manifest.go            # Declarative workspace manifest
 │   ├── sandboxmatrix/grpc/        # gRPC gateway — proxies exec/file ops to sandboxd pods
 │   ├── configfilearg/             # Config file argument parsing
 │   ├── deploy/                    # Kubernetes manifests and Helm charts
@@ -54,21 +56,20 @@ The repository is organized as a **Zig-based Go project**:
 ├── sandboxd/                      # Runtime daemon in Zig (exec, files, networking)
 ├── sdk/python/                    # Python gRPC client SDK
 ├── sdk/typescript/                # TypeScript gRPC client SDK
-├── skills/k8e-sandbox-skill/      # MCP skill files for agent installation
+│── skills/k8e-sandbox/            # SKILL.md for agent CLI integration
 └── tests/unit.go                  # Test helper utilities
 ```
 
 ### Key Architectural Flows
 
-**Agent submitting work via MCP:**
+**Agent submitting work via CLI:**
 ```
-AI Agent (stdin/stdout)
-  → k8e sandbox-mcp (MCP JSON-RPC, stdio or SSE)
-    → sandboxmcp.Client (gRPC with TLS)
-      → sandbox-grpc-gateway:50051 (TLS gRPC)
-        → Orchestrator (K8s API: create/destroy pods)
-        → sandboxd HTTP proxy (port 2024 inside sandbox pods)
-          → Isolated container (gVisor/Kata/Firecracker)
+AI Agent (shell command)
+  → k8e sandbox run "code" (direct gRPC with TLS)
+    → sandbox-grpc-gateway:50051 (TLS gRPC)
+      → Orchestrator (K8s API: create/destroy pods)
+      → sandboxd HTTP proxy (port 2024 inside sandbox pods)
+        → Isolated container (gVisor/Kata/Firecracker)
 ```
 
 **Direct SDK usage:**
@@ -130,9 +131,9 @@ Integration tests require a running K8E cluster and are invoked via `make test`.
 - **Single binary**: All components (server, agent, CLI tools) compile into one `k8e` binary; behavior is determined by subcommand
 - **No separate config files for most things**: Configuration is passed via CLI flags and environment variables; a config file loader (`pkg/configfilearg`) bridges the two
 - **Sandbox sessions are Kubernetes pods**: Each agent workload runs in an isolated pod with a pluggable RuntimeClass (gVisor, Kata, Firecracker)
-- **gRPC-first**: The sandbox API is gRPC; the MCP server and Python/TypeScript SDKs are thin wrappers around it
+- **gRPC-first**: The sandbox API is gRPC; the CLI commands and Python/TypeScript SDKs are thin wrappers around it
 - **Warm pools**: Pre-booted sandbox pods reduce session startup latency; the `SandboxWarmPool` CRD lets users configure pool size and runtime per namespace
-- **Cross-process session reuse**: The `tenantID` field on sessions allows multiple MCP client calls to share the same sandbox session via `FindActiveSession()`
+- **Cross-process session reuse**: The `tenantID` field on sessions allows multiple CLI calls to share the same sandbox session via state files and `FindActiveSession()`
 
 ## Agent skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-K8E is a CNCF-conformant Kubernetes distribution packaged as a single binary under 100MB, purpose-built for secure, isolated AI agent execution at scale. It provides built-in sandbox orchestration (warm pools, session management), a gRPC gateway for sandbox operations, an MCP server bridging AI agents to sandbox infrastructure, and client SDKs in Python and TypeScript.
+K8E is a CNCF-conformant Kubernetes distribution packaged as a single binary under 100MB, purpose-built for secure, isolated AI agent execution at scale. It provides built-in sandbox orchestration (warm pools, session management), a gRPC gateway for sandbox operations, a CLI command group (`k8e sandbox`) bridging AI agents to sandbox infrastructure, and client SDKs in Python and TypeScript.
 
 ## Architecture (Big Picture)
 
@@ -18,14 +18,12 @@ The repository is organized as a **Zig-based Go project**:
 │   ├── server/                    # Control plane + optional agent
 │   ├── agent/                     # Agent-only (kubelet + containerd)
 │   ├── kubectl/                   # kubectl wrapper
-│   ├── sandbox-mcp.go             # MCP stdio/HTTP bridge (cli/cmds)
 │   └── sandbox-gateway.go         # Sandbox gRPC gateway (cli/cmds)
 ├── pkg/
 │   ├── cli/cmds/                  # CLI flag definitions + command wiring
 │   │   ├── root.go                # App setup, global flags
 │   │   ├── server.go              # Server struct + all server flags
 │   │   ├── agent.go               # Agent struct + all agent flags
-│   │   ├── sandbox_mcp.go         # sandbox-mcp + sandbox-install-skill commands
 │   │   └── sandbox_gateway.go     # sandbox-gateway command
 │   ├── server/                    # Server daemon orchestration
 │   ├── agent/                     # Agent daemon orchestration
@@ -37,11 +35,14 @@ The repository is organized as a **Zig-based Go project**:
 │   │       ├── server.go          # gRPC SandboxService (create/destroy/exec sessions)
 │   │       ├── orchestrator.go    # Orchestration logic (sub-agents, confirm actions)
 │   │       └── pb/                # Generated protobuf Go code
-│   ├── sandboxmcp/                # MCP server bridging AI agents to sandbox
-│   │   ├── server.go              # JSON-RPC MCP server (stdio + SSE modes)
-│   │   ├── tools.go               # All 12 MCP tool implementations
+│   ├── sandboxmcp/                # gRPC client + skill installation
 │   │   ├── client.go              # gRPC client with TLS auto-discovery
-│   │   └── install.go             # Skill installation for claude/kiro/gemini
+│   │   └── install.go             # Skill installation for codex/claude/pi/openclaw
+│   ├── sandboxcli/                # CLI command handlers for k8e sandbox
+│   │   ├── commands.go            # 10 sandbox command handlers
+│   │   ├── session.go             # Session state persistence + flock locking
+│   │   ├── snapshot.go            # Workspace snapshot save/restore
+│   │   └── manifest.go            # Declarative workspace manifest
 │   ├── sandboxmatrix/grpc/        # gRPC gateway — proxies exec/file ops to sandboxd pods
 │   ├── configfilearg/             # Config file argument parsing
 │   ├── deploy/                    # Kubernetes manifests and Helm charts
@@ -54,21 +55,20 @@ The repository is organized as a **Zig-based Go project**:
 ├── sandboxd/                      # Runtime daemon in Zig (exec, files, networking)
 ├── sdk/python/                    # Python gRPC client SDK
 ├── sdk/typescript/                # TypeScript gRPC client SDK
-├── skills/k8e-sandbox-skill/      # MCP skill files for agent installation
+├── skills/k8e-sandbox/            # SKILL.md for agent CLI integration
 └── tests/unit.go                  # Test helper utilities
 ```
 
 ### Key Architectural Flows
 
-**Agent submitting work via MCP:**
+**Agent submitting work via CLI:**
 ```
-AI Agent (stdin/stdout)
-  → k8e sandbox-mcp (MCP JSON-RPC, stdio or SSE)
-    → sandboxmcp.Client (gRPC with TLS)
-      → sandbox-grpc-gateway:50051 (TLS gRPC)
-        → Orchestrator (K8s API: create/destroy pods)
-        → sandboxd HTTP proxy (port 2024 inside sandbox pods)
-          → Isolated container (gVisor/Kata/Firecracker)
+AI Agent (shell command)
+  → k8e sandbox run "code" (direct gRPC with TLS)
+    → sandbox-grpc-gateway:50051 (TLS gRPC)
+      → Orchestrator (K8s API: create/destroy pods)
+      → sandboxd HTTP proxy (port 2024 inside sandbox pods)
+        → Isolated container (gVisor/Kata/Firecracker)
 ```
 
 **Direct SDK usage:**
@@ -130,9 +130,9 @@ Integration tests require a running K8E cluster and are invoked via `make test`.
 - **Single binary**: All components (server, agent, CLI tools) compile into one `k8e` binary; behavior is determined by subcommand
 - **No separate config files for most things**: Configuration is passed via CLI flags and environment variables; a config file loader (`pkg/configfilearg`) bridges the two
 - **Sandbox sessions are Kubernetes pods**: Each agent workload runs in an isolated pod with a pluggable RuntimeClass (gVisor, Kata, Firecracker)
-- **gRPC-first**: The sandbox API is gRPC; the MCP server and Python/TypeScript SDKs are thin wrappers around it
+- **gRPC-first**: The sandbox API is gRPC; the CLI commands and Python/TypeScript SDKs are thin wrappers around it
 - **Warm pools**: Pre-booted sandbox pods reduce session startup latency; the `SandboxWarmPool` CRD lets users configure pool size and runtime per namespace
-- **Cross-process session reuse**: The `tenantID` field on sessions allows multiple MCP client calls to share the same sandbox session via `FindActiveSession()`
+- **Cross-process session reuse**: The `tenantID` field on sessions allows multiple CLI calls to share the same sandbox session via state files and `FindActiveSession()`
 
 ## Agent skills
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -sfL https://k8e.sh/install.sh | sh -
 | 3 | [⚙️ Components](#️-components) |
 | 4 | [🚀 Quick Start](#-quick-start) |
 | 5 | [🔒 Sandbox Runtime Setup](#-sandbox-runtime-setup) |
-| 6 | [🤖 Sandbox MCP Skill](#-sandbox-mcp-skill) |
+| 6 | [🤖 Sandbox CLI Skill](#-sandbox-cli-skill) |
 | 7 | [🐍 Python Client SDK](#-python-client-sdk) |
 | 8 | [🟦 TypeScript Client SDK](#-typescript-client-sdk) |
 | 9 | [🖥️ Advanced Installation](#️-advanced-installation) |
@@ -68,7 +68,7 @@ As autonomous AI agents increasingly generate and execute untrusted code, robust
 | 🗑️ **Ephemeral Workspaces** | Auto-cleanup after agent session ends |
 | 🧠 **Warm Pool** | Pre-booted sandbox pods for sub-500ms session claim latency |
 | 🤝 **agent-sandbox compatible** | Works with [`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox) |
-| 🔄 **MCP / A2A ready** | Any MCP-compatible agent (kiro, claude, gemini) connects via `k8e sandbox-mcp` |
+| 🔄 **SKILL + CLI** | AI agents (codex, claude, pi, openclaw) connect via `k8e sandbox` CLI commands |
 
 ---
 
@@ -109,11 +109,11 @@ As autonomous AI agents increasingly generate and execute untrusted code, robust
          ▲
          │  gRPC (TLS)
 ┌────────┴────────┐
-│  k8e sandbox-mcp│  ← MCP stdio bridge
+│  k8e sandbox    │  ← CLI commands
 └────────┬────────┘
-         │  stdin/stdout
-┌────────┴────────┐
-│  AI Agent       │  (kiro / claude / gemini / any MCP client)
+         │  gRPC (TLS)
+         ▼
+│  AI Agent       │  (codex / claude / pi / openclaw)
 └─────────────────┘
 ```
 
@@ -136,7 +136,7 @@ As autonomous AI agents increasingly generate and execute untrusted code, robust
 | 📈 **Metrics Server** | v0.7.x | Resource metrics |
 | 💾 **Local Path Provisioner** | v0.0.30 | Persistent storage |
 | 🛡️ **gVisor / Kata / Firecracker** | — | Pluggable sandbox isolation runtimes |
-| 🤖 **Sandbox MCP Server** | built-in | `k8e sandbox-mcp` — agent tool bridge |
+| 🤖 **Sandbox CLI** | built-in | `k8e sandbox` — agent tool commands |
 
 </div>
 
@@ -177,21 +177,19 @@ kubectl -n sandbox-matrix get pods   # Sandbox Matrix starts automatically
 
 ### Step 4 — Connect Your AI Agent
 
-`sandbox-install-skill` does two things at once:
-1. Writes the `k8e-sandbox` MCP server entry into the agent's config file
-2. Copies the sandbox skill files from `/var/lib/k8e/server/skills/` into the agent's skills directory
-
-K8E server must have started at least once before running this command (it stages the skill files on first boot).
+Install the K8E sandbox skill into your AI agent:
 
 ```bash
-k8e sandbox-install-skill all   # installs into kiro, claude, gemini at once
+k8e sandbox-install-skill all   # installs skill files for all supported agents
 ```
 
 Then ask your agent naturally:
 
 > "Run this Python snippet in a sandbox"
 
-That's it. The agent calls `sandbox_run` automatically — no session management needed.
+The agent executes `k8e sandbox run` automatically — no session management needed.
+
+Supported agents: **codex**, **claude**, **pi**, **openclaw**.
 
 ---
 
@@ -251,15 +249,15 @@ kubectl get runtimeclass
 
 ---
 
-## 🤖 Sandbox MCP Skill
+## 🤖 Sandbox CLI Skill
 
-`k8e sandbox-mcp` is a built-in MCP server that bridges any MCP-compatible AI agent to K8E's sandbox infrastructure over gRPC — no extra binaries, no manual endpoint config.
+`k8e sandbox` is a built-in CLI command group that gives AI agents direct access to K8E's sandbox infrastructure — no MCP server, no extra processes, no manual endpoint config.
 
 ```
-AI Agent (kiro / claude / gemini)
-    │  stdin/stdout
+AI Agent (codex / claude / pi / openclaw)
+    │  shell command
     ▼
-k8e sandbox-mcp
+k8e sandbox run "print('hello')" --lang python
     │  gRPC (TLS, auto-discovered)
     ▼
 sandbox-grpc-gateway:50051
@@ -270,90 +268,86 @@ Isolated Pod (gVisor / Kata / Firecracker)
 
 ### Install the Skill
 
-`sandbox-install-skill` does two things in one command:
-1. Writes the `k8e-sandbox` MCP server entry into the agent's config file
-2. Copies skill files from `/var/lib/k8e/server/skills/` into the agent's skills directory
-
-> K8E server must have started at least once before running this — it stages the skill files to `/var/lib/k8e/server/skills/` on first boot.
+`sandbox-install-skill` copies skill files to the agent's skills directory:
 
 ```bash
 # All supported agents at once
 k8e sandbox-install-skill all
 
 # Or per agent
-k8e sandbox-install-skill kiro      # MCP config → .kiro/settings.json (workspace)
-                                    # Skills     → .kiro/skills/k8e-sandbox-skill/
-k8e sandbox-install-skill claude    # MCP config → ~/.claude.json
-                                    # Skills     → ~/.claude/skills/k8e-sandbox-skill/
-k8e sandbox-install-skill gemini    # MCP config → ~/.gemini/settings.json
-                                    # Skills     → ~/.gemini/skills/k8e-sandbox-skill/
+k8e sandbox-install-skill claude    # Skills → ~/.claude/skills/k8e-sandbox/
+k8e sandbox-install-skill openclaw  # Skills → ~/.openclaw/skills/k8e-sandbox/
+k8e sandbox-install-skill kiro      # Skills → .kiro/skills/k8e-sandbox/
+k8e sandbox-install-skill gemini    # Skills → ~/.gemini/skills/k8e-sandbox/
 ```
 
-**Manual setup** — add to your agent's MCP config:
+### Available Commands
 
-```json
-{
-  "mcpServers": {
-    "k8e-sandbox": {
-      "command": "k8e",
-      "args": ["sandbox-mcp"]
-    }
-  }
-}
-```
-
-For claude code:
-
-```bash
-claude mcp add k8e-sandbox -- k8e sandbox-mcp
-```
-
-### Verify
-
-```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test","version":"1.0"},"capabilities":{}}}' \
-  | k8e sandbox-mcp
-```
-
-### Available Tools
-
-| Tool | Description |
+| Command | Description |
 |---|---|
-| `sandbox_run` | Run code/commands — auto-manages full session lifecycle |
-| `sandbox_status` | Check if sandbox service is available |
-| `sandbox_create_session` | Create an isolated sandbox pod |
-| `sandbox_destroy_session` | Destroy session and clean up |
-| `sandbox_exec` | Run a command in a specific session |
-| `sandbox_exec_stream` | Run a command, get streaming output |
-| `sandbox_write_file` | Write a file into `/workspace` |
-| `sandbox_read_file` | Read a file from `/workspace` |
-| `sandbox_list_files` | List files modified since a timestamp |
-| `sandbox_pip_install` | Install Python packages via pip |
-| `sandbox_run_subagent` | Spawn a child sandbox (depth ≤ 1) |
-| `sandbox_confirm_action` | Gate irreversible actions on user approval |
+| `k8e sandbox run <code>` | Run code or shell command (auto-manages session) |
+| `k8e sandbox status` | Check sandbox service and current session |
+| `k8e sandbox create` | Create a new session (custom runtime, egress) |
+| `k8e sandbox destroy <sid>` | Destroy a session |
+| `k8e sandbox write <sid> <path>` | Write file to /workspace (content via stdin) |
+| `k8e sandbox read <sid> <path>` | Read file from /workspace |
+| `k8e sandbox list <sid>` | List files in /workspace |
+| `k8e sandbox subagent <parent-sid>` | Spawn child sandbox (max depth 1) |
+| `k8e sandbox confirm <sid> <action>` | Gate irreversible action on human approval |
+| `k8e sandbox snapshot save <sid> <name>` | Save workspace as named snapshot |
+| `k8e sandbox snapshot restore <name>` | Create new session from saved snapshot |
+| `k8e sandbox snapshot list` | List saved snapshots |
+
+See [skills/k8e-sandbox/SKILL.md](skills/k8e-sandbox/SKILL.md) for full usage examples.
+
+### Quick Examples
+
+```bash
+# Run Python code
+k8e sandbox run "print('hello')" --lang python
+
+# Multi-line code via stdin
+k8e sandbox run --lang python <<'EOF'
+for i in range(10):
+    print(i)
+EOF
+
+# Write a script then execute
+k8e sandbox write $SID /workspace/script.py <<'EOF'
+import pandas as pd
+print(pd.__version__)
+EOF
+k8e sandbox run "python3 /workspace/script.py" --session-id $SID
+
+# Create session with custom runtime and egress
+k8e sandbox create --runtime firecracker --allowed-hosts pypi.org,github.com
+
+# Stream long-running output
+k8e sandbox run "python3 train.py" --session-id $SID --raw
+
+# Workspace manifest
+k8e sandbox create --manifest workspace.yaml
+
+# Workspace snapshots
+k8e sandbox snapshot save $SID my-checkpoint
+k8e sandbox snapshot restore my-checkpoint
+```
 
 ### Configuration Overrides
 
-The MCP server auto-discovers the local cluster. Override when needed:
+The CLI auto-discovers the local cluster via TLS. Override when needed:
 
 ```bash
-K8E_SANDBOX_ENDPOINT=10.0.0.1:50051 k8e sandbox-mcp          # remote cluster
-K8E_SANDBOX_CERT=/path/to/ca.crt k8e sandbox-mcp              # custom TLS cert
-k8e sandbox-mcp --endpoint 10.0.0.1:50051 --tls-cert /path/to/ca.crt
+K8E_SANDBOX_ENDPOINT=10.0.0.1:50051 k8e sandbox run "echo hello"
+K8E_SANDBOX_CERT=/path/to/ca.crt k8e sandbox run "echo hello"
+k8e sandbox run "echo hello" --tenant my-project
 ```
-
-Auto-discovery probe order:
-1. `K8E_SANDBOX_ENDPOINT` env var
-2. `K8E_SANDBOX_CERT` / `K8E_SANDBOX_KEY` env vars
-3. `/var/lib/k8e/server/tls/serving-kube-apiserver.crt` (server node, root)
-4. `/etc/k8e/k8e.yaml` kubeconfig CA (agent node / non-root)
-5. `127.0.0.1:50051` with system CA pool
 
 ---
 
 ## 🐍 Python Client SDK
 
-The Python SDK talks directly to the sandbox gRPC gateway — no MCP process spawn, no stdio handshake (~1–5 ms vs ~500 ms for MCP stdio).
+The Python SDK talks directly to the sandbox gRPC gateway — no process spawn, no stdio handshake (~1–5 ms vs ~500 ms for CLI).
 
 ### Install
 
@@ -427,7 +421,7 @@ with sandbox_session(runtime_class="kata", allowed_hosts=["github.com"]) as (cli
 
 ## 🟦 TypeScript Client SDK
 
-The TypeScript SDK talks directly to the sandbox gRPC gateway — no MCP process spawn, no stdio handshake (~1–5 ms vs ~500 ms for MCP stdio).
+The TypeScript SDK talks directly to the sandbox gRPC gateway — no process spawn, no stdio handshake (~1–5 ms vs ~500 ms for CLI).
 
 ### Install
 
@@ -539,7 +533,7 @@ K8E_KUBECONFIG_OUTPUT=<path>    # kubeconfig output path
 | Binary size | **<100MB** | ~70MB | ~1GB+ | ~200MB |
 | Agentic Sandbox | ✅ Native | ❌ No | ⚠️ Manual | ❌ No |
 | eBPF networking | ✅ Cilium | ⚠️ Optional | ⚠️ Optional | ❌ No |
-| MCP skill built-in | ✅ Yes | ❌ No | ❌ No | ❌ No |
+| Sandbox CLI skill built-in | ✅ Yes | ❌ No | ❌ No | ❌ No |
 | HA embedded etcd | ✅ Yes | ✅ Yes | ✅ Yes | ⚠️ Limited |
 | CNCF conformant | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
 | Multi-arch | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,7 +4,7 @@ How the engineering skills should consume this repo's domain documentation.
 
 ## Before exploring, read these
 
-- **`docs/`** — Architectural Decision Records (KIP-1 through KIP-5). Read the ADR that touches the area you're working in.
+- **`docs/`** — Architectural Decision Records (KIP-1 through KIP-10). Read the ADR that touches the area you're working in.
 - **`CLAUDE.md`** at the repo root — project overview, architecture, build/test instructions.
 - **`CONTEXT.md`** — if it exists in the future, read it for domain language and glossary.
 
@@ -15,23 +15,28 @@ This is a single-context repo:
 ```
 /
 ├── CLAUDE.md                    # Project overview + architecture
-├── docs/                    # KIP-1 … KIP-6 (architectural decisions)
+├── docs/                    # KIP-1 … KIP-10 (architectural decisions)
 │   ├── kip-1-native-etcd-storage-client.md
 │   ├── kip-2-upgrade-dependencies-to-kubernetes-1.35.md
 │   ├── kip-3-agentic-ai-sandbox-matrix.md
 │   ├── kip-4-sandbox-mcp-skill.md
 │   ├── kip-5-openclaw-sandbox-management.md
-│   ├── kip-6-embedded-etcd-remove-kine-sqlite.md
+│   ├── kip-6-embedded-etcd-design.md
+│   ├── kip-7-embedded-etcd-fuse.md
+│   ├── kip-8-skill-cli-replace-mcp.md
+│   ├── kip-9-sandbox-workspace-manifest.md
+│   ├── kip-10-sandbox-snapshot.md
 │   └── sandbox-mcp-quickstart.md
 ├── docs/kip-6-embedded-etcd-design.md      # Embedded etcd 设计方案
 ├── docs/kip-7-embedded-etcd-fuse.md        # Embedded etcd 融合方案（集成官方 embed 包）
 ├── pkg/                         # Main source code
-│   ├── sandboxmcp/              # MCP server bridging AI agents → sandbox
+│   ├── sandboxcli/              # CLI command handlers (k8e sandbox)
+│   ├── sandboxmcp/              # gRPC client + skill installation
 │   ├── sandboxmatrix/           # Core sandbox orchestration (warm pools, sessions)
 │   ├── server/                  # Control plane daemon
 │   ├── agent/                   # Agent daemon (kubelet + containerd)
 │   └── ...
-├── skills/k8e-sandbox-skill/   # MCP skill files for agent install
+├── skills/k8e-sandbox/         # SKILL.md for agent CLI integration
 ├── sdk/python/                  # Python gRPC client SDK
 ├── sandbox/                     # Sandbox container runtime shim
 └── sandboxd/                    # Runtime daemon (Zig)
@@ -44,8 +49,8 @@ When naming domain concepts (in issue titles, PRDs, refactors), use the terms as
 - **Sandbox** — an isolated execution environment (Kubernetes pod with a pluggable RuntimeClass: gVisor, Kata, Firecracker).
 - **Session** — a user-agent's live interaction with a sandbox, tracked via CRD (`SandboxSession`).
 - **Warm pool** — pre-booted sandbox pods that reduce session startup latency (`SandboxWarmPool` CRD).
-- **MCP** — Model Context Protocol; the JSON-RPC bridge between AI agents and the sandbox orchestration layer.
-- **Tenant ID** — the `tenantID` field used for cross-process session reuse via `FindActiveSession()`.
+- **SKILL + CLI** — `k8e sandbox` CLI commands; the shell-based bridge between AI agents and the sandbox orchestration layer (replaced MCP as of KIP-8).
+- **Tenant ID** — the `tenantID` field used for cross-process session reuse via state files and `FindActiveSession()`.
 - **Orchestrator** — the gRPC-side logic that creates/destroys pods and manages sandbox lifecycle.
 
 ## Flag ADR conflicts

--- a/docs/kip-10-sandbox-snapshot.md
+++ b/docs/kip-10-sandbox-snapshot.md
@@ -1,0 +1,177 @@
+# KIP-10: Sandbox Workspace Snapshot
+
+| Author | Updated | Status |
+|--------|---------|--------|
+| @xiaods | 2026-05-30 | Draft |
+
+## Summary
+
+新增 `k8e sandbox snapshot` 命令组，支持保存和恢复 sandbox workspace 快照。当前 workspace PVC 在 session destroy 或 TTL GC 后删除，所有文件丢失。快照机制允许 Agent 持久化工作成果并在后续 session 中恢复。
+
+参考 [OpenAI Agents Sandbox Snapshots](https://openai.github.io/openai-agents-python/sandbox/guide/#snapshotspec) 设计。
+
+## Motivation
+
+KIP-8 的 session 生命周期是短暂的：
+
+```
+Agent 工作流:
+  1. create session → 安装依赖 + 克隆仓库 (2min)
+  2. 执行分析任务 (30min)
+  3. destroy session → 所有文件丢失 ❌
+  
+  下次类似任务:
+  4. create session → 重新安装依赖 + 克隆仓库 (2min) 😞
+```
+
+典型场景：
+- **长任务中断**：训练进行到一半，需要暂停，下次继续
+- **多阶段工作流**：阶段 1 生成数据 → 阶段 2 分析 → 两个阶段可能跨天
+- **模板复用**：预装常用工具链（Python 2.7 + 3.11 + Node 20）的工作区模板，每次 clone 不必重装
+- **协作**：用户 A 在 workspace 里准备好数据，用户 B 基于同一 workspace 继续工作
+
+## Design
+
+### 命令
+
+```bash
+# 保存当前 session 的 workspace 为命名快照
+k8e sandbox snapshot save <session-id> <name>
+
+# 列出所有快照
+k8e sandbox snapshot list
+
+# 从快照恢复为新 session
+k8e sandbox snapshot restore <name>
+  [--runtime gvisor] [--tenant <id>] [--allowed-hosts ...]
+
+# 删除快照
+k8e sandbox snapshot delete <name>
+```
+
+### 快照存储
+
+```
+~/.k8e/sandbox/snapshots/
+  my-template/
+    workspace.tar.gz      ← PVC 内容打包
+    metadata.json         ← 快照元数据
+  project-a-stage1/
+    workspace.tar.gz
+    metadata.json
+```
+
+**为什么用 tar.gz 而非 CSI snapshot？**
+
+| 方案 | 优点 | 缺点 |
+|------|------|------|
+| tar.gz 文件 | 不需要 CSI driver，直接可用；可跨集群传输；占用空间小 | 大 workspace 保存慢；不在 K8s 存储层 |
+| CSI VolumeSnapshot | K8s 原生；Restic 可做增量 | 需要 CSI snapshotter 部署；集群依赖；不可跨集群 |
+
+**选择 tar.gz**：K8E 是单二进制分发，不应依赖可选的 CSI driver。tar.gz 简单可靠，适用于 Agent 工作区（通常 < 1GB）。
+
+### metadata.json
+
+```json
+{
+  "name": "my-template",
+  "created_at": "2026-05-30T10:00:00Z",
+  "session_id": "sess-abc123",
+  "tenant_id": "my-project",
+  "size_bytes": 52428800,
+  "file_count": 142
+}
+```
+
+### 实现流程
+
+**save**：
+```
+1. 校验 session 存在且 Active
+2. Exec: tar czf /tmp/_snapshot.tar.gz -C /workspace .
+3. ReadFile: 下载 _snapshot.tar.gz 内容
+4. 写入 ~/.k8e/sandbox/snapshots/<name>/workspace.tar.gz
+5. 写入 metadata.json
+6. 输出 {"ok":true,"name":"my-template","size_bytes":...}
+```
+
+**restore**：
+```
+1. 读取 metadata.json + workspace.tar.gz
+2. CreateSession (gRPC)
+3. WriteFile: 上传 workspace.tar.gz 到 sandbox
+4. Exec: tar xzf /tmp/_snapshot.tar.gz -C /workspace
+5. Exec: rm /tmp/_snapshot.tar.gz
+6. 写 state 文件
+7. 输出 {"session_id":"...","restored_from":"my-template"}
+```
+
+**list**：
+```
+1. 扫描 ~/.k8e/sandbox/snapshots/ 目录
+2. 读取每个子目录的 metadata.json
+3. 格式化输出
+```
+
+**delete**：
+```
+1. 删除 ~/.k8e/sandbox/snapshots/<name>/ 目录
+```
+
+### 输出格式
+
+```bash
+# save
+$ k8e sandbox snapshot save sess-abc my-template
+{"ok":true,"name":"my-template","size_bytes":52428800,"file_count":142}
+
+# list
+$ k8e sandbox snapshot list
+{"snapshots":[{"name":"my-template","created_at":"...","size_bytes":52428800},{"name":"project-a","created_at":"...","size_bytes":1048576}]}
+
+# restore → 返回 session_id（和 create 格式一致）
+$ k8e sandbox snapshot restore my-template
+{"session_id":"sess-new-xxx","pod_ip":"10.42.1.55","restored_from":"my-template"}
+
+# restore + 开始工作（等价于 restore + run）
+$ SID=$(k8e sandbox snapshot restore my-template | jq -r .session_id)
+$ k8e sandbox run "python3 train.py --resume" --session-id $SID
+
+# delete
+$ k8e sandbox snapshot delete my-template
+{"ok":true}
+```
+
+### 与 manifest 组合
+
+```bash
+# 从快照恢复 + 叠加 manifest（新文件添加到已有 workspace）
+# 三步：
+SID=$(k8e sandbox snapshot restore my-template | jq -r .session_id)
+# 手动 write 新文件
+k8e sandbox run "python3 /workspace/stage2.py" --session-id $SID
+```
+
+### 边界处理
+
+| 场景 | 行为 |
+|------|------|
+| workspace 过大（>500MB） | 输出 warning 到 stderr，继续保存 |
+| session 已销毁 | 报错 "session not active" |
+| 同名快照已存在 | `--force` 覆盖，否则报错 |
+| restore 时原 session 模板不存在 | CreateSession 用默认值（gvisor, 默认 allowed-hosts） |
+| 快照文件损坏 | metadata 校验失败，报错 |
+
+### 文件变更
+
+| 文件 | 变更 |
+|------|------|
+| `pkg/sandboxcli/snapshot.go` | 新文件：快照 save/restore/list/delete 逻辑 |
+| `pkg/sandboxcli/commands.go` | 新增 `SnapshotCommand()` 命令组 |
+| `pkg/cli/cmds/sandbox.go` | sandbox 命令组注册 snapshot 子命令 |
+| `skills/k8e-sandbox/SKILL.md` | 新增 snapshot 使用示例 |
+
+## 相关 KIP
+
+- [KIP-8](./kip-8-skill-cli-replace-mcp.md) — CLI sandbox 命令（本 KIP 的前置依赖）
+- [KIP-9](./kip-9-sandbox-workspace-manifest.md) — Workspace manifest（与本 KIP 互补：manifest 定义初始状态，snapshot 持久化中间状态）

--- a/docs/kip-8-openai-alignment.md
+++ b/docs/kip-8-openai-alignment.md
@@ -1,0 +1,120 @@
+# K8E Sandbox vs OpenAI Agents Sandbox — 对齐分析
+
+| 分析日期 | 对照版本 |
+|---------|---------|
+| 2026-05-30 | OpenAI Agents SDK v0.14+ (beta) vs K8E KIP-8 |
+
+## 架构对比
+
+| 维度 | OpenAI Agents Sandbox | K8E Sandbox (KIP-8) | 对齐状态 |
+|------|----------------------|---------------------|---------|
+| **接入层** | Python SDK `SandboxAgent` + `Runner` | `k8e sandbox` CLI（gRPC 直连） | ⚠️ 不同范式，但互补 |
+| **隔离后端** | UnixLocal / Docker / 托管提供商 | Kubernetes Pod + RuntimeClass（gVisor/Kata/FC） | ✅ K8E 隔离更强 |
+| **通道协议** | SDK 内部工具调用 | gRPC（protobuf）→ sandboxd HTTP :2024 | ✅ gRPC 性能更优 |
+| **会话管理** | SDK-owned / developer-owned 生命周期 | State 文件 `~/.k8e/sandbox/{tenant}/state.json` + tenant 跨进程复用 | ✅ 概念对齐 |
+| **审批门禁** | 外置运行时审批 | `confirm` + `approve` CLI 命令（内存 channel） | ✅ 都有，K8E 更显式 |
+
+## 功能对比
+
+### 1. Workspace 定义（Manifest）
+
+| | OpenAI | K8E | 差距 |
+|---|--------|-----|------|
+| 文件/目录 | `File`, `Dir`, `LocalFile`, `LocalDir` | `k8e sandbox write` (逐一写入) | 🔴 K8E 无声明式 workspace |
+| Git 仓库 | `GitRepo(repo, ref)` | `k8e sandbox run "git clone ..."` | 🔴 K8E 需手动 clone |
+| 远程挂载 | S3/GCS/Azure/Box Mount | 无（仅 FQDN egress 白名单） | 🔴 K8E 无远程存储挂载 |
+| 环境变量 | Manifest `env` | 无 | 🟡 可在 sandboxd 层加 |
+| 用户/权限 | `User`, `Permissions`, `run_as` | 无（sandbox 内 root） | 🟡 安全增强方向 |
+
+**建议**：K8E 当前 workspace 构建靠 Agent 手动执行 CLI 命令。后续 KIP 可引入 `SandboxWorkspace` CRD 或 Manifest 概念——声明式定义初始工作区（GitRepo、文件模板、挂载），控制器在 CreateSession 时自动 materialize 到 PVC。
+
+### 2. 工具能力（Capabilities）
+
+| | OpenAI | K8E | 差距 |
+|---|--------|-----|------|
+| Shell 执行 | `Shell` → `exec_command`, `write_stdin` (PTY) | `run` (Exec + ExecStream) | ✅ 对齐 |
+| 文件读写 | `Filesystem` → `apply_patch`, `view_image` | `write` / `read` / `list` (全量) | 🟡 K8E 无 patch 编辑、无图片查看 |
+| 技能发现 | `Skills` (lazy_from, LocalDir, GitRepo) | SKILL.md 在 Agent 侧（非 sandbox 内） | 🟡 概念相似但位置不同 |
+| 记忆 | `Memory` (跨 run 持久化经验) | 无 | 🔴 缺失 |
+| 上下文压缩 | `Compaction` | 无 | 🔴 缺失 |
+
+**patch 编辑**：OpenAI 的 `apply_patch` 允许 Agent 用 unified diff 精确修改文件，而不是全量重写。对大文件场景效率更高。K8E 当前只有全量 `write`。
+
+**建议**：
+- `apply_patch` 可以作为 `sandboxd` 新增 HTTP endpoint (`POST /files/patch`)，然后通过 `k8e sandbox patch <sid> <path>` (stdin diff) 暴露
+- `Memory` 和 `Compaction` 是 Agent SDK 层概念，K8E 作为基础设施层不需要内置——由上层 Agent 框架处理
+
+### 3. 快照与持久化（Snapshots）
+
+| | OpenAI | K8E | 差距 |
+|---|--------|-----|------|
+| 本地快照 | `LocalSnapshotSpec` | 无 | 🔴 缺失 |
+| 远程快照 | `RemoteSnapshotSpec` | 无 | 🔴 缺失 |
+| 会话恢复 | `session_state`, `RunState` | State 文件 + tenant FindActiveSession | ✅ 跨进程复用对齐 |
+| TTL | 无（快照持久） | SandboxMatrix `sessionTTL` + GC | 🟡 K8E 偏临时 |
+
+**关键差距**：OpenAI 的 manager 可以让用户保存沙箱 workspace 快照并在后续 run 中恢复。K8E 的 PVC 在 session destroy/GC 后即删除——文件丢失。
+
+**建议**：
+- 短期：允许 `create` 指定 `--keep-workspace` 跳过 GC 的 PVC 删除
+- 中期：`SandboxSnapshot` CRD —— 对 PVC 做 Filesystem 快照（CSI snapshot），实现 save/restore
+
+### 4. 托管提供商（Hosted Providers）
+
+OpenAI 支持 8 个托管提供商作为 sandbox backend（Modal, Cloudflare, E2B, Daytona, Runloop, Vercel, Blaxel）。K8E 只有一个 backend（Kubernetes Pods with RuntimeClass）。
+
+**这不是差距——是定位差异**：OpenAI 是 Agent SDK（统一编程接口），K8E 是基础设施（统一运行时）。K8E 的 gRPC 接口可以被任何上层 SDK 封装为 provider。
+
+**建议**：编写一个 `K8ESandboxClient` 实现 OpenAI 的 sandbox client 协议，让 K8E 成为 OpenAI Agents SDK 的一个托管提供商。这样 K8E 获得所有上层能力（Manifest、Capabilities、Snapshots）而无需自己重复实现。
+
+### 5. 安全模型
+
+| | OpenAI | K8E | 对齐 |
+|---|--------|-----|------|
+| 文件权限 | 用户/组 + `run_as` | 无（sandbox 内 root） | 🔴 |
+| 网络隔离 | 容器级别 | Cilium eBPF `toFQDNs` per-session | ✅ K8E 更强 |
+| 运行时隔离 | Docker / 托管 VM | gVisor / Kata / Firecracker | ✅ K8E 更强 |
+| 审批门禁 | 外置 | `confirm` + `approve` 内置 | ✅ 都有 |
+| 只读文件系统 | 支持 | `readOnlyRootFilesystem: true` | ✅ |
+| 深度限制 | 无 | 子沙箱 max depth=1 | ✅ K8E 额外保护 |
+
+**安全是 K8E 的强项**——eBPF 内核级网络隔离 + 微虚拟机运行时隔离。但文件系统权限粒度不如 OpenAI。
+
+## 核心结论
+
+### K8E 的优势（不可替代）
+
+1. **生产级隔离**：gVisor/Kata/Firecracker 微虚拟机，非 Docker 容器可比
+2. **eBPF 网络策略**：Cilium `toFQDNs` per-session，内核级强制执行
+3. **Warm pool**：预启动 Pod 池，<500ms session 冷启动
+4. **多租户**：tenant 隔离 + SandboxMatrix CRD 策略
+5. **统一运行时**：任何 Agent 框架都能通过 CLI 或 SDK 接入
+
+### 需要补足的差距（按优先级）
+
+| 优先级 | 差距 | 建议方案 | KIP |
+|--------|------|---------|-----|
+| **P0** | 无 Manfiest（声明式 workspace） | `SandboxWorkspace` CRD + `--manifest` flag | KIP-9 |
+| **P0** | 无快照（workspace 无法持久化） | PVC CSI snapshot + `k8e sandbox snapshot save/restore` | KIP-10 |
+| **P1** | 无 patch 编辑 | `sandboxd` 新增 `/files/patch` + `k8e sandbox patch` | 小改动 |
+| **P1** | OpenAI SDK provider | 实现 `K8ESandboxClient` 成为托管提供商 | 新项目 |
+| **P2** | 文件系统权限 | `run_as` + sandboxd 用户切换 | KIP-11 |
+| **P2** | 远程存储挂载 | S3/GCS CSI driver + Manifest mount entries | KIP-12 |
+
+### 当前 KIP-8 已经对齐的部分
+
+```
+OpenAI Sandbox                K8E Sandbox (KIP-8)
+─────────────                 ────────────────────
+exec_command      ←────────→  k8e sandbox run
+exec_stream       ←────────→  k8e sandbox run --raw
+write_file        ←────────→  k8e sandbox write (stdin)
+read_file         ←────────→  k8e sandbox read
+list_files        ←────────→  k8e sandbox list
+session create    ←────────→  k8e sandbox create
+session destroy   ←────────→  k8e sandbox destroy
+session resume    ←────────→  state file + --tenant
+approval gate     ←────────→  k8e sandbox confirm + approve
+```
+
+**结论**：KIP-8 的设计方向正确。CLI 命令集覆盖了 OpenAI sandbox 核心执行能力的 80%。剩余的 20%（Manifest、Snapshot、Patch）是声明式工作区管理和状态持久化的增强，应作为后续 KIP 补齐。K8E 作为基础设施层的定位——通过 gRPC 为上层 Agent 框架提供统一运行时——与 OpenAI 的 SDK 层是互补而非竞争关系。

--- a/docs/kip-9-sandbox-workspace-manifest.md
+++ b/docs/kip-9-sandbox-workspace-manifest.md
@@ -1,0 +1,164 @@
+# KIP-9: Sandbox Workspace Manifest
+
+| Author | Updated | Status |
+|--------|---------|--------|
+| @xiaods | 2026-05-30 | Draft |
+
+## Summary
+
+新增 `--manifest` flag 到 `k8e sandbox create`，支持声明式定义 sandbox 初始工作区。Agent 通过 YAML 文件指定文件、目录和 Git 仓库，CLI 在 CreateSession 后自动 materialize 到 PVC，无需 Agent 手动执行多次 `write` + `git clone`。
+
+参考 [OpenAI Agents Sandbox Manifest](https://openai.github.io/openai-agents-python/sandbox/guide/#manifest) 设计。
+
+## Motivation
+
+KIP-8 的 CLI 模式要求 Agent 手动构建 workspace：
+
+```bash
+SID=$(k8e sandbox create | jq -r .session_id)
+echo "# Task" | k8e sandbox write $SID /workspace/task.md
+echo "print('hello')" | k8e sandbox write $SID /workspace/script.py
+k8e sandbox run "git clone https://github.com/org/repo.git /workspace/repo" --session-id $SID
+k8e sandbox run "python3 /workspace/script.py" --session-id $SID
+```
+
+4 次 CLI 调用 + 4 次 gRPC 往返，Agent 需要维护 session ID 跨命令，容易出错。
+
+Manifest 模式：
+
+```bash
+k8e sandbox create --manifest workspace.yaml | jq -r .session_id
+# manifest 内容已自动 materialize，直接开始工作
+k8e sandbox run "python3 /workspace/script.py" --session-id $SID
+```
+
+## Design
+
+### Manifest 格式
+
+```yaml
+# workspace.yaml
+entries:
+  - file:
+      path: task.md
+      content: |
+        # Analysis Task
+        Read the data in repo/data.csv and produce a summary report.
+  - dir:
+      path: output
+  - dir:
+      path: scripts
+  - file:
+      path: scripts/analyze.py
+      content: |
+        import pandas as pd
+        df = pd.read_csv("/workspace/repo/data.csv")
+        print(df.describe())
+  - gitRepo:
+      path: repo
+      repo: https://github.com/example/project.git
+      ref: main
+```
+
+### CLI 命令
+
+```bash
+# 从 manifest 文件创建 session
+k8e sandbox create --manifest workspace.yaml
+
+# 指定 session-id
+k8e sandbox create --manifest workspace.yaml --session-id my-session
+
+# 结合其他 flag
+k8e sandbox create --manifest workspace.yaml --runtime kata --allowed-hosts pypi.org,github.com
+
+# 简单的 git clone（不需要完整 manifest 文件）
+k8e sandbox create --git-repo https://github.com/org/repo.git
+k8e sandbox create --git-repo https://github.com/org/repo.git --git-ref develop --git-path src
+```
+
+### Materialization 流程
+
+```
+k8e sandbox create --manifest workspace.yaml
+  │
+  ├── 1. 解析 YAML → []Entry
+  ├── 2. CreateSession (gRPC) → session_id
+  ├── 3. 按顺序 materialize 每个 entry:
+  │     ├── File: WriteFile(gRPC) 写入内容
+  │     ├── Dir: Exec(gRPC) "mkdir -p <path>"
+  │     └── GitRepo: Exec(gRPC) "git clone --depth 1 -b <ref> <repo> <path>"
+  ├── 4. materialize 失败 → DestroySession + 报错
+  └── 5. 写 state 文件 + 输出 {"session_id":"...","entries_materialized":3}
+```
+
+**CLI 侧 materialization**（不修改 proto/gRPC）：
+- 所有 entry 由 CLI 进程通过已有的 gRPC 方法依次执行
+- 不需要新增 proto RPC，不需要改 orchestrator
+- 约 100 行 Go 代码
+
+### 错误处理
+
+```bash
+# 部分成功
+$ k8e sandbox create --manifest workspace.yaml
+# File task.md ✓
+# Dir output/ ✓
+# GitRepo repo ✗ (clone failed: authentication required)
+{"error":"manifest materialization failed at entry 3/3: git clone: authentication required"}
+exit 1
+# session 已自动 destroy
+```
+
+### `k8e sandbox run` 也支持 --manifest
+
+`run` 本身会 auto-create session，所以也可以接受 `--manifest`：
+
+```bash
+k8e sandbox run "python3 /workspace/analyze.py" --lang bash --manifest workspace.yaml
+```
+
+内部：先 create + materialize，再 exec code。Agent 一个命令完成全部准备+执行。
+
+### 实现范围
+
+| Entry 类型 | 实现 | 说明 |
+|-----------|------|------|
+| `file` | WriteFile RPC | 支持 `content` (内联) 和 `source` (本地文件路径，未来) |
+| `dir` | Exec RPC `mkdir -p` | |
+| `gitRepo` | Exec RPC `git clone --depth 1` | 默认 shallow clone 节省空间；支持 `ref` (branch/tag/commit) |
+
+**未来扩展**（本 KIP 不做）：
+- `localFile` / `localDir`：从 Agent 主机复制文件到 sandbox
+- `s3Mount` / `gcsMount`：远程存储挂载
+- `SandboxWorkspace` CRD：命名 workspace 模板，跨 session 复用
+
+### 命令变更
+
+`k8e sandbox create` 新增 flags：
+
+| Flag | 描述 |
+|------|------|
+| `--manifest <path>` | YAML manifest 文件路径 |
+| `--git-repo <url>` | Git 仓库 URL（快捷方式，等价于单 entry manifest） |
+| `--git-ref <ref>` | Git ref（配合 `--git-repo`，默认 main） |
+| `--git-path <path>` | 仓库在 workspace 中的路径（默认 repo） |
+
+`k8e sandbox run` 新增 flags：
+
+| Flag | 描述 |
+|------|------|
+| `--manifest <path>` | 同 create（仅在 auto-create session 时生效） |
+
+### 文件变更
+
+| 文件 | 变更 |
+|------|------|
+| `pkg/sandboxcli/manifest.go` | 新文件：YAML 解析 + materialization 逻辑 |
+| `pkg/sandboxcli/commands.go` | `create` 和 `run` 命令新增 `--manifest` flag |
+| `skills/k8e-sandbox/SKILL.md` | 新增 manifest 使用示例 |
+
+## 相关 KIP
+
+- [KIP-8](./kip-8-skill-cli-replace-mcp.md) — CLI sandbox 命令（本 KIP 的前置依赖）
+- [KIP-10](./kip-10-sandbox-snapshot.md) — Workspace 快照持久化（与本 KIP 互补）

--- a/docs/sandbox-mcp-quickstart.md
+++ b/docs/sandbox-mcp-quickstart.md
@@ -1,172 +1,106 @@
-# K8E Sandbox MCP Quickstart
+# K8E Sandbox CLI Quickstart
 
-Install the K8E sandbox skill into your AI agent in one step.
+> **Note**: `k8e sandbox-mcp` has been replaced by `k8e sandbox` CLI commands as of KIP-8.
+> See [KIP-8: SKILL + CLI 替换 MCP 协议层](./kip-8-skill-cli-replace-mcp.md) for migration details.
 
-## Prerequisites
-
-- `runsc` (gVisor) installed **before** starting K8E:
-  ```bash
-  curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] \
-    https://storage.googleapis.com/gvisor/releases release main" \
-    > /etc/apt/sources.list.d/gvisor.list
-  apt-get update && apt-get install -y runsc
-  ```
-  > Do **not** run `runsc install`. K8E detects `runsc` at startup and auto-injects the gVisor stanza into its own containerd config (`/var/lib/k8e/agent/etc/containerd/config.toml`).
-- K8E cluster running (`systemctl status k8e`)
-- `k8e` binary in `$PATH`
-
-## One-Command Install
-
-`sandbox-install-skill` does two things in one command:
-1. Writes the `k8e-sandbox` MCP server entry into the agent's config file
-2. Copies the sandbox skill files from `/var/lib/k8e/server/skills/` into the agent's skills directory
-
-> **Prerequisite:** K8E server must have started at least once. On first boot it stages the skill files to `/var/lib/k8e/server/skills/`. If that directory is missing, start K8E first: `systemctl start k8e`
+## Quick Start
 
 ```bash
-# Install into all supported agents at once
+# Run code (auto-creates session)
+k8e sandbox run "print('hello')" --lang python
+
+# Check status
+k8e sandbox status
+
+# Run shell commands
+k8e sandbox run "ls -la /workspace"
+```
+
+## Install the Skill
+
+```bash
+# Install skill files for all agents
 k8e sandbox-install-skill all
-
-# Or install into a specific agent
-k8e sandbox-install-skill kiro      # MCP config → .kiro/settings.json (workspace)
-                                    # Skills     → .kiro/skills/k8e-sandbox-skill/
-k8e sandbox-install-skill claude    # MCP config → ~/.claude.json
-                                    # Skills     → ~/.claude/skills/k8e-sandbox-skill/
-k8e sandbox-install-skill gemini    # MCP config → ~/.gemini/settings.json
-                                    # Skills     → ~/.gemini/skills/k8e-sandbox-skill/
 ```
 
-| Agent | MCP config | Skills directory |
-|---|---|---|
-| claude code | `~/.claude.json` | `~/.claude/skills/k8e-sandbox-skill/` |
-| kiro-cli | `.kiro/settings.json` (workspace) or `~/.kiro/settings.json` (global) | `.kiro/skills/k8e-sandbox-skill/` |
-| gemini cli | `~/.gemini/settings.json` | `~/.gemini/skills/k8e-sandbox-skill/` |
+## Core Commands
 
-## Manual Setup (alternative)
+| Command | Description |
+|---------|-------------|
+| `k8e sandbox run <code>` | Run code or shell command (auto-manages session) |
+| `k8e sandbox status` | Check sandbox service and current session |
+| `k8e sandbox create` | Create a new session |
+| `k8e sandbox destroy <sid>` | Destroy a session |
+| `k8e sandbox write <sid> <path>` | Write file to /workspace (stdin) |
+| `k8e sandbox read <sid> <path>` | Read file from /workspace |
+| `k8e sandbox list <sid>` | List files in /workspace |
+| `k8e sandbox subagent <parent-sid>` | Spawn child sandbox |
+| `k8e sandbox confirm <sid> <action>` | Gate irreversible action |
+| `k8e sandbox snapshot save <sid> <name>` | Save workspace snapshot |
+| `k8e sandbox snapshot restore <name>` | Restore from snapshot |
 
-If you prefer to configure manually:
-
-**claude code:**
-```bash
-claude mcp add k8e-sandbox -- k8e sandbox-mcp
-```
-
-**kiro-cli / gemini cli** — add to settings JSON:
-```json
-{
-  "mcpServers": {
-    "k8e-sandbox": {
-      "command": "k8e",
-      "args": ["sandbox-mcp"]
-    }
-  }
-}
-```
-
-## Usage
-
-Once installed, just ask your agent naturally:
-
-> "Run this Python snippet in a sandbox"
-> "Execute this shell script safely"
-> "Test this code without affecting my machine"
-
-The agent will use `sandbox_run` automatically — no session management needed.
-
-## Available Tools
-
-### High-level (recommended)
-
-| Tool | Description |
-|---|---|
-| `sandbox_run` | Run code/commands — auto-manages session lifecycle |
-| `sandbox_status` | Check if sandbox service is available |
-
-### Low-level (full control)
-
-| Tool | Description |
-|---|---|
-| `sandbox_create_session` | Create an isolated sandbox pod |
-| `sandbox_destroy_session` | Destroy session and clean up |
-| `sandbox_exec` | Run a command in a specific session |
-| `sandbox_exec_stream` | Run a command, get streaming output |
-| `sandbox_write_file` | Write a file into `/workspace` |
-| `sandbox_read_file` | Read a file from `/workspace` |
-| `sandbox_list_files` | List files modified since a timestamp |
-| `sandbox_pip_install` | Install Python packages via pip |
-| `sandbox_run_subagent` | Spawn a child sandbox (depth ≤ 1) |
-| `sandbox_confirm_action` | Gate irreversible actions on user approval |
-
-## Python SDK Usage
-
-Direct gRPC — no MCP overhead (~1–5 ms vs ~500 ms for MCP stdio).
-
-### Install
+## Examples
 
 ```bash
-python3 -m pip install grpcio grpcio-tools protobuf
+# Multi-line code via stdin
+k8e sandbox run --lang python <<'EOF'
+for i in range(10):
+    print(i)
+EOF
+
+# Write a script then execute
+echo "import pandas as pd" | k8e sandbox write $SID /workspace/script.py
+k8e sandbox run "python3 /workspace/script.py" --session-id $SID
+
+# Create session with manifest
+k8e sandbox create --manifest workspace.yaml
+
+# Save and restore snapshots
+k8e sandbox snapshot save $SID my-checkpoint
+k8e sandbox snapshot restore my-checkpoint
+
+# Stream long-running output
+k8e sandbox run "python3 train.py" --session-id $SID --raw
 ```
 
-### Generate stubs (once)
-
-```bash
-python3 -m grpc_tools.protoc -I proto \
-  --python_out=sdk/python \
-  --grpc_python_out=sdk/python \
-  proto/sandbox/v1/sandbox.proto
-
-touch sdk/python/sandbox/__init__.py sdk/python/sandbox/v1/__init__.py
-```
-
-### Run code
-
-```python
-from sandbox_client import SandboxClient
-
-with SandboxClient() as client:
-    result = client.run("print('hello')", language="python")
-    print(result.stdout)   # hello
-```
-
-### Multi-step workflow
-
-```python
-with SandboxClient() as client:
-    client.run("pip install pandas", "bash")
-    result = client.run("python3 analyze.py", "bash")
-```
-
-### Custom session (runtime / egress)
-
-```python
-from sandbox_client import sandbox_session
-
-with sandbox_session(runtime_class="kata", allowed_hosts=["github.com"]) as (client, sid):
-    client.write_file(sid, "/workspace/main.py", code)
-    result = client.exec(sid, "python3 /workspace/main.py")
-```
-
-> SDK source: `sdk/python/sandbox_client.py`
-
----
-
-## Configuration Overrides
+## Configuration
 
 ```bash
 # Remote cluster
-K8E_SANDBOX_ENDPOINT=10.0.0.1:50051 k8e sandbox-mcp
+K8E_SANDBOX_ENDPOINT=10.0.0.1:50051 k8e sandbox run "echo hello"
 
 # Custom TLS cert
-K8E_SANDBOX_CERT=/path/to/ca.crt k8e sandbox-mcp
+K8E_SANDBOX_CERT=/path/to/ca.crt k8e sandbox run "echo hello"
 
-# Via flags
-k8e sandbox-mcp --endpoint 10.0.0.1:50051 --tls-cert /path/to/ca.crt
+# Tenant-based session persistence
+k8e sandbox run "echo hello" --tenant my-project
 ```
 
 ## Verify
 
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test","version":"1.0"},"capabilities":{}}}' \
-  | k8e sandbox-mcp
+k8e sandbox status
+# {"available":true,"session_id":"sess-abc","tenant_id":"default"}
 ```
+
+## Session Persistence
+
+Sessions are automatically persisted via state files at `~/.k8e/sandbox/{tenant}/state.json`. Use `--tenant` for cross-process reuse.
+
+```bash
+export K8E_SANDBOX_TENANT=my-project
+k8e sandbox run "echo hello"   # creates/uses project session
+k8e sandbox run "echo world"   # reuses same session
+```
+
+## Migration from MCP
+
+| Old (MCP) | New (CLI) |
+|-----------|-----------|
+| `k8e sandbox-mcp` | `k8e sandbox` |
+| `sandbox_run` | `k8e sandbox run` |
+| `sandbox_create_session` | `k8e sandbox create` |
+| `sandbox_write_file` | `k8e sandbox write` |
+| `sandbox_pip_install` | `k8e sandbox run "pip install ..."` |
+
+Full migration guide: [KIP-8](./kip-8-skill-cli-replace-mcp.md)

--- a/pkg/cli/cmds/sandbox.go
+++ b/pkg/cli/cmds/sandbox.go
@@ -20,6 +20,7 @@ func NewSandboxCommand() cli.Command {
 			sandboxcli.SubagentCommand(),
 			sandboxcli.ConfirmCommand(),
 			sandboxcli.ApproveCommand(),
+			sandboxcli.SnapshotCommand(),
 		},
 	}
 }

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -46,6 +46,48 @@ func isMultiLine(code string) bool {
 	return strings.Contains(code, "\n")
 }
 
+// ensureSession resolves session ID, auto-creating one with manifest if needed.
+// Returns (sessionID, needsFinalize, error).
+func ensureSession(client *sandboxmcp.Client, ctx *cli.Context) (string, bool, error) {
+	sid, err := resolveSession(context.Background(), ctx.String("tenant"), ctx.String("session-id"))
+	if err != nil {
+		return "", false, err
+	}
+	if sid != "" {
+		return sid, false, nil
+	}
+
+	resp, err := client.SandboxServiceClient.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		TenantId: ctx.String("tenant"), RuntimeClass: "gvisor",
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("create session: %w", err)
+	}
+	sid = resp.SessionId
+
+	manifest, mErr := resolveManifest(ctx)
+	if mErr != nil {
+		client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+		return "", false, fmt.Errorf("manifest: %w", mErr)
+	}
+	if manifest != nil {
+		if err := materializeManifest(client, sid, manifest); err != nil {
+			client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+			return "", false, fmt.Errorf("manifest materialization: %w", err)
+		}
+	}
+	return sid, true, nil
+}
+
+// isInterpretedLang returns true for languages that need shell wrapping.
+func isInterpretedLang(lang string) bool {
+	switch strings.ToLower(lang) {
+	case "python", "python3", "py", "node", "nodejs", "js", "javascript":
+		return true
+	}
+	return false
+}
+
 // buildCommand wraps code for a given language.
 // bash: pass through as-is. python/node: single-line uses -c, multi-line uses temp file.
 func buildCommand(lang, code string) string {
@@ -108,47 +150,14 @@ func RunCommand() cli.Command {
 			client := newClient()
 			defer client.Close()
 
-			sid, err := resolveSession(context.Background(), ctx.String("tenant"), ctx.String("session-id"))
+			sid, needsFinalize, err := ensureSession(client, ctx)
 			if err != nil {
 				printErrorExit(err.Error(), 2)
 				return nil
 			}
 
-			// auto-create session if none exists
-			needsFinalize := false
-			if sid == "" {
-				resp, err := client.SandboxServiceClient.CreateSession(context.Background(), &pb.CreateSessionRequest{
-					TenantId:     ctx.String("tenant"),
-					RuntimeClass: "gvisor",
-				})
-				if err != nil {
-					printErrorExit("create session: "+err.Error(), 2)
-					return nil
-				}
-				sid = resp.SessionId
-				needsFinalize = true
-
-				// materialize manifest for auto-created sessions
-				manifest, mErr := resolveManifest(ctx)
-				if mErr != nil {
-					client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
-					printErrorExit("manifest: "+mErr.Error(), 1)
-					return nil
-				}
-				if manifest != nil {
-					if err := materializeManifest(client, sid, manifest); err != nil {
-						client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
-						printErrorExit("manifest materialization: "+err.Error(), 1)
-						return nil
-					}
-				}
-			}
-
 			// python/node multi-line: write file first, then execute
-			lowLang := strings.ToLower(lang)
-			if (lowLang == "python" || lowLang == "python3" || lowLang == "py" ||
-				lowLang == "node" || lowLang == "nodejs" || lowLang == "js" || lowLang == "javascript") &&
-				isMultiLine(code) {
+			if isInterpretedLang(lang) && isMultiLine(code) {
 				if err := writeCodeFile(client, sid, lang, code); err != nil {
 					printErrorExit("write code: "+err.Error(), 1)
 					return nil

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -91,6 +91,10 @@ func RunCommand() cli.Command {
 			cli.StringFlag{Name: "session-id", EnvVar: "K8E_SANDBOX_SESSION_ID", Usage: "Explicit session ID"},
 			cli.StringFlag{Name: "tenant", EnvVar: "K8E_SANDBOX_TENANT", Usage: "Tenant for cross-process session reuse"},
 			cli.BoolFlag{Name: "raw", Usage: "Stream raw output (no JSON wrapper)"},
+			cli.StringFlag{Name: "manifest", Usage: "Path to workspace manifest (only when auto-creating session)"},
+			cli.StringFlag{Name: "git-repo", Usage: "Git repo to clone (only when auto-creating session)"},
+			cli.StringFlag{Name: "git-ref", Value: "main", Usage: "Git ref for --git-repo"},
+			cli.StringFlag{Name: "git-path", Value: "repo", Usage: "Destination path for --git-repo"},
 		},
 		Action: func(ctx *cli.Context) error {
 			code, err := readCode(ctx)
@@ -123,6 +127,21 @@ func RunCommand() cli.Command {
 				}
 				sid = resp.SessionId
 				needsFinalize = true
+
+				// materialize manifest for auto-created sessions
+				manifest, mErr := resolveManifest(ctx)
+				if mErr != nil {
+					client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+					printErrorExit("manifest: "+mErr.Error(), 1)
+					return nil
+				}
+				if manifest != nil {
+					if err := materializeManifest(client, sid, manifest); err != nil {
+						client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+						printErrorExit("manifest materialization: "+err.Error(), 1)
+						return nil
+					}
+				}
 			}
 
 			// python/node multi-line: write file first, then execute
@@ -232,6 +251,10 @@ func CreateCommand() cli.Command {
 			cli.StringFlag{Name: "tenant", EnvVar: "K8E_SANDBOX_TENANT", Usage: "Tenant identifier"},
 			cli.StringFlag{Name: "allowed-hosts", Usage: "Comma-separated FQDN egress allowlist"},
 			cli.StringFlag{Name: "session-id", Usage: "Custom session ID"},
+			cli.StringFlag{Name: "manifest", Usage: "Path to workspace manifest YAML file"},
+			cli.StringFlag{Name: "git-repo", Usage: "Git repository URL to clone (shortcut)"},
+			cli.StringFlag{Name: "git-ref", Value: "main", Usage: "Git ref for --git-repo"},
+			cli.StringFlag{Name: "git-path", Value: "repo", Usage: "Destination path for --git-repo"},
 		},
 		Action: func(ctx *cli.Context) error {
 			client := newClient()
@@ -253,15 +276,53 @@ func CreateCommand() cli.Command {
 				return nil
 			}
 
+			sid := resp.SessionId
+
+			// materialize manifest if provided
+			manifest, mErr := resolveManifest(ctx)
+			if mErr != nil {
+				client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+				printErrorExit("manifest: "+mErr.Error(), 1)
+				return nil
+			}
+			if manifest != nil {
+				if err := materializeManifest(client, sid, manifest); err != nil {
+					client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+					printErrorExit("manifest materialization failed: "+err.Error(), 1)
+					return nil
+				}
+			}
+
 			// always write state file (unless explicit session-id)
 			if ctx.String("session-id") == "" {
 				_ = finalizeState(ctx.String("tenant"), resp.SessionId)
 			}
 
-			printJSON(map[string]any{"session_id": resp.SessionId, "pod_ip": resp.PodIp})
+			count := 0
+			if manifest != nil {
+				count = len(manifest.Entries)
+			}
+			printJSON(map[string]any{"session_id": resp.SessionId, "pod_ip": resp.PodIp, "entries_materialized": count})
 			return nil
 		},
 	}
+}
+
+// resolveManifest builds a Manifest from --manifest, --git-repo flags, or returns nil.
+func resolveManifest(ctx *cli.Context) (*Manifest, error) {
+	if path := ctx.String("manifest"); path != "" {
+		return parseManifest(path)
+	}
+	if repo := ctx.String("git-repo"); repo != "" {
+		return &Manifest{Entries: []ManifestEntry{
+			{GitRepo: &GitRepoEntry{
+				Path: ctx.String("git-path"),
+				Repo: repo,
+				Ref:  ctx.String("git-ref"),
+			}},
+		}}, nil
+	}
+	return nil, nil
 }
 
 // ── DestroyCommand ──────────────────────────────────────────────────────────

--- a/pkg/sandboxcli/manifest.go
+++ b/pkg/sandboxcli/manifest.go
@@ -1,0 +1,131 @@
+package sandboxcli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"github.com/xiaods/k8e/pkg/sandboxmcp"
+)
+
+// ManifestEntry represents one entry in a workspace manifest.
+type ManifestEntry struct {
+	File    *FileEntry    `yaml:"file,omitempty"`
+	Dir     *DirEntry     `yaml:"dir,omitempty"`
+	GitRepo *GitRepoEntry `yaml:"gitRepo,omitempty"`
+}
+
+// FileEntry declares a file to be written into the sandbox.
+type FileEntry struct {
+	Path    string `yaml:"path"`
+	Content string `yaml:"content"`
+	Mode    string `yaml:"mode,omitempty"` // "0755" etc.
+}
+
+// DirEntry declares a directory to be created.
+type DirEntry struct {
+	Path string `yaml:"path"`
+}
+
+// GitRepoEntry declares a git repository to be cloned.
+type GitRepoEntry struct {
+	Path string `yaml:"path"`
+	Repo string `yaml:"repo"`
+	Ref  string `yaml:"ref,omitempty"` // default: main
+}
+
+// Manifest is the top-level structure of a workspace manifest YAML file.
+type Manifest struct {
+	Entries []ManifestEntry `yaml:"entries"`
+}
+
+// parseManifest reads and parses a manifest YAML file.
+func parseManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	if len(m.Entries) == 0 {
+		return &m, nil
+	}
+	return &m, nil
+}
+
+// materializeManifest applies all entries from a parsed manifest into a sandbox session.
+// On error, returns the 1-based index of the failed entry.
+func materializeManifest(client *sandboxmcp.Client, sid string, m *Manifest) error {
+	if m == nil || len(m.Entries) == 0 {
+		return nil
+	}
+	ctx := context.Background()
+
+	for i, entry := range m.Entries {
+		switch {
+		case entry.File != nil:
+			if err := materializeFile(ctx, client, sid, entry.File); err != nil {
+				return fmt.Errorf("entry %d/%d (file %s): %w", i+1, len(m.Entries), entry.File.Path, err)
+			}
+		case entry.Dir != nil:
+			if err := materializeDir(ctx, client, sid, entry.Dir); err != nil {
+				return fmt.Errorf("entry %d/%d (dir %s): %w", i+1, len(m.Entries), entry.Dir.Path, err)
+			}
+		case entry.GitRepo != nil:
+			if err := materializeGitRepo(ctx, client, sid, entry.GitRepo); err != nil {
+				return fmt.Errorf("entry %d/%d (gitRepo %s): %w", i+1, len(m.Entries), entry.GitRepo.Path, err)
+			}
+		default:
+			return fmt.Errorf("entry %d/%d: no valid type (file, dir, or gitRepo)", i+1, len(m.Entries))
+		}
+		fmt.Fprintf(os.Stderr, "[k8e-sandbox] ✓ %s\n", entryDesc(entry))
+	}
+	return nil
+}
+
+func materializeFile(ctx context.Context, client *sandboxmcp.Client, sid string, f *FileEntry) error {
+	mode := "w"
+	if f.Mode != "" {
+		mode = f.Mode
+	}
+	_, err := client.SandboxServiceClient.WriteFile(ctx, &pb.WriteFileRequest{
+		SessionId: sid, Path: filepath.Join("/workspace", f.Path), Content: f.Content, Mode: mode,
+	})
+	return err
+}
+
+func materializeDir(ctx context.Context, client *sandboxmcp.Client, sid string, d *DirEntry) error {
+	_, err := client.SandboxServiceClient.Exec(ctx, &pb.ExecRequest{
+		SessionId: sid, Command: "mkdir -p " + filepath.Join("/workspace", d.Path), Timeout: 10,
+	})
+	return err
+}
+
+func materializeGitRepo(ctx context.Context, client *sandboxmcp.Client, sid string, g *GitRepoEntry) error {
+	ref := g.Ref
+	if ref == "" {
+		ref = "main"
+	}
+	cmd := fmt.Sprintf("git clone --depth 1 -b %s %s %s", ref, g.Repo, filepath.Join("/workspace", g.Path))
+	_, err := client.SandboxServiceClient.Exec(ctx, &pb.ExecRequest{
+		SessionId: sid, Command: cmd, Timeout: 120,
+	})
+	return err
+}
+
+func entryDesc(e ManifestEntry) string {
+	switch {
+	case e.File != nil:
+		return fmt.Sprintf("file %s", e.File.Path)
+	case e.Dir != nil:
+		return fmt.Sprintf("dir %s/", e.Dir.Path)
+	case e.GitRepo != nil:
+		return fmt.Sprintf("gitRepo %s → %s", e.GitRepo.Repo, e.GitRepo.Path)
+	}
+	return "unknown"
+}

--- a/pkg/sandboxcli/snapshot.go
+++ b/pkg/sandboxcli/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,11 +259,15 @@ func snapshotRestoreCommand() cli.Command {
 				return nil
 			}
 
-			// 6. Write state
-			_ = finalizeState(ctx.String("tenant"), sid)
+			// 6. Write state (inherit tenant from snapshot if not overridden)
+			tenant := ctx.String("tenant")
+			if tenant == "" {
+				tenant = meta.TenantID
+			}
+			_ = finalizeState(tenant, sid)
 
 			printJSON(map[string]any{
-				"session_id": sid, "pod_ip": resp.PodIp, "restored_from": name,
+				"session_id": sid, "pod_ip": resp.PodIp, "tenant_id": tenant, "restored_from": name,
 			})
 			return nil
 		},
@@ -293,6 +296,3 @@ func snapshotDeleteCommand() cli.Command {
 		},
 	}
 }
-
-// suppress unused import warnings
-var _ = io.Discard

--- a/pkg/sandboxcli/snapshot.go
+++ b/pkg/sandboxcli/snapshot.go
@@ -1,0 +1,298 @@
+package sandboxcli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+)
+
+const snapshotsDir = ".k8e/sandbox/snapshots"
+
+// SnapshotMeta holds metadata about a saved snapshot.
+type SnapshotMeta struct {
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+	SessionID string `json:"session_id"`
+	TenantID  string `json:"tenant_id"`
+	SizeBytes int64  `json:"size_bytes"`
+	FileCount int    `json:"file_count"`
+}
+
+func snapshotDir(name string) string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, snapshotsDir, name)
+}
+
+func snapshotMetaPath(name string) string {
+	return filepath.Join(snapshotDir(name), "metadata.json")
+}
+
+func snapshotTarPath(name string) string {
+	return filepath.Join(snapshotDir(name), "workspace.tar.gz")
+}
+
+// ── SnapshotCommand ─────────────────────────────────────────────────────────
+
+func SnapshotCommand() cli.Command {
+	return cli.Command{
+		Name:  "snapshot",
+		Usage: "Save and restore sandbox workspace snapshots",
+		Subcommands: []cli.Command{
+			snapshotSaveCommand(),
+			snapshotListCommand(),
+			snapshotRestoreCommand(),
+			snapshotDeleteCommand(),
+		},
+	}
+}
+
+func snapshotSaveCommand() cli.Command {
+	return cli.Command{
+		Name:      "save",
+		Usage:     "Save the workspace of a session as a named snapshot",
+		ArgsUsage: "<session-id> <name>",
+		Action: func(ctx *cli.Context) error {
+			sid := ctx.Args().Get(0)
+			name := ctx.Args().Get(1)
+			if sid == "" || name == "" {
+				printErrorExit("usage: k8e sandbox snapshot save <session-id> <name>", 1)
+				return nil
+			}
+
+			client := newClient()
+			defer client.Close()
+
+			// 1. Create tar.gz inside sandbox
+			fmt.Fprintf(os.Stderr, "[k8e-sandbox] archiving workspace...\n")
+			_, err := client.SandboxServiceClient.Exec(context.Background(), &pb.ExecRequest{
+				SessionId: sid,
+				Command:   "tar czf /tmp/_snapshot.tar.gz -C /workspace . 2>/dev/null",
+				Timeout:   300,
+			})
+			if err != nil {
+				printErrorExit("archive workspace: "+err.Error(), 1)
+				return nil
+			}
+
+			// 2. Get file count and size
+			countResp, err := client.SandboxServiceClient.Exec(context.Background(), &pb.ExecRequest{
+				SessionId: sid,
+				Command:   "find /workspace -type f | wc -l",
+				Timeout:   30,
+			})
+			fileCount := 0
+			if err == nil {
+				fmt.Sscanf(countResp.Stdout, "%d", &fileCount)
+			}
+
+			// 3. Download tar.gz
+			fmt.Fprintf(os.Stderr, "[k8e-sandbox] downloading snapshot...\n")
+			readResp, err := client.SandboxServiceClient.ReadFile(context.Background(), &pb.ReadFileRequest{
+				SessionId: sid, Path: "/tmp/_snapshot.tar.gz",
+			})
+			if err != nil {
+				printErrorExit("read snapshot: "+err.Error(), 1)
+				return nil
+			}
+
+			// 4. Save to disk
+			dir := snapshotDir(name)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				printErrorExit("create snapshot dir: "+err.Error(), 2)
+				return nil
+			}
+			if err := os.WriteFile(snapshotTarPath(name), []byte(readResp.Content), 0644); err != nil {
+				printErrorExit("write snapshot: "+err.Error(), 2)
+				return nil
+			}
+
+			// 5. Write metadata
+			meta := SnapshotMeta{
+				Name:      name,
+				CreatedAt: time.Now().UTC().Format(time.RFC3339),
+				SessionID: sid,
+				SizeBytes: int64(len(readResp.Content)),
+				FileCount: fileCount,
+			}
+			metaData, _ := json.MarshalIndent(meta, "", "  ")
+			os.WriteFile(snapshotMetaPath(name), metaData, 0644) //nolint:errcheck
+
+			// 6. Cleanup temp file in sandbox
+			client.SandboxServiceClient.Exec(context.Background(), &pb.ExecRequest{
+				SessionId: sid, Command: "rm -f /tmp/_snapshot.tar.gz", Timeout: 10,
+			}) //nolint:errcheck
+
+			printJSON(map[string]any{
+				"ok": true, "name": name,
+				"size_bytes": meta.SizeBytes, "file_count": meta.FileCount,
+			})
+			return nil
+		},
+	}
+}
+
+func snapshotListCommand() cli.Command {
+	return cli.Command{
+		Name:  "list",
+		Usage: "List saved snapshots",
+		Action: func(ctx *cli.Context) error {
+			home, _ := os.UserHomeDir()
+			base := filepath.Join(home, snapshotsDir)
+			entries, err := os.ReadDir(base)
+			if err != nil {
+				if os.IsNotExist(err) {
+					printJSON(map[string]any{"snapshots": []any{}})
+					return nil
+				}
+				printErrorExit("read snapshots dir: "+err.Error(), 2)
+				return nil
+			}
+
+			var snapshots []map[string]any
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				data, err := os.ReadFile(snapshotMetaPath(e.Name()))
+				if err != nil {
+					continue
+				}
+				var meta SnapshotMeta
+				if json.Unmarshal(data, &meta) != nil {
+					continue
+				}
+				snapshots = append(snapshots, map[string]any{
+					"name": meta.Name, "created_at": meta.CreatedAt,
+					"size_bytes": meta.SizeBytes, "file_count": meta.FileCount,
+				})
+			}
+			printJSON(map[string]any{"snapshots": snapshots})
+			return nil
+		},
+	}
+}
+
+func snapshotRestoreCommand() cli.Command {
+	return cli.Command{
+		Name:      "restore",
+		Usage:     "Create a new session from a saved snapshot",
+		ArgsUsage: "<name>",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "runtime", Value: "gvisor", Usage: "Runtime class"},
+			cli.StringFlag{Name: "tenant", EnvVar: "K8E_SANDBOX_TENANT", Usage: "Tenant identifier"},
+			cli.StringFlag{Name: "allowed-hosts", Usage: "Comma-separated FQDN egress allowlist"},
+		},
+		Action: func(ctx *cli.Context) error {
+			name := ctx.Args().First()
+			if name == "" {
+				printErrorExit("usage: k8e sandbox snapshot restore <name>", 1)
+				return nil
+			}
+
+			// 1. Read metadata
+			metaData, err := os.ReadFile(snapshotMetaPath(name))
+			if err != nil {
+				printErrorExit("snapshot not found: "+name, 1)
+				return nil
+			}
+			var meta SnapshotMeta
+			if json.Unmarshal(metaData, &meta) != nil {
+				printErrorExit("snapshot metadata corrupted: "+name, 2)
+				return nil
+			}
+
+			// 2. Read tar.gz
+			tarData, err := os.ReadFile(snapshotTarPath(name))
+			if err != nil {
+				printErrorExit("snapshot data not found: "+name, 2)
+				return nil
+			}
+
+			// 3. Create new session
+			client := newClient()
+			defer client.Close()
+
+			var hosts []string
+			if raw := ctx.String("allowed-hosts"); raw != "" {
+				hosts = strings.Split(raw, ",")
+			}
+
+			resp, err := client.SandboxServiceClient.CreateSession(context.Background(), &pb.CreateSessionRequest{
+				TenantId:     ctx.String("tenant"),
+				RuntimeClass: ctx.String("runtime"),
+				AllowedHosts: hosts,
+			})
+			if err != nil {
+				printErrorExit("create session: "+err.Error(), 2)
+				return nil
+			}
+
+			sid := resp.SessionId
+
+			// 4. Upload tar.gz to sandbox
+			// Use WriteFile for large data (handled by gRPC streaming)
+			_, err = client.SandboxServiceClient.WriteFile(context.Background(), &pb.WriteFileRequest{
+				SessionId: sid, Path: "/tmp/_snapshot.tar.gz", Content: string(tarData), Mode: "w",
+			})
+			if err != nil {
+				client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+				printErrorExit("upload snapshot: "+err.Error(), 2)
+				return nil
+			}
+
+			// 5. Extract
+			_, err = client.SandboxServiceClient.Exec(context.Background(), &pb.ExecRequest{
+				SessionId: sid,
+				Command:   "tar xzf /tmp/_snapshot.tar.gz -C /workspace && rm -f /tmp/_snapshot.tar.gz",
+				Timeout:   120,
+			})
+			if err != nil {
+				client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+				printErrorExit("extract snapshot: "+err.Error(), 1)
+				return nil
+			}
+
+			// 6. Write state
+			_ = finalizeState(ctx.String("tenant"), sid)
+
+			printJSON(map[string]any{
+				"session_id": sid, "pod_ip": resp.PodIp, "restored_from": name,
+			})
+			return nil
+		},
+	}
+}
+
+func snapshotDeleteCommand() cli.Command {
+	return cli.Command{
+		Name:      "delete",
+		Usage:     "Delete a saved snapshot",
+		ArgsUsage: "<name>",
+		Action: func(ctx *cli.Context) error {
+			name := ctx.Args().First()
+			if name == "" {
+				printErrorExit("usage: k8e sandbox snapshot delete <name>", 1)
+				return nil
+			}
+
+			dir := snapshotDir(name)
+			if err := os.RemoveAll(dir); err != nil {
+				printErrorExit("delete snapshot: "+err.Error(), 2)
+				return nil
+			}
+			printJSON(map[string]any{"ok": true})
+			return nil
+		},
+	}
+}
+
+// suppress unused import warnings
+var _ = io.Discard

--- a/pkg/sandboxmcp/client.go
+++ b/pkg/sandboxmcp/client.go
@@ -1,4 +1,4 @@
-// Package sandboxmcp implements the K8E Sandbox MCP server.
+// Package sandboxmcp provides the gRPC client for K8E sandbox operations.
 package sandboxmcp
 
 import (


### PR DESCRIPTION
- restore now defaults to the snapshot's original tenant_id
    - output includes tenant_id field
    - remove unused io import