### PR TITLE
docs: add TLS SAN server setup instructions to sandbox skill

### DIFF
--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -113,10 +113,8 @@ func buildCommand(lang, code string) string {
 		}
 		return fmt.Sprintf("node -e %q", code)
 	case "ts", "typescript":
-		if isMultiLine(code) {
-			return "tsx /workspace/_k8e_run.ts"
-		}
-		return fmt.Sprintf("tsx -e %q", code)
+		// tsx always creates /tmp/tsx-0. Redirect via TMPDIR.
+		return "TMPDIR=/workspace tsx /workspace/_k8e_run.ts"
 	default: // bash / sh
 		return code
 	}
@@ -177,7 +175,7 @@ func runAction(ctx *cli.Context) error {
 		return nil
 	}
 
-	if isInterpretedLang(lang) && isMultiLine(code) {
+	if isInterpretedLang(lang) && (isMultiLine(code) || strings.HasPrefix(lang, "ts")) {
 		if err := writeCodeFile(cli, sid, lang, code); err != nil {
 			printErrorExit("write code: "+err.Error(), 1)
 			return nil

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -12,6 +12,27 @@ All code execution goes through `k8e-sandbox-cli` — never run code directly on
 
 **Trigger keywords (中文):** "帮我跑", "运行", "试试", "执行", "测试", "安装并使用", "分析这个CSV", "处理这个文件", "看看输出", "帮我算"
 
+## Pre-flight
+
+Before any sandbox operation, check that the required environment variables are set:
+
+```bash
+if [ -z "$K8E_SANDBOX_ENDPOINT" ] || [ -z "$K8E_SANDBOX_APIKEY" ]; then
+  echo "⚠ Sandbox not configured. Please provide:"
+  echo "  export K8E_SANDBOX_ENDPOINT=<server-ip>:50051"
+  echo "  export K8E_SANDBOX_APIKEY=<your-api-key>"
+  exit 1
+fi
+```
+
+**If either variable is missing**, stop immediately and ask the user:
+
+> "I need your K8E sandbox credentials to run code securely:
+>   `K8E_SANDBOX_ENDPOINT` — the server address (e.g. `54.116.141.251:50051`)
+>   `K8E_SANDBOX_APIKEY` — your API key (get it from the server: `k8e sandbox-apikey create my-agent`)"
+
+Do NOT proceed with any code execution until both are set.
+
 ## Environment
 
 Download the platform-specific binary (~44MB) from [GitHub Releases](https://github.com/xiaods/k8e/releases).

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -33,6 +33,20 @@ fi
 
 Do NOT proceed with any code execution until both are set.
 
+### Server-side TLS setup (one-time)
+
+The server admin must add the public IP to the TLS certificate SAN list so clients can verify the connection:
+
+```yaml
+# /etc/k8e/config.yaml
+tls-san:
+  - 54.116.141.251
+```
+
+Then restart: `systemctl restart k8e`
+
+If the server has not added the public IP, the CLI will use TOFU (Trust-On-First-Use) with API key authentication — functional but less secure. Remind the admin to add `tls-san` for full TLS verification.
+
 ## Environment
 
 Download the platform-specific binary (~44MB) from [GitHub Releases](https://github.com/xiaods/k8e/releases).

--- a/skills/k8e-sandbox/SKILL.md
+++ b/skills/k8e-sandbox/SKILL.md
@@ -12,6 +12,27 @@ All code execution goes through `k8e-sandbox-cli` — never run code directly on
 
 **Trigger keywords (中文):** "帮我跑", "运行", "试试", "执行", "测试", "安装并使用", "分析这个CSV", "处理这个文件", "看看输出", "帮我算"
 
+## Pre-flight
+
+Before any sandbox operation, check that the required environment variables are set:
+
+```bash
+if [ -z "$K8E_SANDBOX_ENDPOINT" ] || [ -z "$K8E_SANDBOX_APIKEY" ]; then
+  echo "⚠ Sandbox not configured. Please provide:"
+  echo "  export K8E_SANDBOX_ENDPOINT=<server-ip>:50051"
+  echo "  export K8E_SANDBOX_APIKEY=<your-api-key>"
+  exit 1
+fi
+```
+
+**If either variable is missing**, stop immediately and ask the user:
+
+> "I need your K8E sandbox credentials to run code securely:
+>   `K8E_SANDBOX_ENDPOINT` — the server address (e.g. `54.116.141.251:50051`)
+>   `K8E_SANDBOX_APIKEY` — your API key (get it from the server: `k8e sandbox-apikey create my-agent`)"
+
+Do NOT proceed with any code execution until both are set.
+
 ## Environment
 
 Download the platform-specific binary (~44MB) from [GitHub Releases](https://github.com/xiaods/k8e/releases).

--- a/skills/k8e-sandbox/SKILL.md
+++ b/skills/k8e-sandbox/SKILL.md
@@ -33,6 +33,20 @@ fi
 
 Do NOT proceed with any code execution until both are set.
 
+### Server-side TLS setup (one-time)
+
+The server admin must add the public IP to the TLS certificate SAN list so clients can verify the connection:
+
+```yaml
+# /etc/k8e/config.yaml
+tls-san:
+  - 54.116.141.251
+```
+
+Then restart: `systemctl restart k8e`
+
+If the server has not added the public IP, the CLI will use TOFU (Trust-On-First-Use) with API key authentication — functional but less secure. Remind the admin to add `tls-san` for full TLS verification.
+
 ## Environment
 
 Download the platform-specific binary (~44MB) from [GitHub Releases](https://github.com/xiaods/k8e/releases).


### PR DESCRIPTION
[docs: add TLS SAN server setup instructions to sandbox skill](https://github.com/xiaods/k8e/commit/dfbcdac86413aab1f91571382c1cf19ca65567c0)