### PR TITLE
fix(sandboxd): preserve final char of absolute file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,20 @@ k8e-sandbox-cli run "print('hello')" --lang python
 # Shell command (default lang=bash)
 k8e-sandbox-cli run "ls -la /workspace"
 
-# TypeScript
-k8e-sandbox-cli run "console.log(42)" --lang ts
+# TypeScript — type annotations run via tsx
+k8e-sandbox-cli run "const nums: number[] = [1, 2, 3]; console.log(nums.reduce((a, b) => a + b, 0))" --lang ts
+
+# Multi-line TypeScript via stdin (interfaces, async/await)
+k8e-sandbox-cli run --lang ts <<'EOF'
+interface User { name: string; age: number }
+
+async function oldest(users: User[]): Promise<User> {
+  return users.reduce((a, b) => (a.age > b.age ? a : b));
+}
+
+const users: User[] = [{ name: "Ada", age: 36 }, { name: "Linus", age: 54 }];
+oldest(users).then((u) => console.log(`Oldest: ${u.name} (${u.age})`));
+EOF
 
 # Multi-line via stdin
 k8e-sandbox-cli run --lang python <<'EOF'

--- a/sandboxd/src/files.zig
+++ b/sandboxd/src/files.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const main = @import("main.zig");
 const exec = @import("exec.zig");
+const path_util = @import("path.zig");
 
 const WriteRequest = struct {
     path: []const u8 = "",
@@ -21,13 +22,7 @@ pub fn handleWrite(allocator: std.mem.Allocator, client_fd: i32, body: []const u
         return;
     }
 
-    const full_path = if (std.mem.startsWith(u8, req.path, "/"))
-        try allocator.dupeZ(u8, req.path)
-    else blk: {
-        const s = try std.fmt.allocPrint(allocator, "/workspace/{s}", .{req.path});
-        break :blk try allocator.realloc(s, s.len + 1);
-    };
-    full_path[full_path.len - 1] = 0;
+    const full_path = try path_util.resolveWorkspacePath(allocator, req.path);
     defer allocator.free(full_path);
 
     // Ensure parent directory exists using mkdir recursion
@@ -42,7 +37,7 @@ pub fn handleWrite(allocator: std.mem.Allocator, client_fd: i32, body: []const u
         std.os.linux.O{ .CREAT = true, .ACCMODE = .WRONLY, .TRUNC = true };
     const mode: u32 = 0o644;
 
-    const fd = std.os.linux.open(@as([*:0]const u8, @ptrCast(full_path.ptr)), open_flags, mode);
+    const fd = std.os.linux.open(full_path.ptr, open_flags, mode);
     if (fd < 0) {
         const msg = try std.fmt.allocPrint(allocator, "{{\"error\":\"open failed\"}}", .{});
         defer allocator.free(msg);
@@ -84,16 +79,10 @@ pub fn handleRead(allocator: std.mem.Allocator, client_fd: i32, query: []const u
         return;
     };
 
-    const full_path = if (std.mem.startsWith(u8, path, "/"))
-        try allocator.dupeZ(u8, path)
-    else blk: {
-        const s = try std.fmt.allocPrint(allocator, "/workspace/{s}", .{path});
-        break :blk try allocator.realloc(s, s.len + 1);
-    };
-    full_path[full_path.len - 1] = 0;
+    const full_path = try path_util.resolveWorkspacePath(allocator, path);
     defer allocator.free(full_path);
 
-    const fd = std.os.linux.open(@as([*:0]const u8, @ptrCast(full_path.ptr)), std.os.linux.O{ .ACCMODE = .RDONLY }, 0);
+    const fd = std.os.linux.open(full_path.ptr, std.os.linux.O{ .ACCMODE = .RDONLY }, 0);
     if (fd < 0) {
         const msg = try std.fmt.allocPrint(allocator, "{{\"error\":\"not found\"}}", .{});
         defer allocator.free(msg);

--- a/sandboxd/src/files_test.zig
+++ b/sandboxd/src/files_test.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const path_util = @import("path.zig");
 
 fn extractQueryParam(query: []const u8, key: []const u8) ?[]const u8 {
     var it = std.mem.splitScalar(u8, query, '&');
@@ -30,4 +31,23 @@ test "extractQueryParam: empty query returns null" {
 
 test "extractQueryParam: key with empty value" {
     try std.testing.expectEqualStrings("", extractQueryParam("path=", "path").?);
+}
+
+test "resolveWorkspacePath: absolute path preserved verbatim" {
+    // Regression: an earlier version clobbered the final char of absolute
+    // paths, so /workspace/_k8e_run.ts was written to /workspace/_k8e_run.t
+    // and `tsx /workspace/_k8e_run.ts` failed with ERR_MODULE_NOT_FOUND.
+    const a = std.testing.allocator;
+    const p = try path_util.resolveWorkspacePath(a, "/workspace/_k8e_run.ts");
+    defer a.free(p);
+    try std.testing.expectEqualStrings("/workspace/_k8e_run.ts", p);
+    try std.testing.expectEqual(@as(u8, 0), p.ptr[p.len]);
+}
+
+test "resolveWorkspacePath: relative path rooted at /workspace" {
+    const a = std.testing.allocator;
+    const p = try path_util.resolveWorkspacePath(a, "notes.txt");
+    defer a.free(p);
+    try std.testing.expectEqualStrings("/workspace/notes.txt", p);
+    try std.testing.expectEqual(@as(u8, 0), p.ptr[p.len]);
 }

--- a/sandboxd/src/path.zig
+++ b/sandboxd/src/path.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+/// Resolve a request path to an absolute, null-terminated filesystem path.
+/// Absolute paths (leading "/") are used verbatim; relative paths are rooted
+/// at /workspace. The returned slice is sentinel-terminated and its .len does
+/// NOT include the terminator, so it can be passed straight to syscalls via
+/// .ptr. Caller owns the memory.
+pub fn resolveWorkspacePath(allocator: std.mem.Allocator, path: []const u8) ![:0]u8 {
+    if (std.mem.startsWith(u8, path, "/")) {
+        return allocator.dupeZ(u8, path);
+    }
+    return std.fmt.allocPrintSentinel(allocator, "/workspace/{s}", .{path}, 0);
+}


### PR DESCRIPTION
handleWrite/handleRead null-terminated absolute paths by writing 0 to the last byte of a dupeZ slice — but dupeZ's .len excludes the sentinel, so this clobbered the final real character. /workspace/_k8e_run.ts was written to /workspace/_k8e_run.t, so `tsx /workspace/_k8e_run.ts` failed with ERR_MODULE_NOT_FOUND. Single-line python/node dodged it via inline -c/-e; TS always writes a file, so it always hit the bug.

Extract resolveWorkspacePath into path.zig (sentinel-terminated, no manual clobber), shared by both handlers, with regression tests. Also improve the README TypeScript examples.