### PR TITLE
feat: add TypeScript runtime support to sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ __pycache__
 zig-out
 .claude/*
 server
+sandbox-cli

--- a/build.zig
+++ b/build.zig
@@ -293,6 +293,7 @@ pub fn build(b: *std.Build) !void {
     all_step.dependOn(runc_step);
     all_step.dependOn(cni_step);
     all_step.dependOn(sandboxd_step);
+    try addSandboxCLIBuild(b, all_step);
     // hcsshim is Windows-only; only include on Windows hosts
     if (builtin.os.tag == .windows) {
         all_step.dependOn(hcsshim_step);
@@ -364,6 +365,35 @@ fn buildVersionFlags(allocator: std.mem.Allocator, v: VersionInfo) ![]const u8 {
         try xflag(allocator, PKG_ETCD ++ "/api/v3/version.GitSHA", "HEAD"),
     };
     return std.mem.join(allocator, " ", &parts);
+}
+
+fn addSandboxCLIBuild(b: *std.Build, all_step: *std.Build.Step) !void {
+    const cli_step = b.step("sandbox-cli", "Build cross-platform sandbox CLI binary");
+    const cli_targets = [_]struct { goos: []const u8, goarch: []const u8, ext: []const u8 }{
+        .{ .goos = "linux", .goarch = "amd64", .ext = "" },
+        .{ .goos = "linux", .goarch = "arm64", .ext = "" },
+        .{ .goos = "darwin", .goarch = "amd64", .ext = "" },
+        .{ .goos = "darwin", .goarch = "arm64", .ext = "" },
+        .{ .goos = "windows", .goarch = "amd64", .ext = ".exe" },
+    };
+
+    for (cli_targets) |t| {
+        const out_name = b.fmt("bin/k8e-{s}-{s}{s}", .{ t.goos, t.goarch, t.ext });
+        const out_path = b.getInstallPath(.bin, out_name);
+
+        const go_build = b.addSystemCommand(&[_][]const u8{
+            "go", "build",
+            "-ldflags", "-s -w",
+            "-o", out_path,
+            "./cmd/sandbox-cli/",
+        });
+        go_build.setEnvironmentVariable("GOOS", t.goos);
+        go_build.setEnvironmentVariable("GOARCH", t.goarch);
+        go_build.setEnvironmentVariable("CGO_ENABLED", "0");
+        cli_step.dependOn(&go_build.step);
+    }
+
+    all_step.dependOn(cli_step);
 }
 
 fn findBash() []const u8 {

--- a/cmd/sandbox-cli/main.go
+++ b/cmd/sandbox-cli/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"github.com/xiaods/k8e/pkg/cli/cmds"
+	"github.com/xiaods/k8e/pkg/version"
+)
+
+func main() {
+	app := cmds.NewApp()
+	app.Name = version.Program
+	app.Usage = "K8E sandbox CLI — connect to any K8E cluster"
+	app.Version = version.Version
+	app.HideVersion = false
+	app.Commands = []cli.Command{
+		cmds.NewSandboxCommand(),
+	}
+	app.Flags = nil // no data-dir flag needed for sandbox CLI
+
+	if err := app.Run(os.Args); err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/pkg/cli/cmds/sandbox.go
+++ b/pkg/cli/cmds/sandbox.go
@@ -9,6 +9,11 @@ func NewSandboxCommand() cli.Command {
 	return cli.Command{
 		Name:  "sandbox",
 		Usage: "Manage K8E sandbox sessions — run code in isolated environments",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "endpoint", EnvVar: "K8E_SANDBOX_ENDPOINT", Usage: "gRPC endpoint (default: 127.0.0.1:50051)"},
+			cli.StringFlag{Name: "apikey", EnvVar: "K8E_SANDBOX_APIKEY", Usage: "API key for remote cluster authentication"},
+			cli.BoolFlag{Name: "debug", EnvVar: "K8E_SANDBOX_DEBUG", Usage: "Enable debug logging"},
+		},
 		Subcommands: []cli.Command{
 			sandboxcli.RunCommand(),
 			sandboxcli.StatusCommand(),
@@ -21,6 +26,7 @@ func NewSandboxCommand() cli.Command {
 			sandboxcli.ConfirmCommand(),
 			sandboxcli.ApproveCommand(),
 			sandboxcli.SnapshotCommand(),
+			sandboxcli.InstallSkillCommand(),
 		},
 	}
 }

--- a/pkg/cli/cmds/sandbox.go
+++ b/pkg/cli/cmds/sandbox.go
@@ -26,6 +26,7 @@ func NewSandboxCommand() cli.Command {
 			sandboxcli.ConfirmCommand(),
 			sandboxcli.ApproveCommand(),
 			sandboxcli.SnapshotCommand(),
+			sandboxcli.ApiKeyCommand(),
 			sandboxcli.InstallSkillCommand(),
 		},
 	}

--- a/pkg/sandboxcli/apikey.go
+++ b/pkg/sandboxcli/apikey.go
@@ -1,0 +1,182 @@
+package sandboxcli
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const apiKeySecretName = "sandbox-api-keys"
+const apiKeySecretNS = "sandbox-matrix"
+
+type apiKeyStore map[string]string // name → key
+
+func readAPIKeys() (apiKeyStore, error) {
+	k8s, err := newK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig required for api-key management: %w", err)
+	}
+	secret, err := k8s.CoreV1().Secrets(apiKeySecretNS).Get(context.Background(), apiKeySecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("api-key secret not found (run 'k8e sandbox api-key init' on the server node)")
+	}
+	data, ok := secret.Data["keys.json"]
+	if !ok {
+		return nil, fmt.Errorf("api-key secret corrupted: missing keys.json")
+	}
+	var store apiKeyStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("api-key secret corrupted: %w", err)
+	}
+	if store == nil {
+		store = make(apiKeyStore)
+	}
+	return store, nil
+}
+
+func writeAPIKeys(store apiKeyStore) error {
+	k8s, err := newK8sClient()
+	if err != nil {
+		return err
+	}
+	data, _ := json.Marshal(store)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: apiKeySecretName, Namespace: apiKeySecretNS},
+		Data:       map[string][]byte{"keys.json": data},
+	}
+	// try update first, create if not found
+	_, err = k8s.CoreV1().Secrets(apiKeySecretNS).Update(context.Background(), secret, metav1.UpdateOptions{})
+	if err != nil {
+		_, err = k8s.CoreV1().Secrets(apiKeySecretNS).Create(context.Background(), secret, metav1.CreateOptions{})
+	}
+	return err
+}
+
+func generateAPIKey() string {
+	b := make([]byte, 32)
+	rand.Read(b) //nolint:errcheck
+	return "k8e-" + hex.EncodeToString(b)
+}
+
+func newK8sClient() (kubernetes.Interface, error) {
+	kc := os.Getenv("KUBECONFIG")
+	if kc == "" {
+		if home, _ := os.UserHomeDir(); home != "" {
+			kc = home + "/.kube/config"
+		}
+	}
+	if kc == "" {
+		kc = "/etc/k8e/k8e.yaml"
+	}
+	cfg, err := clientcmd.BuildConfigFromFlags("", kc)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+// ── ApiKeyCommand ──────────────────────────────────────────────────────────
+
+func ApiKeyCommand() cli.Command {
+	return cli.Command{
+		Name:  "api-key",
+		Usage: "Manage sandbox API keys for remote cluster access",
+		Subcommands: []cli.Command{
+			apiKeyCreateCommand(),
+			apiKeyListCommand(),
+			apiKeyDeleteCommand(),
+		},
+	}
+}
+
+func apiKeyCreateCommand() cli.Command {
+	return cli.Command{
+		Name:      "create",
+		Usage:     "Create a new API key",
+		ArgsUsage: "<name>",
+		Action: func(ctx *cli.Context) error {
+			name := ctx.Args().First()
+			if name == "" {
+				printErrorExit("usage: k8e sandbox api-key create <name>", 1)
+				return nil
+			}
+			store, err := readAPIKeys()
+			if err != nil {
+				printErrorExit(err.Error(), 1)
+				return nil
+			}
+			if _, exists := store[name]; exists {
+				printErrorExit("api-key '"+name+"' already exists", 1)
+				return nil
+			}
+			key := generateAPIKey()
+			store[name] = key
+			if err := writeAPIKeys(store); err != nil {
+				printErrorExit("write api-key: "+err.Error(), 2)
+				return nil
+			}
+			printJSON(map[string]any{"name": name, "key": key})
+			return nil
+		},
+	}
+}
+
+func apiKeyListCommand() cli.Command {
+	return cli.Command{
+		Name:  "list",
+		Usage: "List API keys (names only, keys are not shown)",
+		Action: func(ctx *cli.Context) error {
+			store, err := readAPIKeys()
+			if err != nil {
+				printErrorExit(err.Error(), 1)
+				return nil
+			}
+			names := make([]string, 0, len(store))
+			for k := range store {
+				names = append(names, k)
+			}
+			printJSON(map[string]any{"keys": names})
+			return nil
+		},
+	}
+}
+
+func apiKeyDeleteCommand() cli.Command {
+	return cli.Command{
+		Name:      "delete",
+		Usage:     "Delete an API key",
+		ArgsUsage: "<name>",
+		Action: func(ctx *cli.Context) error {
+			name := ctx.Args().First()
+			if name == "" {
+				printErrorExit("usage: k8e sandbox api-key delete <name>", 1)
+				return nil
+			}
+			store, err := readAPIKeys()
+			if err != nil {
+				printErrorExit(err.Error(), 1)
+				return nil
+			}
+			if _, exists := store[name]; !exists {
+				printErrorExit("api-key '"+name+"' not found", 1)
+				return nil
+			}
+			delete(store, name)
+			if err := writeAPIKeys(store); err != nil {
+				printErrorExit("write api-key: "+err.Error(), 2)
+				return nil
+			}
+			printJSON(map[string]any{"ok": true, "name": name})
+			return nil
+		},
+	}
+}

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -16,8 +16,38 @@ import (
 
 // newClient wraps sandboxmcp.NewClient with fatal error handling.
 // On connection failure, prints JSON error and exits with code 2.
+// Supports --endpoint and --apikey from parent sandbox command for remote clusters.
 func newClient() *sandboxmcp.Client {
 	c, err := sandboxmcp.NewClient()
+	if err != nil {
+		printErrorExit("sandbox not reachable: "+err.Error(), 2)
+	}
+	return c
+}
+
+// newClientFromCtx creates a gRPC client using endpoint/apikey from parent sandbox command flags.
+func newClientFromCtx(ctx *cli.Context) *sandboxmcp.Client {
+	endpoint := ""
+	apikey := ""
+	if parent := ctx.Parent(); parent != nil {
+		endpoint = parent.String("endpoint")
+		apikey = parent.String("apikey")
+	}
+	// fallback to env vars if parent not available
+	if endpoint == "" {
+		endpoint = os.Getenv("K8E_SANDBOX_ENDPOINT")
+	}
+	if apikey == "" {
+		apikey = os.Getenv("K8E_SANDBOX_APIKEY")
+	}
+
+	var c *sandboxmcp.Client
+	var err error
+	if endpoint != "" {
+		c, err = sandboxmcp.NewClientWithEndpoint(endpoint, apikey)
+	} else {
+		c, err = sandboxmcp.NewClient()
+	}
 	if err != nil {
 		printErrorExit("sandbox not reachable: "+err.Error(), 2)
 	}
@@ -154,7 +184,7 @@ func RunCommand() cli.Command {
 			lang := ctx.String("lang")
 			raw := ctx.Bool("raw")
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			sid, needsFinalize, err := ensureSession(client, ctx)
@@ -230,7 +260,7 @@ func StatusCommand() cli.Command {
 		Name:  "status",
 		Usage: "Check sandbox service availability and current session",
 		Action: func(ctx *cli.Context) error {
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			// lightweight probe
@@ -273,7 +303,7 @@ func CreateCommand() cli.Command {
 			cli.StringFlag{Name: "git-path", Value: "repo", Usage: "Destination path for --git-repo"},
 		},
 		Action: func(ctx *cli.Context) error {
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			var hosts []string
@@ -354,7 +384,7 @@ func DestroyCommand() cli.Command {
 				printErrorExit("session-id required", 1)
 				return nil
 			}
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			resp, err := client.SandboxServiceClient.DestroySession(context.Background(),
@@ -403,7 +433,7 @@ func WriteCommand() cli.Command {
 				return nil
 			}
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			resp, err := client.SandboxServiceClient.WriteFile(context.Background(), &pb.WriteFileRequest{
@@ -437,7 +467,7 @@ func ReadCommand() cli.Command {
 				return nil
 			}
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			resp, err := client.SandboxServiceClient.ReadFile(context.Background(), &pb.ReadFileRequest{
@@ -474,7 +504,7 @@ func ListCommand() cli.Command {
 				return nil
 			}
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			resp, err := client.SandboxServiceClient.ListFiles(context.Background(), &pb.ListFilesRequest{
@@ -508,7 +538,7 @@ func SubagentCommand() cli.Command {
 				return nil
 			}
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			resp, err := client.SandboxServiceClient.RunSubAgent(context.Background(), &pb.RunSubAgentRequest{
@@ -543,7 +573,7 @@ func ConfirmCommand() cli.Command {
 				return nil
 			}
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			// Phase 1: register
@@ -601,7 +631,7 @@ func ApproveCommand() cli.Command {
 			}
 			approved := !ctx.Bool("reject")
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			resp, err := client.SandboxServiceClient.ApproveAction(context.Background(), &pb.ApproveActionRequest{
@@ -620,4 +650,24 @@ func ApproveCommand() cli.Command {
 // timeDuration converts seconds to time.Duration.
 func timeDuration(seconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
+}
+
+// ── InstallSkillCommand ────────────────────────────────────────────────────
+
+func InstallSkillCommand() cli.Command {
+	return cli.Command{
+		Name:      "install-skill",
+		Usage:     "Install K8E sandbox skill into AI agent config",
+		ArgsUsage: "[claude|kiro|gemini|openclaw|all]",
+		Action: func(ctx *cli.Context) error {
+			target := ctx.Args().First()
+			if target == "" {
+				target = "all"
+			}
+			if err := sandboxmcp.InstallSkill(target); err != nil {
+				printErrorExit(err.Error(), 1)
+			}
+			return nil
+		},
+	}
 }

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -14,17 +14,6 @@ import (
 	"github.com/xiaods/k8e/pkg/sandboxmcp"
 )
 
-// newClient wraps sandboxmcp.NewClient with fatal error handling.
-// On connection failure, prints JSON error and exits with code 2.
-// Supports --endpoint and --apikey from parent sandbox command for remote clusters.
-func newClient() *sandboxmcp.Client {
-	c, err := sandboxmcp.NewClient()
-	if err != nil {
-		printErrorExit("sandbox not reachable: "+err.Error(), 2)
-	}
-	return c
-}
-
 // newClientFromCtx creates a gRPC client using endpoint/apikey from parent sandbox command flags.
 func newClientFromCtx(ctx *cli.Context) *sandboxmcp.Client {
 	endpoint := ""

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -82,14 +82,14 @@ func ensureSession(client *sandboxmcp.Client, ctx *cli.Context) (string, bool, e
 // isInterpretedLang returns true for languages that need shell wrapping.
 func isInterpretedLang(lang string) bool {
 	switch strings.ToLower(lang) {
-	case "python", "python3", "py", "node", "nodejs", "js", "javascript":
+	case "python", "python3", "py", "node", "nodejs", "js", "javascript", "ts", "typescript":
 		return true
 	}
 	return false
 }
 
 // buildCommand wraps code for a given language.
-// bash: pass through as-is. python/node: single-line uses -c, multi-line uses temp file.
+// bash: pass through as-is. python/node/ts: single-line uses -c/-e, multi-line uses temp file.
 func buildCommand(lang, code string) string {
 	switch strings.ToLower(lang) {
 	case "python", "python3", "py":
@@ -102,6 +102,11 @@ func buildCommand(lang, code string) string {
 			return "node /tmp/_k8e_run.js"
 		}
 		return fmt.Sprintf("node -e %q", code)
+	case "ts", "typescript":
+		if isMultiLine(code) {
+			return "tsx /tmp/_k8e_run.ts"
+		}
+		return fmt.Sprintf("tsx -e %q", code)
 	default: // bash / sh
 		return code
 	}
@@ -113,6 +118,8 @@ func writeCodeFile(client *sandboxmcp.Client, sid, lang, code string) error {
 	switch strings.ToLower(lang) {
 	case "node", "nodejs", "js", "javascript":
 		path = "/tmp/_k8e_run.js"
+	case "ts", "typescript":
+		path = "/tmp/_k8e_run.ts"
 	}
 	_, err := client.SandboxServiceClient.WriteFile(context.Background(), &pb.WriteFileRequest{
 		SessionId: sid, Path: path, Content: code, Mode: "w",
@@ -128,7 +135,7 @@ func RunCommand() cli.Command {
 		Usage:     "Run code or a shell command in a sandbox. Auto-creates session if needed.",
 		ArgsUsage: "<code>",
 		Flags: []cli.Flag{
-			cli.StringFlag{Name: "lang", Value: "bash", Usage: "Language hint: python, bash (default), node"},
+			cli.StringFlag{Name: "lang", Value: "bash", Usage: "Language hint: python, bash (default), node, ts"},
 			cli.IntFlag{Name: "timeout", Value: 30, Usage: "Timeout in seconds"},
 			cli.StringFlag{Name: "session-id", EnvVar: "K8E_SANDBOX_SESSION_ID", Usage: "Explicit session ID"},
 			cli.StringFlag{Name: "tenant", EnvVar: "K8E_SANDBOX_TENANT", Usage: "Tenant for cross-process session reuse"},

--- a/pkg/sandboxcli/snapshot.go
+++ b/pkg/sandboxcli/snapshot.go
@@ -66,7 +66,7 @@ func snapshotSaveCommand() cli.Command {
 				return nil
 			}
 
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			// 1. Create tar.gz inside sandbox
@@ -216,7 +216,7 @@ func snapshotRestoreCommand() cli.Command {
 			}
 
 			// 3. Create new session
-			client := newClient()
+			client := newClientFromCtx(ctx)
 			defer client.Close()
 
 			var hosts []string

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -16,12 +17,16 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
+
+const apiKeySecretNS = "sandbox-matrix"
+const apiKeySecretName = "sandbox-api-keys"
 
 const sandboxdPort = 2024
 
@@ -40,6 +45,7 @@ type Server struct {
 	lisAddr  string
 	certFile string
 	keyFile  string
+	apiKeys  map[string]string // name → key for validation
 }
 
 func NewServer(k8s kubernetes.Interface, dyn dynamic.Interface, certFile, keyFile string, grpcPort int) *Server {
@@ -57,17 +63,46 @@ func NewServer(k8s kubernetes.Interface, dyn dynamic.Interface, certFile, keyFil
 	return s
 }
 
+// loadAPIKeys reads API keys from the sandbox-api-keys Secret.
+func (s *Server) loadAPIKeys(ctx context.Context) {
+	secret, err := s.k8s.CoreV1().Secrets(apiKeySecretNS).Get(ctx, apiKeySecretName, metav1.GetOptions{})
+	if err != nil {
+		logrus.Debugf("sandbox gRPC: no api-key secret found, all requests allowed")
+		return
+	}
+	data, ok := secret.Data["keys.json"]
+	if !ok {
+		return
+	}
+	var store map[string]string
+	if err := json.Unmarshal(data, &store); err != nil {
+		logrus.Warnf("sandbox gRPC: api-key secret corrupted: %v", err)
+		return
+	}
+	s.apiKeys = store
+	logrus.Infof("sandbox gRPC: loaded %d API key(s)", len(store))
+}
+
 // Start registers the gRPC server and begins listening on lisAddr (default 0.0.0.0:50051).
 func (s *Server) Start(ctx context.Context) error {
 	lis, err := net.Listen("tcp", s.lisAddr)
 	if err != nil {
 		return fmt.Errorf("grpc listen: %w", err)
 	}
+
+	// Load API keys from Secret for remote client authentication
+	s.loadAPIKeys(ctx)
+
 	creds, err := credentials.NewServerTLSFromFile(s.certFile, s.keyFile)
 	if err != nil {
 		return fmt.Errorf("grpc tls credentials: %w", err)
 	}
-	gs := grpc.NewServer(grpc.Creds(creds))
+
+	opts := []grpc.ServerOption{grpc.Creds(creds)}
+	if len(s.apiKeys) > 0 {
+		opts = append(opts, grpc.UnaryInterceptor(s.apiKeyInterceptor))
+	}
+	gs := grpc.NewServer(opts...)
 	pb.RegisterSandboxServiceServer(gs, s)
 	logrus.Infof("sandbox gRPC gateway listening on %s", s.lisAddr)
 	go func() {
@@ -280,4 +315,26 @@ func (s *Server) getPodIP(ctx context.Context, sessionID string) (string, error)
 		}
 	}
 	return "", status.Errorf(codes.Unavailable, "session %s has no pod IP after 60s", sessionID)
+}
+
+// apiKeyInterceptor validates the authorization header against known API keys.
+func (s *Server) apiKeyInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "missing metadata")
+	}
+	auth := md.Get("authorization")
+	if len(auth) == 0 {
+		return nil, status.Error(codes.Unauthenticated, "missing authorization header")
+	}
+	token := strings.TrimPrefix(auth[0], "Bearer ")
+	if token == auth[0] {
+		return nil, status.Error(codes.Unauthenticated, "invalid authorization format, expected 'Bearer <key>'")
+	}
+	for _, key := range s.apiKeys {
+		if key == token {
+			return handler(ctx, req)
+		}
+	}
+	return nil, status.Error(codes.Unauthenticated, "invalid api key")
 }

--- a/pkg/sandboxmcp/client.go
+++ b/pkg/sandboxmcp/client.go
@@ -14,6 +14,8 @@ import (
 	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -64,6 +66,26 @@ func NewClient() (*Client, error) {
 	}
 
 	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, fmt.Errorf("sandbox mcp: dial %s: %w", endpoint, err)
+	}
+	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
+}
+
+// NewClientWithEndpoint connects to a remote K8E cluster at endpoint with optional API key.
+// When apiKey is set, uses insecure transport + per-RPC metadata authentication.
+// When apiKey is empty, falls back to TLS auto-discovery.
+func NewClientWithEndpoint(endpoint, apiKey string) (*Client, error) {
+	if apiKey == "" {
+		return NewClient()
+	}
+	// Remote cluster with API key: insecure connection + metadata auth interceptor
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	opts = append(opts, grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+apiKey)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}))
+	conn, err := grpc.NewClient(endpoint, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("sandbox mcp: dial %s: %w", endpoint, err)
 	}

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -25,6 +25,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# TypeScript runtime: tsx for direct execution, typescript for tsc compilation
+RUN npm install -g tsx typescript
+
 # Upgrade pip
 RUN pip install --no-cache-dir --upgrade pip
 

--- a/skills/k8e-sandbox/SKILL.md
+++ b/skills/k8e-sandbox/SKILL.md
@@ -43,7 +43,7 @@ k8e sandbox status
 
 ```bash
 k8e sandbox run <code>
-  [--lang python|bash|node]   # default: bash
+  [--lang python|bash|node|ts]   # default: bash
   [--session-id <id>]         # specify session explicitly (skips auto-creation)
   [--tenant <id>]             # tenant for cross-process session reuse
   [--timeout 30]              # timeout in seconds


### PR DESCRIPTION
- Dockerfile: install tsx + typescript globally
- commands.go: add --lang ts/typescript to buildCommand + writeCodeFile
- commands.go: update --lang flag help text
- SKILL.md: document --lang ts

Agent usage:
  k8e sandbox run 'console.log(42)' --lang ts       # single-line
  k8e sandbox run --lang ts <<'EOF'                  # multi-line
  interface Foo { bar: string }
  const x: Foo = { bar: 'hello' }
  console.log(x.bar)
EOF