### PR TITLE
fix: add omitempty to MaxTxnOps, SnapshotCatchUpEntries, InitialElect…

### DIFF
--- a/pkg/embedw/etcd.go
+++ b/pkg/embedw/etcd.go
@@ -196,15 +196,15 @@ type etcdYAMLConfig struct {
 	DataDir              string            `yaml:"data-dir"`
 	WalDir               string            `yaml:"wal-dir"`
 	SnapshotCount        int               `yaml:"snapshot-count"`
-	SnapshotCatchUpEntries uint64          `yaml:"snapshot-catchup-entries"`
+	SnapshotCatchUpEntries uint64          `yaml:"snapshot-catchup-entries,omitempty"`
 	MaxSnapFiles         uint              `yaml:"max-snapshots"`
 	MaxWALFiles          uint              `yaml:"max-wals"`
 	TickMs               int               `yaml:"heartbeat-interval"`
 	ElectionMs           int               `yaml:"election-timeout"`
-	InitialElectionTickAdvance bool         `yaml:"initial-election-tick-advance"`
+	InitialElectionTickAdvance bool         `yaml:"initial-election-tick-advance,omitempty"`
 	MaxRequestBytes      uint              `yaml:"max-request-bytes"`
 	MaxConcurrentStreams uint32            `yaml:"max-concurrent-streams"`
-	MaxTxnOps            uint              `yaml:"max-txn-ops"`
+	MaxTxnOps            uint              `yaml:"max-txn-ops,omitempty"`
 	ListenPeerUrls       string            `yaml:"listen-peer-urls"`
 	ListenClientUrls     string            `yaml:"listen-client-urls"`
 	ListenClientHTTPUrls string            `yaml:"listen-client-http-urls"`


### PR DESCRIPTION
…ionTickAdvance

Zero values in YAML config override etcd defaults:
- max-txn-ops: 0 → disables all transactions (default 128)
- snapshot-catchup-entries: 0 → overrides default 5000
- initial-election-tick-advance: false → changes etcd behavior

Add omitempty so unset fields inherit etcd defaults.