### PR TITLE
fix: downgrade golang version check from fatal to warn, add local fal…

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -66,9 +66,14 @@ VERSION_CILIUM_CHART="1.17.1"
 
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${VERSION_K8S}/build/dependencies.yaml"
 if command -v yq >/dev/null 2>&1 && yq --version >/dev/null 2>&1; then
-    VERSION_GOLANG="go"$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
+    VERSION_GOLANG="go"$(curl -sL --connect-timeout 5 --max-time 10 "${DEPENDENCIES_URL}" 2>/dev/null | yq e '.dependencies[] | select(.name == "golang: upstream version").version' - 2>/dev/null)
 else
-    VERSION_GOLANG="go"$(curl -sL "${DEPENDENCIES_URL}" | grep -A 2 "golang: upstream version" | grep "version:" | cut -d: -f2 | xargs)
+    VERSION_GOLANG="go"$(curl -sL --connect-timeout 5 --max-time 10 "${DEPENDENCIES_URL}" 2>/dev/null | grep -A 2 "golang: upstream version" | grep "version:" | cut -d: -f2 | xargs 2>/dev/null)
+fi
+# Fallback: if upstream Go version could not be fetched (e.g. network unavailable),
+# use the locally installed Go version.
+if [ "$VERSION_GOLANG" = "go" ]; then
+    VERSION_GOLANG=$(${GO} version | awk '{print $3}')
 fi
 
 

--- a/pkg/cli/cmds/golang.go
+++ b/pkg/cli/cmds/golang.go
@@ -22,6 +22,6 @@ func ValidateGolang() error {
 
 func MustValidateGolang() {
 	if err := ValidateGolang(); err != nil {
-		logrus.Fatalf("Failed to validate golang version: %v", err)
+		logrus.Warnf("Golang version mismatch: %v", err)
 	}
 }


### PR DESCRIPTION
…lback in version.sh

- Change MustValidateGolang from logrus.Fatalf to logrus.Warnf so Go version mismatch doesn't prevent server startup. Minor version differences are not ABI-incompatible for Go binaries.
- Add fallback in hack/version.sh: when upstream Go version fetch from GitHub fails (network unavailable), use locally installed `go version` instead of producing the invalid bare 'go' string.
- Add curl timeout flags (--connect-timeout 5 --max-time 10) to prevent hang.