### PR TITLE
fix: remove arm64 k8e server matrix, fix go generate cross-arch exec …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ── K8E server binary: linux/amd64 + arm64 ────────────────────────────
+  # ── K8E server binary: linux/amd64 ───────────────────────────────────
   build-k8e:
-    name: Build k8e (${{ matrix.arch }})
+    name: Build k8e
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
     env:
       GOOS: linux
-      GOARCH: ${{ matrix.arch }}
+      GOARCH: amd64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -32,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config build-essential libc6-dev zlib1g-dev libseccomp-dev gcc-aarch64-linux-gnu
+          sudo apt-get install -y pkg-config build-essential libc6-dev zlib1g-dev libseccomp-dev
       - name: Generate resources
         run: |
           mkdir -p build/data build/static
@@ -44,23 +41,18 @@ jobs:
       - name: Package CLI (data tarball)
         run: make package-cli
       - name: Package airgap image
-        if: matrix.arch == 'amd64'
         run: make package-airgap
       - name: Rename artifacts
         run: |
           mkdir -p release-artifacts
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            cp dist/artifacts/k8e-arm64 release-artifacts/k8e-arm64
-          else
-            cp dist/artifacts/k8e release-artifacts/k8e
-          fi
+          cp dist/artifacts/k8e release-artifacts/k8e
           if [ -f dist/artifacts/k8e-airgap-images.tar.gz ]; then
             cp dist/artifacts/k8e-airgap-images.tar.gz release-artifacts/
           fi
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:
-          name: k8e-${{ matrix.arch }}
+          name: k8e
           path: release-artifacts/
 
   # ── Sandbox CLI: cross-platform binaries ──────────────────────────────
@@ -171,7 +163,6 @@ jobs:
         with:
           files: |
             release-artifacts/k8e
-            release-artifacts/k8e-arm64
             release-artifacts/k8e-airgap-images.tar.gz
             release-artifacts/k8e-linux-amd64
             release-artifacts/k8e-linux-arm64


### PR DESCRIPTION
…error

Root cause: GOARCH=arm64 in job env caused go generate's go run to build arm64 binaries that can't execute on amd64 runner.

Fix:
- k8e server: single amd64 build (CGO=1 cross-compile for arm64 is complex)
- sandbox-cli: full cross-platform matrix (CGO=0 works natively)
- Generate step: runs with native GOARCH only
- Removed gcc-aarch64-linux-gnu (not needed for amd64-only k8e build)