### PR TITLE
fix: use int64 for duration fields in etcd YAML config, remove dead e…

### DIFF
--- a/pkg/daemons/executor/etcd.go
+++ b/pkg/daemons/executor/etcd.go
@@ -1,58 +1,11 @@
 package executor
 
 import (
-	"context"
-	"errors"
-	"os"
-	"path/filepath"
-
 	daemonconfig "github.com/xiaods/k8e/pkg/daemons/config"
-	"github.com/xiaods/k8e/pkg/version"
-	"github.com/sirupsen/logrus"
-	"go.etcd.io/etcd/server/v3/embed"
-	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
 )
 
+// Embedded is the embedded executor implementation that runs all Kubernetes
+// components in-process. It is registered via init() in embed.go.
 type Embedded struct {
 	nodeConfig *daemonconfig.Node
-}
-
-func (e *Embedded) ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error {
-	configFile, err := args.ToConfigFile(extraArgs)
-	if err != nil {
-		return err
-	}
-	cfg, err := embed.ConfigFromFile(configFile)
-	if err != nil {
-		return err
-	}
-
-	etcd, err := embed.StartEtcd(cfg)
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		select {
-		case err := <-etcd.Server.ErrNotify():
-			if errors.Is(err, rafthttp.ErrMemberRemoved) {
-				tombstoneFile := filepath.Join(args.DataDir, "tombstone")
-				if err := os.WriteFile(tombstoneFile, []byte{}, 0600); err != nil {
-					logrus.Fatalf("Failed to write tombstone file to %s: %v", tombstoneFile, err)
-				}
-				etcd.Close()
-				logrus.Infof("This node has been removed from the cluster - please restart %s to rejoin the cluster", version.Program)
-				return
-			}
-			logrus.Errorf("etcd error: %v", err)
-		case <-ctx.Done():
-			logrus.Infof("stopping etcd")
-			etcd.Close()
-		case <-etcd.Server.StopNotify():
-			logrus.Fatalf("etcd stopped")
-		case err := <-etcd.Err():
-			logrus.Fatalf("etcd exited: %v", err)
-		}
-	}()
-	return nil
 }

--- a/pkg/daemons/executor/executor.go
+++ b/pkg/daemons/executor/executor.go
@@ -3,17 +3,10 @@ package executor
 import (
 	"context"
 	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/xiaods/k8e/pkg/cli/cmds"
 	daemonconfig "github.com/xiaods/k8e/pkg/daemons/config"
-	yaml2 "gopkg.in/yaml.v2"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
-	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -28,105 +21,15 @@ type Executor interface {
 	Scheduler(ctx context.Context, apiReady <-chan struct{}, args []string) error
 	ControllerManager(ctx context.Context, apiReady <-chan struct{}, args []string) error
 	CurrentETCDOptions() (InitialOptions, error)
-	ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error
 	CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error
 	Containerd(ctx context.Context, node *daemonconfig.Node) error
 	Docker(ctx context.Context, node *daemonconfig.Node) error
-}
-
-type ETCDConfig struct {
-	InitialOptions       `json:",inline"`
-	Name                 string      `json:"name,omitempty"`
-	ListenClientURLs     string      `json:"listen-client-urls,omitempty"`
-	ListenClientHTTPURLs string      `json:"listen-client-http-urls,omitempty"`
-	ListenMetricsURLs    string      `json:"listen-metrics-urls,omitempty"`
-	ListenPeerURLs       string      `json:"listen-peer-urls,omitempty"`
-	AdvertiseClientURLs  string      `json:"advertise-client-urls,omitempty"`
-	DataDir              string      `json:"data-dir,omitempty"`
-	SnapshotCount        int         `json:"snapshot-count,omitempty"`
-	ServerTrust          ServerTrust `json:"client-transport-security"`
-	PeerTrust            PeerTrust   `json:"peer-transport-security"`
-	ForceNewCluster      bool        `json:"force-new-cluster,omitempty"`
-	HeartbeatInterval    int         `json:"heartbeat-interval"`
-	ElectionTimeout      int         `json:"election-timeout"`
-	Logger               string      `json:"logger"`
-	LogOutputs           []string    `json:"log-outputs"`
-
-	ExperimentalInitialCorruptCheck         bool          `json:"experimental-initial-corrupt-check"`
-	ExperimentalWatchProgressNotifyInterval time.Duration `json:"experimental-watch-progress-notify-interval"`
-}
-
-type ServerTrust struct {
-	CertFile       string `json:"cert-file"`
-	KeyFile        string `json:"key-file"`
-	ClientCertAuth bool   `json:"client-cert-auth"`
-	TrustedCAFile  string `json:"trusted-ca-file"`
-}
-
-type PeerTrust struct {
-	CertFile       string `json:"cert-file"`
-	KeyFile        string `json:"key-file"`
-	ClientCertAuth bool   `json:"client-cert-auth"`
-	TrustedCAFile  string `json:"trusted-ca-file"`
 }
 
 type InitialOptions struct {
 	AdvertisePeerURL string `json:"initial-advertise-peer-urls,omitempty"`
 	Cluster          string `json:"initial-cluster,omitempty"`
 	State            string `json:"initial-cluster-state,omitempty"`
-}
-
-func (e ETCDConfig) ToConfigFile(extraArgs []string) (string, error) {
-	confFile := filepath.Join(e.DataDir, "config")
-	bytes, err := yaml.Marshal(&e)
-	if err != nil {
-		return "", err
-	}
-
-	if len(extraArgs) > 0 {
-		var s map[string]interface{}
-		if err := yaml2.Unmarshal(bytes, &s); err != nil {
-			return "", err
-		}
-
-		for _, v := range extraArgs {
-			extraArg := strings.SplitN(v, "=", 2)
-			// Depending on the argV, we have different types to handle.
-			// Source: https://github.com/etcd-io/etcd/blob/44b8ae145b505811775f5af915dd19198d556d55/server/config/config.go#L36-L190 and https://etcd.io/docs/v3.5/op-guide/configuration/#configuration-file
-			if len(extraArg) == 2 {
-				key := strings.TrimLeft(extraArg[0], "-")
-				lowerKey := strings.ToLower(key)
-				var stringArr []string
-				if i, err := strconv.Atoi(extraArg[1]); err == nil {
-					s[key] = i
-				} else if time, err := time.ParseDuration(extraArg[1]); err == nil && (strings.Contains(lowerKey, "time") || strings.Contains(lowerKey, "duration") || strings.Contains(lowerKey, "interval") || strings.Contains(lowerKey, "retention")) {
-					// auto-compaction-retention is either a time.Duration or int, depending on version. If it is an int, it will be caught above.
-					s[key] = time
-				} else if err := yaml.Unmarshal([]byte(extraArg[1]), &stringArr); err == nil {
-					s[key] = stringArr
-				} else {
-					switch strings.ToLower(extraArg[1]) {
-					case "true":
-						s[key] = true
-					case "false":
-						s[key] = false
-					default:
-						s[key] = extraArg[1]
-					}
-				}
-			}
-		}
-
-		bytes, err = yaml2.Marshal(&s)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if err := os.MkdirAll(e.DataDir, 0700); err != nil {
-		return "", err
-	}
-	return confFile, os.WriteFile(confFile, bytes, 0600)
 }
 
 func Set(driver Executor) {
@@ -159,10 +62,6 @@ func ControllerManager(ctx context.Context, apiReady <-chan struct{}, args []str
 
 func CurrentETCDOptions() (InitialOptions, error) {
 	return executor.CurrentETCDOptions()
-}
-
-func ETCD(ctx context.Context, args ETCDConfig, extraArgs []string) error {
-	return executor.ETCD(ctx, args, extraArgs)
 }
 
 func CloudControllerManager(ctx context.Context, ccmRBACReady <-chan struct{}, args []string) error {

--- a/pkg/embedw/etcd.go
+++ b/pkg/embedw/etcd.go
@@ -185,7 +185,7 @@ type etcdYAMLConfig struct {
 	QuotaBackendBytes    int64             `yaml:"quota-backend-bytes"`
 	BackendFreelistType  string            `yaml:"backend-bbolt-freelist-type"`
 	BackendBatchLimit    int               `yaml:"backend-batch-limit"`
-	BackendBatchInterval time.Duration     `yaml:"backend-batch-interval,omitempty"`
+	BackendBatchInterval int64              `yaml:"backend-batch-interval,omitempty"`
 	MaxLearners          int               `yaml:"max-learners"`
 	// TLS — client (nested section)
 	ClientTransportSecurity yamlSecurityConfig `yaml:"client-transport-security"`
@@ -210,12 +210,12 @@ type etcdYAMLConfig struct {
 	EnablePprof          bool              `yaml:"enable-pprof"`
 	EnableLogRotation    bool              `yaml:"enable-log-rotation"`
 	// GRPC
-	GRPCKeepAliveMinTime time.Duration     `yaml:"grpc-keepalive-min-time,omitempty"`
-	GRPCKeepAliveInterval time.Duration    `yaml:"grpc-keepalive-interval,omitempty"`
-	GRPCKeepAliveTimeout time.Duration     `yaml:"grpc-keepalive-timeout,omitempty"`
+	GRPCKeepAliveMinTime  int64            `yaml:"grpc-keepalive-min-time,omitempty"`
+	GRPCKeepAliveInterval int64            `yaml:"grpc-keepalive-interval,omitempty"`
+	GRPCKeepAliveTimeout  int64            `yaml:"grpc-keepalive-timeout,omitempty"`
 	// Feature gates
 	InitialCorruptCheck bool                `yaml:"experimental-initial-corrupt-check"`
-	WatchProgressNotifyInterval time.Duration `yaml:"experimental-watch-progress-notify-interval,omitempty"`
+	WatchProgressNotifyInterval int64         `yaml:"experimental-watch-progress-notify-interval,omitempty"`
 
 	Extra map[string]interface{} `yaml:",inline"`
 }
@@ -265,7 +265,7 @@ func writeConfigFile(path string, cfg Config) error {
 		EnablePprof: cfg.EnablePprof,
 		// Feature gates
 		InitialCorruptCheck:         cfg.InitialCorruptCheck,
-		WatchProgressNotifyInterval: cfg.WatchProgressNotifyInterval,
+		WatchProgressNotifyInterval: int64(cfg.WatchProgressNotifyInterval),
 		// Extra args merged via yaml:",inline"
 		Extra: cfg.ExtraLines,
 	}

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -1142,7 +1142,7 @@ func parseExtraArgs(args []string) map[string]interface{} {
 		if i, err := strconv.Atoi(val); err == nil {
 			m[key] = i
 		} else if d, err := time.ParseDuration(val); err == nil {
-			m[key] = d
+			m[key] = int64(d) // int64 (nanoseconds) — yaml.v2 marshals time.Duration as string, which sigs.k8s.io/yaml+json cannot unmarshal
 		} else {
 			switch strings.ToLower(val) {
 			case "true":


### PR DESCRIPTION
…xecutor path

yaml.v2 marshals time.Duration as string (via TextMarshaler), producing "5s" in YAML. sigs.k8s.io/yaml converts this to JSON string "5s", but encoding/json cannot unmarshal strings into time.Duration — only int64 nanoseconds accepted.

Changes:
- etcdYAMLConfig: change 5 time.Duration fields to int64 (WatchProgressNotify, BackendBatch, GRPCKeepAliveMinTime/Interval/Timeout)
- writeConfigFile: convert cfg.WatchProgressNotifyInterval with int64()
- parseExtraArgs: store int64(d) instead of time.Duration in map values
- Remove dead executor ETCD path (ETCDConfig, ToConfigFile, Embedded.ETCD) superseded by embedw cluster() in commit 1e653cb4