### PR TITLE
refactor: rename sandbox-cli binaries to k8e-sandbox-cli-{platform}

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,12 +92,12 @@ jobs:
         run: |
           EXT=""
           if [ "${{ matrix.goos }}" = "windows" ]; then EXT=".exe"; fi
-          go build -ldflags="-s -w" -o "k8e-${{ matrix.target }}${EXT}" ./cmd/sandbox-cli/
+          go build -ldflags="-s -w" -o "k8e-sandbox-cli-${{ matrix.target }}${EXT}" ./cmd/sandbox-cli/
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:
           name: sandbox-cli-${{ matrix.target }}
-          path: k8e-${{ matrix.target }}*
+          path: k8e-sandbox-cli-${{ matrix.target }}*
 
   # ── Sandbox container image ───────────────────────────────────────────
   build-sandbox-image:
@@ -164,10 +164,10 @@ jobs:
           files: |
             release-artifacts/k8e
             release-artifacts/k8e-airgap-images.tar.gz
-            release-artifacts/k8e-linux-amd64
-            release-artifacts/k8e-linux-arm64
-            release-artifacts/k8e-darwin-amd64
-            release-artifacts/k8e-darwin-arm64
-            release-artifacts/k8e-windows-amd64.exe
+            release-artifacts/k8e-sandbox-cli-linux-amd64
+            release-artifacts/k8e-sandbox-cli-linux-arm64
+            release-artifacts/k8e-sandbox-cli-darwin-amd64
+            release-artifacts/k8e-sandbox-cli-darwin-arm64
+            release-artifacts/k8e-sandbox-cli-windows-amd64.exe
             release-artifacts/SHA256SUMS
           fail_on_unmatched_files: false

--- a/build.zig
+++ b/build.zig
@@ -378,7 +378,7 @@ fn addSandboxCLIBuild(b: *std.Build, all_step: *std.Build.Step) !void {
     };
 
     for (cli_targets) |t| {
-        const out_name = b.fmt("bin/k8e-{s}-{s}{s}", .{ t.goos, t.goarch, t.ext });
+        const out_name = b.fmt("bin/k8e-sandbox-cli-{s}-{s}{s}", .{ t.goos, t.goarch, t.ext });
         const out_path = b.getInstallPath(.bin, out_name);
 
         const go_build = b.addSystemCommand(&[_][]const u8{


### PR DESCRIPTION
Clear distinction from k8e server binary:
  k8e                       ← server binary (linux/amd64)
  k8e-sandbox-cli-linux-amd64
  k8e-sandbox-cli-linux-arm64
  k8e-sandbox-cli-darwin-amd64
  k8e-sandbox-cli-darwin-arm64
  k8e-sandbox-cli-windows-amd64.exe

Updated: release.yml, build.zig