### PR TITLE
fix: install pi skill to ~/.agents/skills/ instead of ~/.pi/skills/

### DIFF
--- a/pkg/sandboxcli/apikey.go
+++ b/pkg/sandboxcli/apikey.go
@@ -27,7 +27,7 @@ func readAPIKeys() (apiKeyStore, error) {
 	}
 	secret, err := k8s.CoreV1().Secrets(apiKeySecretNS).Get(context.Background(), apiKeySecretName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("api-key secret not found (run 'k8e sandbox-apikey create <name>' to create your first key)")
+		return make(apiKeyStore), nil // secret not created yet — first key
 	}
 	data, ok := secret.Data["keys.json"]
 	if !ok {

--- a/pkg/sandboxcli/install.go
+++ b/pkg/sandboxcli/install.go
@@ -16,7 +16,6 @@ const skillFileName = "SKILL.md"
 const (
 	dirClaude = ".claude"
 	dirCodex  = ".codex"
-	dirPi     = ".pi"
 )
 
 // installSkillLocalOrGlobal installs skills into the agent's local workspace first,
@@ -38,7 +37,11 @@ func InstallSkill(target string) error {
 	case "codex":
 		return installSkillLocalOrGlobal(dirCodex, "codex")
 	case "pi":
-		return installSkillLocalOrGlobal(dirPi, "pi")
+		// project-local: .pi/skills/, global: ~/.agents/skills/
+		if _, err := os.Stat(filepath.Join(".pi", "skills")); err == nil {
+			return installAllSkills(filepath.Join(".pi", "skills"), "pi (workspace)")
+		}
+		return installAllSkills(filepath.Join(homeDir(), ".agents", "skills"), "pi (global)")
 	case "all":
 		var errs []error
 		for _, fn := range []func() error{

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 const apiKeySecretNS = "sandbox-matrix"
-const apiKeySecretName = "sandbox-api-keys"
+const apiKeySecretName = "sandbox-apikeys"
 
 const sandboxdPort = 2024
 
@@ -63,7 +63,7 @@ func NewServer(k8s kubernetes.Interface, dyn dynamic.Interface, certFile, keyFil
 	return s
 }
 
-// loadAPIKeys reads API keys from the sandbox-api-keys Secret.
+// loadAPIKeys reads API keys from the sandbox-apikeys Secret.
 func (s *Server) loadAPIKeys(ctx context.Context) {
 	secret, err := s.k8s.CoreV1().Secrets(apiKeySecretNS).Get(ctx, apiKeySecretName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
pi uses ~/.agents/skills/ for global config, not ~/.pi/skills/. Keep project-local .pi/skills/ path unchanged.