### PR TITLE
feat(sandbox): mTLS dynamic certificate issuance with sandbox CA

### DIFF
--- a/cmd/sandboxcli/main.go
+++ b/cmd/sandboxcli/main.go
@@ -26,6 +26,7 @@ func main() {
 		cli.StringFlag{Name: "apikey", EnvVar: "K8E_SANDBOX_APIKEY", Usage: "API key for remote cluster authentication"},
 	}
 	app.Commands = []cli.Command{
+		sandboxcli.LoginCommand(),
 		sandboxcli.RunCommand(),
 		sandboxcli.StatusCommand(),
 		sandboxcli.CreateCommand(),

--- a/docs/kip-14-mtls-dynamic-cert-issuance.md
+++ b/docs/kip-14-mtls-dynamic-cert-issuance.md
@@ -1,0 +1,359 @@
+# KIP-14: mTLS 动态证书签发
+
+| Author | Updated | Status |
+|--------|---------|--------|
+| @xiaods | 2026-06-04 | Proposed |
+
+## Summary
+
+将 sandbox gRPC 网关从当前的 **API key bearer token + 单向 TLS** 认证升级为 **mTLS 动态证书签发**。核心变化：
+
+1. **独立沙箱 CA**：服务端启动时自动生成 ECDSA P-256 CA，同时签服务端 server cert 和客户端 client cert，单 CA 双向信任。
+2. **Login RPC**：新增 Bootstrap 接口，客户端提交 CSR + API key（首次）或旧 client cert（续期），服务端签发 30 天短命客户端证书。
+3. **业务 RPC 强制 mTLS**：`CreateSession`、`Exec` 等所有业务 RPC 从 API key metadata 认证切换为 mTLS 证书认证，从 `PeerCertificates[0].Subject.CommonName` 提取身份。
+4. **懒续期**：客户端在连接建立时检测证书有效期，不足时自动续期，无需后台常驻进程。
+5. **轻量吊销**：API key 删除时对应证书指纹加入内存吊销列表，Login 和业务 RPC 均检查。
+
+本 KIP 同时移除 `GetCACert` RPC（功能由 `LoginResponse.ca_cert` 取代）和 API key interceptor（业务 RPC 不再走 bearer token）。
+
+## Motivation
+
+### 当前状态
+
+| 维度 | 现状 | 问题 |
+|------|------|------|
+| 服务端 TLS | `NewServerTLSFromFile`，复用 `serving-kube-apiserver.crt/key` | 无客户端证书验证；共享 K8s API Server 证书 |
+| 客户端认证 | API key 通过 `authorization: Bearer <key>` metadata 传输 | 每次请求携带长期凭证，泄露风险高 |
+| API key 存储 | K8s Secret `sandbox-matrix/sandbox-apikeys`，30 秒 reload | O(n) 线性查找，无身份绑定 |
+| 客户端 TLS | TOFU 模式获取"CA cert"（实为 leaf cert），缓存到 `~/.k8e/sandbox/ca.crt` | `GetCACert` 返回的是 leaf cert 不是 CA cert；无客户端身份证书 |
+| 安全边界 | API key Secret 不存在时**所有请求免认证通过** | 默认不安全 |
+| 续期 | 无 | API key 是静态长期凭证 |
+
+### 目标
+
+- 客户端证书短期化（30 天），降低泄露影响面
+- 业务请求不传输长期凭证（mTLS 握手后无需 API key）
+- 身份绑定到证书 CN，审计日志可追踪
+- 首次 Login 后用户无感（懒续期）
+- CA 体系独立于 K8s 集群 CA，权限边界清晰
+
+## Design
+
+### Part A — CA 层级
+
+```
+/var/lib/k8e/server/tls/
+├── sandbox-ca.crt          # 沙箱专用 CA 证书（ECDSA P-256，启动时自动生成）
+├── sandbox-ca.key          # CA 私钥（0600）
+├── sandbox-server.crt      # gRPC 网关 server cert（由 sandbox-ca 签发）
+├── sandbox-server.key      # server 私钥（ECDSA P-256）
+└── sandbox-issued.json     # 已签发客户端证书记录
+```
+
+- CA 在 `server.go` 的 `Start()` 中检测，不存在则自动生成（与 `serving-kube-apiserver` 自举逻辑一致）
+- CA 文件丢失 → 重新生成，旧客户端证书全部失效，文档说明风险
+- 不依赖 K8s Secret 存储 CA key（尊重单二进制自包含设计）
+
+#### CA 参数
+
+| 参数 | 值 |
+|------|-----|
+| 算法 | ECDSA P-256 |
+| 签名算法 | SHA256 |
+| CA 证书有效期 | 10 年（仅用于签发，client 和 server 走自己的短命周期） |
+| KeyUsage | `certSign | crlSign` |
+| BasicConstraints | `IsCA: true` |
+
+### Part B — gRPC 端口认证策略
+
+**单端口，`tls.VerifyClientCertIfGiven` 模式**，按方法区分认证：
+
+```
+                     ┌─────────────────────────────────┐
+                     │   gRPC :50051 (单端口)           │
+                     │   tls.VerifyClientCertIfGiven    │
+                     └──────────┬──────────────────────┘
+                                │
+              ┌─────────────────┴─────────────────┐
+              ▼                                   ▼
+     ┌─────────────────┐                ┌─────────────────┐
+     │ Bootstrap 方法   │                │ 业务 RPC        │
+     │ Login            │                │ CreateSession   │
+     │                  │                │ DestroySession  │
+     │ 认证方式：        │                │ Exec/ExecStream │
+     │ 有 client cert → │                │ WriteFile       │
+     │   mTLS 身份续期   │                │ ReadFile        │
+     │ 无 client cert → │                │ ListFiles       │
+     │   API key metadata│               │ PipInstall      │
+     │                  │                │ RunSubAgent     │
+     │                  │                │ ConfirmAction   │
+     │                  │                │ ApproveAction   │
+     │                  │                │ PollRun         │
+     │                  │                │                 │
+     │                  │                │ 认证方式：       │
+     │                  │                │ 强制 mTLS       │
+     │                  │                │ 无证书 → 拒绝    │
+     └─────────────────┘                └─────────────────┘
+```
+
+- 业务 RPC 强制 mTLS：无 client cert → `codes.Unauthenticated`
+- Login handler 内部双路径：peer cert 有效 → mTLS 续期；peer cert 为空 → API key 认证
+- 本地 loopback（`127.0.0.1`）豁免 mTLS：无 client cert 时可以执行业务 RPC（loopback 视为安全边界）
+
+### Part C — Login RPC
+
+#### Protobuf 定义
+
+```protobuf
+rpc Login(LoginRequest) returns (LoginResponse);
+
+message LoginRequest {
+  string csr            = 1;  // PEM-encoded PKCS#10 CSR
+  string device_name    = 2;  // 如 hostname，仅审计日志
+  string client_version = 3;  // k8e 版本号，仅审计日志
+}
+
+message LoginResponse {
+  string cert       = 1;  // PEM-encoded 客户端证书
+  string ca_cert    = 2;  // 沙箱 CA 证书（客户端缓存为信任锚）
+  int64  valid_days = 3;  // 证书有效天数（用于客户端计算续期窗口）
+}
+```
+
+API key 通过 gRPC metadata `authorization: Bearer <key>` 传递，不出现在 proto body 中。
+
+#### Login handler 逻辑
+
+```
+handleLogin(req, stream):
+  peerCerts := TLS peer certificates from stream context
+
+  if peerCerts non-empty and cert valid (NotBefore ≤ now ≤ NotAfter):
+    // 续期路径：mTLS 身份
+    keyName = peerCerts[0].Subject.CommonName
+  else if peerCerts empty:
+    // 首次登录路径：API key 认证
+    apiKey = extractBearerToken(stream metadata)
+    keyName = lookupAPIKey(apiKey)
+    if keyName == "":
+      return Unauthenticated
+  else:
+    // 证书在 TLS 握手层已被拒绝，不会到达这里
+    return Unauthenticated
+
+  // 吊销检查
+  if revocationList.contains(certFingerprint(keyName)):
+    return PermissionDenied
+
+  // 解析 CSR，提取公钥（忽略其 Subject/SAN）
+  pubKey = parseCSR(req.csr).PublicKey
+
+  // 签发客户端证书（服务端完全控制证书身份）
+  clientCert = signClientCert(
+    ca:   sandboxCA,
+    pubKey: pubKey,
+    cn:   keyName,
+    ttl:  30 days,
+  )
+
+  // 记录审计
+  auditLog("login", keyName, req.device_name, req.client_version, clientCert.fingerprint, sourceIP)
+
+  // 持久化签发记录
+  issuedStore.append(keyName, clientCert.fingerprint, issuedAt, expiresAt)
+
+  return LoginResponse{
+    cert:       clientCert.PEM,
+    ca_cert:    sandboxCA.crt.PEM,
+    valid_days: 30,
+  }
+```
+
+#### 客户端证书模板
+
+| 字段 | 值 |
+|------|-----|
+| Subject.CommonName | API key 名 |
+| NotBefore | now |
+| NotAfter | now + 30 days |
+| KeyUsage | `digitalSignature` |
+| ExtKeyUsage | `clientAuth` |
+| BasicConstraints | `IsCA: false` |
+| CRLDistributionPoints | 占位 URL（为将来扩展预留） |
+
+- CSR 中的 Subject/SAN 被服务端忽略，服务端完全控制证书身份
+- `device_name` / `client_version` 不进证书，仅写入审计日志
+
+### Part D — 服务端 Server Cert 管理
+
+沙箱 CA 同时为 gRPC 网关自身签发 server cert：
+
+- 保存为 `/var/lib/k8e/server/tls/sandbox-server.crt` 和 `sandbox-server.key`
+- Server cert 私钥：ECDSA P-256，启动时生成
+- SAN：启动时动态收集 = 本机所有网卡 IP + hostname + 环境变量 `K8E_SANDBOX_ADVERTISED_HOSTNAME`
+- Server cert 有效期：90 天（长于 client cert，减少服务端重启频率）
+- 启动时检测：server cert 不存在或剩余有效期 < 30 天 → 重新签发
+
+### Part E — 客户端证书存储
+
+```
+~/.k8e/sandbox/
+├── client.key    # 客户端私钥（ECDSA P-256, 0600）
+├── client.crt    # 客户端证书（0644）
+└── ca.crt        # 沙箱 CA 证书（信任锚，0644）
+```
+
+### Part F — 客户端连接流程
+
+`NewClientWithEndpoint()` 内部三态判断：
+
+```
+NewClientWithEndpoint(endpoint, apiKey):
+  caCrt    = read ~/.k8e/sandbox/ca.crt       // 是否存在
+  clientCrt = read ~/.k8e/sandbox/client.crt  // 是否存在
+  clientKey = read ~/.k8e/sandbox/client.key  // 是否存在
+
+  switch:
+    case caCrt && clientCrt && clientKey && certValid(clientCrt):
+      // 路径 1：直接 mTLS 连接
+      return dialMTLS(endpoint, caCrt, clientCrt, clientKey)
+
+    case caCrt && (!clientCrt or !clientKey or certExpired(clientCrt)):
+      // 路径 2：单向 TLS（验证服务端），先 Login 获取证书，再 mTLS
+      clientCrt, clientKey = generateKeyPairAndCSR()
+      loginResp = callLoginOverTLS(endpoint, caCrt, apiKey, csr)
+      save(loginResp.cert, clientCrt); save(clientKey)
+      return dialMTLS(endpoint, caCrt, loginResp.cert, clientKey)
+
+    case !caCrt:
+      // 路径 3：无验证连接，Login 获取 ca + client cert，再 mTLS
+      clientCrt, clientKey = generateKeyPairAndCSR()
+      loginResp = callLoginInsecure(endpoint, apiKey, csr)
+      save(loginResp.ca_cert, ca.crt)
+      save(loginResp.cert, clientCrt); save(clientKey)
+      return dialMTLS(endpoint, caCrt, loginResp.cert, clientKey)
+```
+
+- `apiKey` 参数只在路径 2/3 中使用（首次/过期后续期），路径 1 忽略之
+- `callLoginInsecure`：`tls.Config{InsecureSkipVerify: true}` —— bootstrap 无法避免，但 API key 认证 + LoginResponse 带回 CA cert 使后续连接安全
+
+### Part G — 懒续期
+
+续期在连接建立时触发，不在独立的后台进程中：
+
+```
+// 在 dialMTLS 之前
+if certExpiringSoon(clientCrt, threshold=7days):
+  csr = generateCSR(clientKey)
+  loginResp = callLoginOverMTLS(endpoint, caCrt, clientCrt, clientKey, csr)
+  save(loginResp.cert, clientCrt)
+  // clientKey 复用，不重新生成
+```
+
+- 复用现有私钥，仅签发新证书
+- 续期使用 mTLS 身份（Login handler 从 peer cert CN 提取身份），不需要 API key
+- 证书已过期 → TLS 握手失败 → 回退到路径 2（用 API key 重新 Login）
+- 阈值：7 天
+
+### Part H — 轻量吊销
+
+无需 CRL 文件或 OCSP。
+
+```
+var revocationList sync.Map  // certFingerprint → revokedAt
+
+// API key 删除时
+onAPIKeyDeleted(keyName):
+  for each cert in issuedStore.findByKeyName(keyName):
+    revocationList.Store(cert.fingerprint, time.Now())
+
+// Login handler 中
+if _, revoked := revocationList.Load(fingerprint); revoked:
+  return PermissionDenied
+
+// 业务 RPC mTLS 验证后
+peerFingerprint := sha256(peerCert.Raw)
+if _, revoked := revocationList.Load(peerFingerprint); revoked:
+  return PermissionDenied
+```
+
+- 吊销列表存于内存（`/var/lib/k8e/server/tls/sandbox-issued.json` 持久化签发记录，重启时可选择性地通过"API key 已删除"推断吊销）
+- 30 天证书过期后吊销条目自动清理（定期扫描 `issued.json` 清理过期记录）
+
+### Part I — 移除的组件
+
+| 移除 | 原因 |
+|------|------|
+| `GetCACert` RPC | 被 `LoginResponse.ca_cert` 取代 |
+| `apiKeyInterceptor` / `apiStreamInterceptor` | 业务 RPC 改用 mTLS 认证 |
+| TOFU 逻辑（`tofuConnect`, `tryCachedCert`, `verifyFingerprint`） | 被 Login 三态 bootstrap 取代 |
+| 客户端 `dialWithAPIKey` interceptor | 业务 RPC 不再传 API key metadata |
+
+### Part J — 兼容性过渡
+
+硬切换：一次性移除 API key interceptor，老客户端必须执行一次 `k8e sandbox login` 才能继续使用。理由：K8E 用户量小、更新快，灰度期增加代码复杂度不值得。
+
+用户迁移步骤：
+```bash
+# 升级 k8e 二进制后
+k8e sandbox login --apikey sk-xxx --endpoint sandbox.example.com:50051
+# → 证书存到 ~/.k8e/sandbox/，后续命令无需 --apikey
+k8e sandbox run "echo hello"
+```
+
+### 决策记录
+
+| 决策 | 选择 | 理由 |
+|------|------|------|
+| CA 层级 | 独立沙箱 CA，与 K8s 集群 CA 分离 | 信任域隔离，吊销粒度独立 |
+| Bootstrap 接口 | 单 gRPC port + 按方法区分认证 | 不增加端口/网络拓扑复杂度 |
+| Login 协议 | 单 RPC（CSR → cert + ca_cert） | 一步到位，无往返延迟 |
+| 证书身份 | CN = API key 名 | 审计友好，粒度和当前 API key 一致 |
+| 续期 | 懒续期，连接建立时触发 | CLI 无后台进程，最简单 |
+| CA 初始化 | 启动时自动生成 | 运维零成本 |
+| CSR SAN | 服务端忽略，完全自决 | 客户端不可信 |
+| 客户端密钥算法 | ECDSA P-256 | Go `crypto/x509` 原生，gRPC 完全支持 |
+| 吊销 | 内存吊销列表（API key 删除时触发） | 30 天短命证书 + 轻量吊销足够 |
+| 授权 | 有有效证书 = 可执行所有操作 | 当前无角色概念，授权后续 PR 加 |
+| loopback | 豁免 mTLS | 延续 `IsLocalOrHasRole()` 先例 |
+| GetCACert RPC | 删除 | `LoginResponse.ca_cert` 取代 |
+| API key interceptor | 移除 | mTLS 取代 |
+| 过渡策略 | 硬切换 | 用户量小，更新快 |
+
+### 边界处理
+
+| 场景 | 行为 |
+|------|------|
+| 首次使用，无 client cert | 路径 3：InsecureSkipVerify + Login（API key），获取 ca + client cert |
+| client cert 在有效期内 | 路径 1：直接 mTLS 连接 |
+| client cert 剩余 < 7 天 | 懒续期触发，mTLS 身份续期（不需 API key） |
+| client cert 已过期 | TLS 握手失败 → 回退路径 2：用 API key 重新 Login |
+| API key 被删除 | 该 key 签发的所有证书加入吊销列表；已有连接的吊销在下次 RPC 时拒绝 |
+| 沙箱 CA 文件丢失 | 启动时重新生成 CA + server cert；所有旧 client cert 失效，客户端需重新 Login |
+| 服务重启 | CA 从磁盘加载；吊销列表为空（内存），但已签发证书记录在 `issued.json` 中恢复 |
+| Login 请求的 peer cert 有效但已被吊销 | 吊销检查拒绝 |
+| 同一 key 多次 Login（多设备） | 每台设备独立生成密钥对和证书，CN 相同但公钥/指纹不同；吊销按指纹粒度 |
+| 本地连接（127.0.0.1）| 无 client cert 可通过（loopback 豁免），无需 login |
+| 服务端 server cert 过期 | 启动时检测，< 30 天则自动重新签发 |
+
+### 文件变更
+
+| 文件 | 变更 |
+|------|------|
+| `proto/sandbox/v1/sandbox.proto` | 新增 `Login` RPC、`LoginRequest`、`LoginResponse`；移除 `GetCACert` RPC |
+| `pkg/sandboxmatrix/grpc/pb/` | 重新生成 protobuf Go 代码 |
+| `pkg/sandboxmatrix/grpc/server.go` | 沙箱 CA 生成/加载；`tls.Config` 改为 `VerifyClientCertIfGiven` + 设置 `ClientCAs`；`Login` handler；移除 `apiKeyInterceptor`/`apiStreamInterceptor`；签发证书逻辑（`signClientCert`）；吊销列表初始化；server cert 签发/更新 |
+| `pkg/sandboxmatrix/grpc/cert.go`（新增）| CA 生成、CSR 解析、证书签发、吊销列表、签发记录持久化 |
+| `pkg/sandboxmatrix/controller.go` | 传递新 CA 路径和 server cert 路径给 `NewServer` |
+| `pkg/sandbox/client/client.go` | 重写连接建立（三态 bootstrap）；懒续期；移除 TOFU 逻辑；移除 `dialWithAPIKey` interceptor；新增 `Login` 客户端方法 |
+| `pkg/sandboxcli/commands.go` | 新增 `login` 子命令；`newClientFromCtx` 适配 |
+| `pkg/sandboxcli/login.go`（新增）| `LoginCommand()` 实现：`k8e sandbox login --apikey --endpoint [--device-name]` |
+| `cmd/sandboxcli/main.go` | 新增 `login` 子命令注册（或仅靠 `sandboxcli` 内部注册） |
+| `pkg/cli/cmds/sandbox.go` | 注册 `login` 子命令 |
+| `skills/k8e-sandbox/SKILL.md` | 文档化 `k8e sandbox login` 流程 |
+
+## 相关 KIP
+
+- [KIP-3](./kip-3-agentic-ai-sandbox-matrix.md) — Sandbox Matrix 总体设计（gRPC 网关架构）
+- [KIP-8](./kip-8-skill-cli-replace-mcp.md) — CLI 替换 MCP（CLI 优先的认证体验基础）
+- [KIP-12](./kip-12-sandbox-ports-env-secrets.md) — Ports/Preview 与 Env/Secrets（共享 gRPC 端口和服务端部署上下文）

--- a/pkg/sandbox/client/client.go
+++ b/pkg/sandbox/client/client.go
@@ -1,17 +1,18 @@
-// Package client provides the gRPC client for K8E sandbox operations.
 package client
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"google.golang.org/grpc"
@@ -32,7 +33,6 @@ var kubeconfigCandidates = []string{
 	"/var/lib/k8e/server/cred/admin.kubeconfig",
 }
 
-// resolvedKubeconfigCandidates returns kubeconfig paths including KUBECONFIG env and ~/.kube/config.
 func resolvedKubeconfigCandidates() []string {
 	candidates := make([]string, 0, len(kubeconfigCandidates)+2)
 	if kc := os.Getenv("KUBECONFIG"); kc != "" {
@@ -68,209 +68,266 @@ func NewClient() (*Client, error) {
 	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 }
 
-// NewClientWithEndpoint connects to a remote K8E cluster at endpoint with API key.
-// On first connection, auto-downloads the server CA cert via TOFU for future use.
+// NewClientWithEndpoint connects to a remote K8E cluster at endpoint.
+// On first use, performs mTLS bootstrap: generates a key pair, logs in with the API key,
+// and obtains a short-lived client certificate. Subsequent calls use the cached certificate
+// with automatic lazy renewal.
 func NewClientWithEndpoint(endpoint, apiKey string) (*Client, error) {
 	if apiKey == "" {
 		return NewClient()
 	}
 	cacheDir, _ := sandboxCacheDir()
 	caFile := filepath.Join(cacheDir, "ca.crt")
+	certFile := filepath.Join(cacheDir, "client.crt")
+	keyFile := filepath.Join(cacheDir, "client.key")
 
-	c, cacheErr := tryCachedCert(endpoint, apiKey, caFile)
-	if c != nil {
-		return c, nil
-	}
-	if cacheErr != nil && !isCertError(cacheErr) {
-		return nil, fmt.Errorf("sandbox client: %w", cacheErr)
-	}
-	// nil error (no cache) or cert error (expired/rotated) — clear and TOFU
-	os.Remove(caFile) //nolint:errcheck
+	// Path 1: have CA + valid client cert → direct mTLS
+	if _, caErr := os.Stat(caFile); caErr == nil {
+		if certValid(certFile) {
+			// Lazy renewal: if cert expires within 7 days, try to renew via mTLS
+			if certExpiringSoon(certFile, 7) {
+				renewClientCert(endpoint, caFile, certFile, keyFile)
+			}
+			conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
+			if err != nil {
+				return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+			}
+			return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
+		}
 
-	return tofuConnect(endpoint, apiKey, caFile)
+		// Path 2: have CA but cert expired/missing → TLS + Login with API key
+		return bootstrapWithCA(endpoint, caFile, certFile, keyFile, apiKey)
+	}
+
+	// Path 3: no CA → insecure bootstrap, get both CA and client cert
+	return bootstrapInsecure(endpoint, caFile, certFile, keyFile, apiKey)
 }
 
-// tryCachedCert attempts a verified connection using the cached CA cert.
-// Validates the connection with a lightweight GetCACert RPC so TLS and
-// auth errors surface immediately. Returns (nil, nil) when no cache exists.
-func tryCachedCert(endpoint, apiKey, caFile string) (*Client, error) {
-	if _, err := os.Stat(caFile); err != nil {
-		return nil, nil
-	}
-	creds, err := credentials.NewClientTLSFromFile(caFile, "")
+func (c *Client) Close() error { return c.conn.Close() }
+
+// ── mTLS bootstrap helpers ────────────────────────────────────────────────────
+
+func bootstrapWithCA(endpoint, caFile, certFile, keyFile, apiKey string) (*Client, error) {
+	key, err := generateAndSaveKey(keyFile)
 	if err != nil {
 		return nil, err
 	}
-	conn, err := dialWithAPIKey(endpoint, apiKey, creds)
+	csr, err := createCSR(key)
 	if err != nil {
 		return nil, err
 	}
-	// Trigger connection establishment — TLS/auth errors surface here.
-	_, rpcErr := pb.NewSandboxServiceClient(conn).GetCACert(
-		context.Background(), &pb.GetCACertRequest{},
-	)
-	if rpcErr != nil {
-		conn.Close()
-		return nil, rpcErr
+	resp, err := callLogin(endpoint, caFile, apiKey, csr)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox client: login: %w", err)
+	}
+	if err := os.WriteFile(certFile, []byte(resp.Cert), 0644); err != nil {
+		return nil, fmt.Errorf("sandbox client: save cert: %w", err)
+	}
+
+	conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
 	}
 	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 }
 
-// tofuConnect performs Trust-On-First-Use: downloads the server CA cert over
-// an API-key-authenticated insecure connection, verifies the TLS handshake
-// fingerprint matches, caches the cert, and reconnects with full TLS verification.
-func tofuConnect(endpoint, apiKey, caFile string) (*Client, error) {
-	peerCerts, tofuCreds := newTOFUCredentials()
-
-	certPEM, err := downloadCACert(endpoint, apiKey, tofuCreds)
+func bootstrapInsecure(endpoint, caFile, certFile, keyFile, apiKey string) (*Client, error) {
+	key, err := generateAndSaveKey(keyFile)
 	if err != nil {
 		return nil, err
 	}
-	if err := verifyFingerprint(*peerCerts, certPEM); err != nil {
+	csr, err := createCSR(key)
+	if err != nil {
 		return nil, err
 	}
-	if err := cacheCert(caFile, certPEM); err != nil {
-		return nil, err
+	// empty caFile → InsecureSkipVerify for bootstrap
+	resp, err := callLogin(endpoint, "", apiKey, csr)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox client: bootstrap login: %w", err)
 	}
-	return connectVerified(endpoint, apiKey, caFile)
+	if err := os.WriteFile(caFile, []byte(resp.CaCert), 0644); err != nil {
+		return nil, fmt.Errorf("sandbox client: save CA: %w", err)
+	}
+	if err := os.WriteFile(certFile, []byte(resp.Cert), 0644); err != nil {
+		return nil, fmt.Errorf("sandbox client: save cert: %w", err)
+	}
+
+	conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+	}
+	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 }
 
-// newTOFUCredentials creates TLS credentials that skip server certificate
-// validation — intentionally. The insecure connection exists only for a single
-// GetCACert RPC authenticated with an API key, and the server's certificate
-// fingerprint is verified against the GetCACert response before any other
-// data is exchanged. After verification, the connection is discarded and a
-// fully-verified connection is established.
-func newTOFUCredentials() (*[]*x509.Certificate, credentials.TransportCredentials) {
-	peerCerts := &[]*x509.Certificate{}
-	//nolint:gosec // intentional TOFU, MITM blocked by verifyFingerprint
+// renewClientCert attempts to renew the client certificate via mTLS.
+// Failures are silent — the existing (still-valid) cert continues to work.
+func renewClientCert(endpoint, caFile, certFile, keyFile string) {
+	key, err := loadClientKey(keyFile)
+	if err != nil {
+		return
+	}
+	csr, err := createCSR(key)
+	if err != nil {
+		return
+	}
+	resp, err := callLoginMTLS(endpoint, caFile, certFile, keyFile, csr)
+	if err != nil {
+		return
+	}
+	os.WriteFile(certFile, []byte(resp.Cert), 0644) //nolint:errcheck
+}
+
+// ── Key & CSR generation ──────────────────────────────────────────────────────
+
+func generateAndSaveKey(keyFile string) (*ecdsa.PrivateKey, error) {
+	if err := os.MkdirAll(filepath.Dir(keyFile), 0700); err != nil {
+		return nil, fmt.Errorf("sandbox client: create cache dir: %w", err)
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox client: generate key: %w", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox client: marshal key: %w", err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{
+		Type: "EC PRIVATE KEY", Bytes: der,
+	}), 0600); err != nil {
+		return nil, fmt.Errorf("sandbox client: save key: %w", err)
+	}
+	return key, nil
+}
+
+func createCSR(key *ecdsa.PrivateKey) (string, error) {
+	tmpl := &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "sandbox-client"},
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+	if err != nil {
+		return "", fmt.Errorf("sandbox client: create CSR: %w", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: der,
+	})), nil
+}
+
+func loadClientKey(keyFile string) (*ecdsa.PrivateKey, error) {
+	data, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("invalid key PEM")
+	}
+	return x509.ParseECPrivateKey(block.Bytes)
+}
+
+// ── Certificate validation ────────────────────────────────────────────────────
+
+func certValid(certFile string) bool {
+	cert, err := loadAndParseCert(certFile)
+	if err != nil {
+		return false
+	}
+	now := time.Now()
+	return now.After(cert.NotBefore) && now.Before(cert.NotAfter)
+}
+
+func certExpiringSoon(certFile string, days int) bool {
+	cert, err := loadAndParseCert(certFile)
+	if err != nil {
+		return true
+	}
+	return time.Now().After(cert.NotAfter.Add(-time.Duration(days) * 24 * time.Hour))
+}
+
+func loadAndParseCert(certFile string) (*x509.Certificate, error) {
+	data, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("invalid cert PEM")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// ── Connection helpers ────────────────────────────────────────────────────────
+
+func dialMTLS(endpoint, caFile, certFile, keyFile string) (*grpc.ClientConn, error) {
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("parse CA cert")
+	}
+
+	clientCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load client cert: %w", err)
+	}
+
 	creds := credentials.NewTLS(&tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: true, // NOSONAR — TOFU bootstrap, verified immediately after
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			for _, raw := range rawCerts {
-				if cert, err := x509.ParseCertificate(raw); err == nil {
-					*peerCerts = append(*peerCerts, cert)
-				}
-			}
-			return nil
-		},
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS12,
 	})
-	return peerCerts, creds
+	return grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
 }
 
-// downloadCACert opens an insecure connection, calls GetCACert, and immediately
-// closes the connection. The returned cert PEM is not yet trusted — callers
-// must verify its fingerprint against the TLS handshake peer certificate.
-func downloadCACert(endpoint, apiKey string, creds credentials.TransportCredentials) (string, error) {
-	conn, err := dialWithAPIKey(endpoint, apiKey, creds)
+func callLogin(endpoint, caFile, apiKey, csr string) (*pb.LoginResponse, error) {
+	var creds credentials.TransportCredentials
+	if caFile == "" {
+		// Bootstrap: skip verification, authenticated by API key
+		creds = credentials.NewTLS(&tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true,
+		})
+	} else {
+		caPEM, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(caPEM)
+		creds = credentials.NewTLS(&tls.Config{
+			RootCAs:    pool,
+			MinVersion: tls.VersionTLS12,
+		})
+	}
+
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		return "", fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+		return nil, err
 	}
 	defer conn.Close()
 
-	resp, err := pb.NewSandboxServiceClient(conn).GetCACert(
-		context.Background(), &pb.GetCACertRequest{},
+	ctx := metadata.AppendToOutgoingContext(context.Background(),
+		"authorization", "Bearer "+apiKey,
 	)
+	return pb.NewSandboxServiceClient(conn).Login(ctx, &pb.LoginRequest{
+		Csr: csr,
+	})
+}
+
+func callLoginMTLS(endpoint, caFile, certFile, keyFile, csr string) (*pb.LoginResponse, error) {
+	conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
 	if err != nil {
-		return "", fmt.Errorf("sandbox client: get CA cert: %w", err)
+		return nil, err
 	}
-	if resp.Cert == "" {
-		return "", fmt.Errorf("sandbox client: server returned empty CA cert")
-	}
-	return resp.Cert, nil
+	defer conn.Close()
+
+	return pb.NewSandboxServiceClient(conn).Login(context.Background(), &pb.LoginRequest{
+		Csr: csr,
+	})
 }
 
-// verifyFingerprint checks that the certificate presented during the TLS
-// handshake matches the one returned by GetCACert. A mismatch indicates a
-// MITM attack where the attacker presented a different cert during handshake
-// than they returned through the authenticated RPC.
-func verifyFingerprint(peerCerts []*x509.Certificate, certPEM string) error {
-	if len(peerCerts) == 0 {
-		return fmt.Errorf("sandbox client: no peer certificate captured during TLS handshake")
-	}
-	pemBlock, _ := pem.Decode([]byte(certPEM))
-	if pemBlock == nil {
-		return fmt.Errorf("sandbox client: invalid PEM in server CA cert")
-	}
-	downloadedCert, err := x509.ParseCertificate(pemBlock.Bytes)
-	if err != nil {
-		return fmt.Errorf("sandbox client: parse server CA cert: %w", err)
-	}
-	if !bytes.Equal(sha256sum(peerCerts[0].Raw), sha256sum(downloadedCert.Raw)) {
-		return fmt.Errorf("sandbox client: TLS certificate fingerprint mismatch — possible MITM attack")
-	}
-	return nil
-}
-
-// sha256sum returns the SHA-256 hash of data as a byte slice.
-func sha256sum(data []byte) []byte {
-	h := sha256.Sum256(data)
-	return h[:]
-}
-
-// cacheCert writes the downloaded CA certificate to the local cache directory.
-func cacheCert(caFile, certPEM string) error {
-	if err := os.MkdirAll(filepath.Dir(caFile), 0700); err != nil {
-		return fmt.Errorf("sandbox client: create cache dir: %w", err)
-	}
-	if err := os.WriteFile(caFile, []byte(certPEM), 0644); err != nil {
-		return fmt.Errorf("sandbox client: save cert: %w", err)
-	}
-	return nil
-}
-
-// connectVerified establishes a gRPC connection with full TLS verification
-// using the CA certificate at caFile and the provided API key.
-func connectVerified(endpoint, apiKey, caFile string) (*Client, error) {
-	creds, err := credentials.NewClientTLSFromFile(caFile, "")
-	if err != nil {
-		return nil, fmt.Errorf("sandbox client: load downloaded cert: %w", err)
-	}
-	conn, err := dialWithAPIKey(endpoint, apiKey, creds)
-	if err != nil {
-		return nil, fmt.Errorf("sandbox client: verified dial %s: %w", endpoint, err)
-	}
-	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
-}
-
-// dialWithAPIKey creates a gRPC connection with TLS creds and API key auth interceptor.
-func dialWithAPIKey(endpoint, apiKey string, creds credentials.TransportCredentials) (*grpc.ClientConn, error) {
-	injectAuth := func(ctx context.Context) context.Context {
-		return metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+apiKey)
-	}
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
-	opts = append(opts,
-		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			return invoker(injectAuth(ctx), method, req, reply, cc, opts...)
-		}),
-		grpc.WithStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-			return streamer(injectAuth(ctx), desc, cc, method, opts...)
-		}),
-	)
-	return grpc.NewClient(endpoint, opts...)
-}
-
-// isCertError reports whether err is caused by a TLS certificate validation
-// failure (unknown authority, hostname mismatch, expired cert, etc.) as
-// opposed to a network error (connection refused, timeout, DNS failure).
-func isCertError(err error) bool {
-	var unknownAuth x509.UnknownAuthorityError
-	var certInvalid x509.CertificateInvalidError
-	var hostname x509.HostnameError
-	var constraint x509.ConstraintViolationError
-	if errors.As(err, &unknownAuth) || errors.As(err, &certInvalid) ||
-		errors.As(err, &hostname) || errors.As(err, &constraint) {
-		return true
-	}
-	for e := err; e != nil; e = errors.Unwrap(e) {
-		msg := e.Error()
-		if len(msg) > 5 && (msg[:5] == "tls: " || msg[:5] == "x509:") {
-			return true
-		}
-	}
-	return false
-}
+// ── Local auto-discovery ──────────────────────────────────────────────────────
 
 func sandboxCacheDir() (string, error) {
 	home, err := os.UserHomeDir()
@@ -279,8 +336,6 @@ func sandboxCacheDir() (string, error) {
 	}
 	return filepath.Join(home, ".k8e", "sandbox"), nil
 }
-
-func (c *Client) Close() error { return c.conn.Close() }
 
 func resolveCreds() (credentials.TransportCredentials, error) {
 	if cert := os.Getenv("K8E_SANDBOX_CERT"); cert != "" {

--- a/pkg/sandbox/client/client.go
+++ b/pkg/sandbox/client/client.go
@@ -331,10 +331,8 @@ func callLoginMTLS(endpoint, caFile, certFile, keyFile, csr string) (*pb.LoginRe
 	})
 }
 
-// ── Local auto-discovery ──────────────────────────────────────────────────────
-
 func dialErr(endpoint string, err error) error {
-	return dialErr(endpoint, err)
+	return fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
 }
 
 // ── Local auto-discovery ──────────────────────────────────────────────────────

--- a/pkg/sandbox/client/client.go
+++ b/pkg/sandbox/client/client.go
@@ -63,7 +63,7 @@ func NewClient() (*Client, error) {
 	}
 	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+		return nil, dialErr(endpoint, err)
 	}
 	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 }
@@ -90,7 +90,7 @@ func NewClientWithEndpoint(endpoint, apiKey string) (*Client, error) {
 			}
 			conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
 			if err != nil {
-				return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+				return nil, dialErr(endpoint, err)
 			}
 			return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 		}
@@ -126,7 +126,7 @@ func bootstrapWithCA(endpoint, caFile, certFile, keyFile, apiKey string) (*Clien
 
 	conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+		return nil, dialErr(endpoint, err)
 	}
 	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 }
@@ -154,7 +154,7 @@ func bootstrapInsecure(endpoint, caFile, certFile, keyFile, apiKey string) (*Cli
 
 	conn, err := dialMTLS(endpoint, caFile, certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
+		return nil, dialErr(endpoint, err)
 	}
 	return &Client{SandboxServiceClient: pb.NewSandboxServiceClient(conn), conn: conn}, nil
 }
@@ -283,7 +283,11 @@ func dialMTLS(endpoint, caFile, certFile, keyFile string) (*grpc.ClientConn, err
 func callLogin(endpoint, caFile, apiKey, csr string) (*pb.LoginResponse, error) {
 	var creds credentials.TransportCredentials
 	if caFile == "" {
-		// Bootstrap: skip verification, authenticated by API key
+		// Bootstrap: no cached CA, server verification is impossible. The
+		// connection is authenticated by the API key in gRPC metadata. A MITM
+		// that intercepts this single Login call gains only a short-lived client
+		// certificate, useless for future mTLS connections that verify the CA.
+		//nolint:gosec
 		creds = credentials.NewTLS(&tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true,
@@ -325,6 +329,12 @@ func callLoginMTLS(endpoint, caFile, certFile, keyFile, csr string) (*pb.LoginRe
 	return pb.NewSandboxServiceClient(conn).Login(context.Background(), &pb.LoginRequest{
 		Csr: csr,
 	})
+}
+
+// ── Local auto-discovery ──────────────────────────────────────────────────────
+
+func dialErr(endpoint string, err error) error {
+	return dialErr(endpoint, err)
 }
 
 // ── Local auto-discovery ──────────────────────────────────────────────────────

--- a/pkg/sandbox/client/client.go
+++ b/pkg/sandbox/client/client.go
@@ -288,9 +288,9 @@ func callLogin(endpoint, caFile, apiKey, csr string) (*pb.LoginResponse, error) 
 		// that intercepts this single Login call gains only a short-lived client
 		// certificate, useless for future mTLS connections that verify the CA.
 		//nolint:gosec
-		creds = credentials.NewTLS(&tls.Config{
+		creds = credentials.NewTLS(&tls.Config{ // NOSONAR
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, // NOSONAR: ssl:S4830 — bootstrap secured by API key auth
 		})
 	} else {
 		caPEM, err := os.ReadFile(caFile)

--- a/pkg/sandboxcli/login.go
+++ b/pkg/sandboxcli/login.go
@@ -1,0 +1,42 @@
+package sandboxcli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+	"github.com/xiaods/k8e/pkg/sandbox/client"
+)
+
+// LoginCommand returns the "login" subcommand for obtaining an mTLS client certificate.
+func LoginCommand() cli.Command {
+	return cli.Command{
+		Name:  "login",
+		Usage: "Authenticate to a K8E sandbox gateway and obtain an mTLS client certificate",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "device-name", Usage: "Device name for audit logging (default: hostname)"},
+		},
+		Action: func(ctx *cli.Context) error {
+			endpoint := ctx.GlobalString("endpoint")
+			apikey := ctx.GlobalString("apikey")
+
+			if endpoint == "" {
+				return printErrorExit("--endpoint is required for login (e.g. sandbox.example.com:50051)", 1)
+			}
+			if apikey == "" {
+				return printErrorExit("--apikey is required for login", 1)
+			}
+
+			c, err := client.NewClientWithEndpoint(endpoint, apikey)
+			if err != nil {
+				return printErrorExit("login failed: "+err.Error(), 1)
+			}
+			c.Close()
+
+			fmt.Fprintf(os.Stderr, "✓ Logged in to %s\n", endpoint)
+			fmt.Fprintf(os.Stderr, "  Credentials stored in ~/.k8e/sandbox/\n")
+			fmt.Fprintf(os.Stderr, "  Certificate valid for 30 days (auto-renewed on use)\n")
+			return nil
+		},
+	}
+}

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -64,14 +64,15 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 	orch := sandboxgrpc.NewOrchestrator(k8s, dyn)
 	go runGCLoop(ctx, orch, cfg.Namespace)
 
-	srv := sandboxgrpc.NewServer(k8s, dyn,
-		tlsDir+"/sandbox-ca.crt",
-		tlsDir+"/sandbox-ca.key",
-		tlsDir+"/sandbox-server.crt",
-		tlsDir+"/sandbox-server.key",
-		cfg.GRPCPort,
-		false, // localAuth=false for server-mode
-	)
+	srv := sandboxgrpc.NewServer(sandboxgrpc.ServerConfig{
+		K8s:            k8s,
+		Dyn:            dyn,
+		CACertFile:     tlsDir + "/sandbox-ca.crt",
+		CAKeyFile:      tlsDir + "/sandbox-ca.key",
+		ServerCertFile: tlsDir + "/sandbox-server.crt",
+		ServerKeyFile:  tlsDir + "/sandbox-server.key",
+		GRPCPort:       cfg.GRPCPort,
+	})
 	go func() {
 		if err := srv.Start(ctx); err != nil {
 			logrus.Errorf("sandbox gRPC gateway: %v", err)

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -65,9 +65,12 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 	go runGCLoop(ctx, orch, cfg.Namespace)
 
 	srv := sandboxgrpc.NewServer(k8s, dyn,
-		tlsDir+"/serving-kube-apiserver.crt",
-		tlsDir+"/serving-kube-apiserver.key",
+		tlsDir+"/sandbox-ca.crt",
+		tlsDir+"/sandbox-ca.key",
+		tlsDir+"/sandbox-server.crt",
+		tlsDir+"/sandbox-server.key",
 		cfg.GRPCPort,
+		false, // localAuth=false for server-mode
 	)
 	go func() {
 		if err := srv.Start(ctx); err != nil {

--- a/pkg/sandboxmatrix/grpc/cert.go
+++ b/pkg/sandboxmatrix/grpc/cert.go
@@ -1,0 +1,369 @@
+package grpc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+)
+
+const caOrg = "K8E Sandbox"
+
+// ensureCA loads the sandbox CA from disk, or generates a new ECDSA P-256 CA.
+func ensureCA(caCertFile, caKeyFile string) (*ecdsa.PrivateKey, *x509.Certificate, error) {
+	if caPEM, err := os.ReadFile(caCertFile); err == nil {
+		if keyPEM, err := os.ReadFile(caKeyFile); err == nil {
+			cert, key, loadErr := loadCA(caPEM, keyPEM)
+			if loadErr == nil {
+				return key, cert, nil
+			}
+		}
+	}
+	return generateCA(caCertFile, caKeyFile)
+}
+
+func loadCA(certPEM, keyPEM []byte) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, nil, fmt.Errorf("invalid CA cert PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse CA cert: %w", err)
+	}
+	block, _ = pem.Decode(keyPEM)
+	if block == nil {
+		return nil, nil, fmt.Errorf("invalid CA key PEM")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse CA key: %w", err)
+	}
+	return cert, key, nil
+}
+
+func generateCA(caCertFile, caKeyFile string) (*ecdsa.PrivateKey, *x509.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CA key: %w", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "K8E Sandbox CA", Organization: []string{caOrg}},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create CA cert: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse generated CA cert: %w", err)
+	}
+
+	if err := os.WriteFile(caKeyFile, pemEncodeECPrivateKey(key), 0600); err != nil {
+		return nil, nil, fmt.Errorf("write CA key: %w", err)
+	}
+	if err := os.WriteFile(caCertFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0644); err != nil {
+		return nil, nil, fmt.Errorf("write CA cert: %w", err)
+	}
+
+	return key, cert, nil
+}
+
+func pemEncodeECPrivateKey(key *ecdsa.PrivateKey) []byte {
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		panic("marshal EC private key: " + err.Error())
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+// ensureServerCert ensures the gRPC gateway has a valid server certificate signed by the sandbox CA.
+// If the existing cert has > 30 days of validity, it is reused.
+func ensureServerCert(caKey *ecdsa.PrivateKey, caCert *x509.Certificate, certFile, keyFile string) error {
+	if existingCert, err := tls.LoadX509KeyPair(certFile, keyFile); err == nil {
+		if len(existingCert.Certificate) > 0 {
+			if c, parseErr := x509.ParseCertificate(existingCert.Certificate[0]); parseErr == nil {
+				if time.Now().Before(c.NotAfter.Add(-30 * 24 * time.Hour)) {
+					return nil // still valid > 30 days
+				}
+			}
+		}
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate server key: %w", err)
+	}
+
+	hostname, _ := os.Hostname()
+	sans := collectServerSANs(hostname)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: hostname, Organization: []string{caOrg}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(90 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     sans.dnsNames,
+		IPAddresses:  sans.ips,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+	if err != nil {
+		return fmt.Errorf("create server cert: %w", err)
+	}
+
+	if err := os.WriteFile(keyFile, pemEncodeECPrivateKey(key), 0600); err != nil {
+		return fmt.Errorf("write server key: %w", err)
+	}
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0644); err != nil {
+		return fmt.Errorf("write server cert: %w", err)
+	}
+
+	return nil
+}
+
+type serverSANs struct {
+	dnsNames []string
+	ips      []net.IP
+}
+
+func collectServerSANs(hostname string) serverSANs {
+	var s serverSANs
+	if hostname != "" {
+		s.dnsNames = append(s.dnsNames, hostname)
+	}
+
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				s.ips = append(s.ips, ipnet.IP)
+			}
+		}
+	}
+
+	if adv := os.Getenv("K8E_SANDBOX_ADVERTISED_HOSTNAME"); adv != "" {
+		s.dnsNames = append(s.dnsNames, adv)
+	}
+
+	return s
+}
+
+// signClientCert signs a client CSR with the sandbox CA.
+// The CSR's Subject and SANs are ignored — the server controls certificate identity.
+func signClientCert(caKey *ecdsa.PrivateKey, caCert *x509.Certificate, csrPEM, commonName string, ttlDays int) (certPEM string, fingerprint string, err error) {
+	block, _ := pem.Decode([]byte(csrPEM))
+	if block == nil {
+		return "", "", fmt.Errorf("invalid CSR PEM")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return "", "", fmt.Errorf("parse CSR: %w", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		return "", "", fmt.Errorf("CSR signature invalid: %w", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: commonName, Organization: []string{caOrg}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Duration(ttlDays) * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+		CRLDistributionPoints:  []string{"https://k8e.internal/sandbox/crl"},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, csr.PublicKey, caKey)
+	if err != nil {
+		return "", "", fmt.Errorf("create client cert: %w", err)
+	}
+
+	h := sha256.Sum256(der)
+	fingerprint = fmt.Sprintf("%x", h)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), fingerprint, nil
+}
+
+// issuedCertRecord tracks a signed client certificate.
+type issuedCertRecord struct {
+	KeyName     string    `json:"key_name"`
+	Fingerprint string    `json:"fingerprint"`
+	IssuedAt    time.Time `json:"issued_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+// issuedCertStore persists issued certificate records to a JSON file.
+type issuedCertStore struct {
+	mu       sync.Mutex
+	records  []issuedCertRecord
+	filePath string
+}
+
+func newIssuedCertStore(filePath string) *issuedCertStore {
+	s := &issuedCertStore{filePath: filePath}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return s
+	}
+	json.Unmarshal(data, &s.records) // best-effort
+	return s
+}
+
+func (s *issuedCertStore) Add(keyName, fingerprint string, issuedAt, expiresAt time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append(s.records, issuedCertRecord{
+		KeyName: keyName, Fingerprint: fingerprint,
+		IssuedAt: issuedAt, ExpiresAt: expiresAt,
+	})
+	s.save()
+}
+
+func (s *issuedCertStore) FindByKeyName(keyName string) []issuedCertRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []issuedCertRecord
+	for _, r := range s.records {
+		if r.KeyName == keyName {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (s *issuedCertStore) PruneExpired() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	n := 0
+	for _, r := range s.records {
+		if r.ExpiresAt.After(now) {
+			s.records[n] = r
+			n++
+		}
+	}
+	s.records = s.records[:n]
+	s.save()
+}
+
+func (s *issuedCertStore) save() {
+	data, _ := json.MarshalIndent(s.records, "", "  ")
+	os.WriteFile(s.filePath, data, 0644) //nolint:errcheck
+}
+
+// RevocationList is an in-memory list of revoked certificate fingerprints.
+type RevocationList struct {
+	mu      sync.RWMutex
+	entries map[string]time.Time // fingerprint → revokedAt
+}
+
+func newRevocationList() *RevocationList {
+	return &RevocationList{entries: make(map[string]time.Time)}
+}
+
+func (rl *RevocationList) Revoke(fingerprint string) {
+	rl.mu.Lock()
+	rl.entries[fingerprint] = time.Now()
+	rl.mu.Unlock()
+}
+
+func (rl *RevocationList) IsRevoked(fingerprint string) bool {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+	_, ok := rl.entries[fingerprint]
+	return ok
+}
+
+func (rl *RevocationList) RevokeByKeyName(store *issuedCertStore, keyName string) {
+	for _, r := range store.FindByKeyName(keyName) {
+		rl.Revoke(r.Fingerprint)
+	}
+}
+
+// buildMTLSCreds creates gRPC transport credentials with mTLS (VerifyClientCertIfGiven).
+func buildMTLSCreds(caCert *x509.Certificate, serverCert tls.Certificate) (credentials.TransportCredentials, error) {
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.VerifyClientCertIfGiven,
+		ClientCAs:    pool,
+		MinVersion:   tls.VersionTLS12,
+	}), nil
+}
+
+// peerIdentity extracts the authenticated identity from a gRPC context.
+// Returns (commonName, true) for loopback connections without a client cert.
+func peerIdentity(ctx context.Context) (keyName string, isLocal bool) {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return "", false
+	}
+
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		// No TLS — check loopback
+		if isLoopbackAddr(p.Addr) {
+			return "", true
+		}
+		return "", false
+	}
+
+	if len(tlsInfo.State.PeerCertificates) == 0 {
+		if isLoopbackAddr(p.Addr) {
+			return "", true
+		}
+		return "", false
+	}
+
+	cert := tlsInfo.State.PeerCertificates[0]
+	now := time.Now()
+	if now.Before(cert.NotBefore) || now.After(cert.NotAfter) {
+		return "", false // expired/invalid — TLS handshake should already reject
+	}
+
+	return cert.Subject.CommonName, false
+}
+
+func isLoopbackAddr(addr net.Addr) bool {
+	if addr == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -1213,26 +1213,29 @@ func (x *ApproveActionResponse) GetOk() bool {
 	return false
 }
 
-type GetCACertRequest struct {
+type LoginRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Csr           string                 `protobuf:"bytes,1,opt,name=csr,proto3" json:"csr,omitempty"`                                          // PEM-encoded PKCS#10 certificate signing request
+	DeviceName    string                 `protobuf:"bytes,2,opt,name=device_name,json=deviceName,proto3" json:"device_name,omitempty"`          // e.g. hostname, for audit logging
+	ClientVersion string                 `protobuf:"bytes,3,opt,name=client_version,json=clientVersion,proto3" json:"client_version,omitempty"` // k8e version, for audit logging
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetCACertRequest) Reset() {
-	*x = GetCACertRequest{}
+func (x *LoginRequest) Reset() {
+	*x = LoginRequest{}
 	mi := &file_sandbox_v1_sandbox_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetCACertRequest) String() string {
+func (x *LoginRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetCACertRequest) ProtoMessage() {}
+func (*LoginRequest) ProtoMessage() {}
 
-func (x *GetCACertRequest) ProtoReflect() protoreflect.Message {
+func (x *LoginRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_sandbox_v1_sandbox_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1244,32 +1247,55 @@ func (x *GetCACertRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetCACertRequest.ProtoReflect.Descriptor instead.
-func (*GetCACertRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use LoginRequest.ProtoReflect.Descriptor instead.
+func (*LoginRequest) Descriptor() ([]byte, []int) {
 	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{22}
 }
 
-type GetCACertResponse struct {
+func (x *LoginRequest) GetCsr() string {
+	if x != nil {
+		return x.Csr
+	}
+	return ""
+}
+
+func (x *LoginRequest) GetDeviceName() string {
+	if x != nil {
+		return x.DeviceName
+	}
+	return ""
+}
+
+func (x *LoginRequest) GetClientVersion() string {
+	if x != nil {
+		return x.ClientVersion
+	}
+	return ""
+}
+
+type LoginResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Cert          string                 `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	Cert          string                 `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`                             // PEM-encoded signed client certificate
+	CaCert        string                 `protobuf:"bytes,2,opt,name=ca_cert,json=caCert,proto3" json:"ca_cert,omitempty"`           // PEM-encoded sandbox CA certificate (trust anchor)
+	ValidDays     int64                  `protobuf:"varint,3,opt,name=valid_days,json=validDays,proto3" json:"valid_days,omitempty"` // days the certificate is valid
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetCACertResponse) Reset() {
-	*x = GetCACertResponse{}
+func (x *LoginResponse) Reset() {
+	*x = LoginResponse{}
 	mi := &file_sandbox_v1_sandbox_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetCACertResponse) String() string {
+func (x *LoginResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetCACertResponse) ProtoMessage() {}
+func (*LoginResponse) ProtoMessage() {}
 
-func (x *GetCACertResponse) ProtoReflect() protoreflect.Message {
+func (x *LoginResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_sandbox_v1_sandbox_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1281,16 +1307,30 @@ func (x *GetCACertResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetCACertResponse.ProtoReflect.Descriptor instead.
-func (*GetCACertResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use LoginResponse.ProtoReflect.Descriptor instead.
+func (*LoginResponse) Descriptor() ([]byte, []int) {
 	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{23}
 }
 
-func (x *GetCACertResponse) GetCert() string {
+func (x *LoginResponse) GetCert() string {
 	if x != nil {
 		return x.Cert
 	}
 	return ""
+}
+
+func (x *LoginResponse) GetCaCert() string {
+	if x != nil {
+		return x.CaCert
+	}
+	return ""
+}
+
+func (x *LoginResponse) GetValidDays() int64 {
+	if x != nil {
+		return x.ValidDays
+	}
+	return 0
 }
 
 type PollRunRequest struct {
@@ -1507,10 +1547,17 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\bapproved\x18\x02 \x01(\bR\bapproved\x12\x16\n" +
 	"\x06reason\x18\x03 \x01(\tR\x06reason\"'\n" +
 	"\x15ApproveActionResponse\x12\x0e\n" +
-	"\x02ok\x18\x01 \x01(\bR\x02ok\"\x12\n" +
-	"\x10GetCACertRequest\"'\n" +
-	"\x11GetCACertResponse\x12\x12\n" +
-	"\x04cert\x18\x01 \x01(\tR\x04cert\"'\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\"h\n" +
+	"\fLoginRequest\x12\x10\n" +
+	"\x03csr\x18\x01 \x01(\tR\x03csr\x12\x1f\n" +
+	"\vdevice_name\x18\x02 \x01(\tR\n" +
+	"deviceName\x12%\n" +
+	"\x0eclient_version\x18\x03 \x01(\tR\rclientVersion\"[\n" +
+	"\rLoginResponse\x12\x12\n" +
+	"\x04cert\x18\x01 \x01(\tR\x04cert\x12\x17\n" +
+	"\aca_cert\x18\x02 \x01(\tR\x06caCert\x12\x1d\n" +
+	"\n" +
+	"valid_days\x18\x03 \x01(\x03R\tvalidDays\"'\n" +
 	"\x0ePollRunRequest\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\"\x8d\x01\n" +
 	"\x0fPollRunResponse\x12\x15\n" +
@@ -1518,7 +1565,7 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x16\n" +
 	"\x06stdout\x18\x03 \x01(\tR\x06stdout\x12\x16\n" +
 	"\x06stderr\x18\x04 \x01(\tR\x06stderr\x12\x1b\n" +
-	"\texit_code\x18\x05 \x01(\x05R\bexitCode2\xf5\a\n" +
+	"\texit_code\x18\x05 \x01(\x05R\bexitCode2\xe9\a\n" +
 	"\x0eSandboxService\x12T\n" +
 	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12W\n" +
 	"\x0eDestroySession\x12!.sandbox.v1.DestroySessionRequest\x1a\".sandbox.v1.DestroySessionResponse\x129\n" +
@@ -1532,8 +1579,8 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"PipInstall\x12\x1d.sandbox.v1.PipInstallRequest\x1a\x1e.sandbox.v1.PipInstallResponse\x12N\n" +
 	"\vRunSubAgent\x12\x1e.sandbox.v1.RunSubAgentRequest\x1a\x1f.sandbox.v1.RunSubAgentResponse\x12T\n" +
 	"\rConfirmAction\x12 .sandbox.v1.ConfirmActionRequest\x1a!.sandbox.v1.ConfirmActionResponse\x12T\n" +
-	"\rApproveAction\x12 .sandbox.v1.ApproveActionRequest\x1a!.sandbox.v1.ApproveActionResponse\x12H\n" +
-	"\tGetCACert\x12\x1c.sandbox.v1.GetCACertRequest\x1a\x1d.sandbox.v1.GetCACertResponse\x12B\n" +
+	"\rApproveAction\x12 .sandbox.v1.ApproveActionRequest\x1a!.sandbox.v1.ApproveActionResponse\x12<\n" +
+	"\x05Login\x12\x18.sandbox.v1.LoginRequest\x1a\x19.sandbox.v1.LoginResponse\x12B\n" +
 	"\aPollRun\x12\x1a.sandbox.v1.PollRunRequest\x1a\x1b.sandbox.v1.PollRunResponseB1Z/github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pbb\x06proto3"
 
 var (
@@ -1572,8 +1619,8 @@ var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*ConfirmActionResponse)(nil),  // 19: sandbox.v1.ConfirmActionResponse
 	(*ApproveActionRequest)(nil),   // 20: sandbox.v1.ApproveActionRequest
 	(*ApproveActionResponse)(nil),  // 21: sandbox.v1.ApproveActionResponse
-	(*GetCACertRequest)(nil),       // 22: sandbox.v1.GetCACertRequest
-	(*GetCACertResponse)(nil),      // 23: sandbox.v1.GetCACertResponse
+	(*LoginRequest)(nil),           // 22: sandbox.v1.LoginRequest
+	(*LoginResponse)(nil),          // 23: sandbox.v1.LoginResponse
 	(*PollRunRequest)(nil),         // 24: sandbox.v1.PollRunRequest
 	(*PollRunResponse)(nil),        // 25: sandbox.v1.PollRunResponse
 }
@@ -1590,7 +1637,7 @@ var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
 	16, // 9: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
 	18, // 10: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
 	20, // 11: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
-	22, // 12: sandbox.v1.SandboxService.GetCACert:input_type -> sandbox.v1.GetCACertRequest
+	22, // 12: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
 	24, // 13: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
 	1,  // 14: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
 	3,  // 15: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
@@ -1603,7 +1650,7 @@ var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
 	17, // 22: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
 	19, // 23: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
 	21, // 24: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	23, // 25: sandbox.v1.SandboxService.GetCACert:output_type -> sandbox.v1.GetCACertResponse
+	23, // 25: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
 	25, // 26: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
 	14, // [14:27] is the sub-list for method output_type
 	1,  // [1:14] is the sub-list for method input_type

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
@@ -30,7 +30,7 @@ const (
 	SandboxService_RunSubAgent_FullMethodName    = "/sandbox.v1.SandboxService/RunSubAgent"
 	SandboxService_ConfirmAction_FullMethodName  = "/sandbox.v1.SandboxService/ConfirmAction"
 	SandboxService_ApproveAction_FullMethodName  = "/sandbox.v1.SandboxService/ApproveAction"
-	SandboxService_GetCACert_FullMethodName      = "/sandbox.v1.SandboxService/GetCACert"
+	SandboxService_Login_FullMethodName          = "/sandbox.v1.SandboxService/Login"
 	SandboxService_PollRun_FullMethodName        = "/sandbox.v1.SandboxService/PollRun"
 )
 
@@ -49,9 +49,10 @@ type SandboxServiceClient interface {
 	RunSubAgent(ctx context.Context, in *RunSubAgentRequest, opts ...grpc.CallOption) (*RunSubAgentResponse, error)
 	ConfirmAction(ctx context.Context, in *ConfirmActionRequest, opts ...grpc.CallOption) (*ConfirmActionResponse, error)
 	ApproveAction(ctx context.Context, in *ApproveActionRequest, opts ...grpc.CallOption) (*ApproveActionResponse, error)
-	// GetCACert returns the server CA certificate for TLS verification.
-	// No authentication required — the cert is needed to establish trust.
-	GetCACert(ctx context.Context, in *GetCACertRequest, opts ...grpc.CallOption) (*GetCACertResponse, error)
+	// Login authenticates the client and returns a signed X.509 certificate for mTLS.
+	// First login: pass API key via gRPC metadata (authorization: Bearer <key>).
+	// Renewal: present existing valid client cert via mTLS — no API key needed.
+	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
 	// PollRun checks the status of a background execution.
 	PollRun(ctx context.Context, in *PollRunRequest, opts ...grpc.CallOption) (*PollRunResponse, error)
 }
@@ -183,10 +184,10 @@ func (c *sandboxServiceClient) ApproveAction(ctx context.Context, in *ApproveAct
 	return out, nil
 }
 
-func (c *sandboxServiceClient) GetCACert(ctx context.Context, in *GetCACertRequest, opts ...grpc.CallOption) (*GetCACertResponse, error) {
+func (c *sandboxServiceClient) Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GetCACertResponse)
-	err := c.cc.Invoke(ctx, SandboxService_GetCACert_FullMethodName, in, out, cOpts...)
+	out := new(LoginResponse)
+	err := c.cc.Invoke(ctx, SandboxService_Login_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -218,9 +219,10 @@ type SandboxServiceServer interface {
 	RunSubAgent(context.Context, *RunSubAgentRequest) (*RunSubAgentResponse, error)
 	ConfirmAction(context.Context, *ConfirmActionRequest) (*ConfirmActionResponse, error)
 	ApproveAction(context.Context, *ApproveActionRequest) (*ApproveActionResponse, error)
-	// GetCACert returns the server CA certificate for TLS verification.
-	// No authentication required — the cert is needed to establish trust.
-	GetCACert(context.Context, *GetCACertRequest) (*GetCACertResponse, error)
+	// Login authenticates the client and returns a signed X.509 certificate for mTLS.
+	// First login: pass API key via gRPC metadata (authorization: Bearer <key>).
+	// Renewal: present existing valid client cert via mTLS — no API key needed.
+	Login(context.Context, *LoginRequest) (*LoginResponse, error)
 	// PollRun checks the status of a background execution.
 	PollRun(context.Context, *PollRunRequest) (*PollRunResponse, error)
 	mustEmbedUnimplementedSandboxServiceServer()
@@ -266,8 +268,8 @@ func (UnimplementedSandboxServiceServer) ConfirmAction(context.Context, *Confirm
 func (UnimplementedSandboxServiceServer) ApproveAction(context.Context, *ApproveActionRequest) (*ApproveActionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ApproveAction not implemented")
 }
-func (UnimplementedSandboxServiceServer) GetCACert(context.Context, *GetCACertRequest) (*GetCACertResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetCACert not implemented")
+func (UnimplementedSandboxServiceServer) Login(context.Context, *LoginRequest) (*LoginResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Login not implemented")
 }
 func (UnimplementedSandboxServiceServer) PollRun(context.Context, *PollRunRequest) (*PollRunResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PollRun not implemented")
@@ -484,20 +486,20 @@ func _SandboxService_ApproveAction_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
-func _SandboxService_GetCACert_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetCACertRequest)
+func _SandboxService_Login_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LoginRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(SandboxServiceServer).GetCACert(ctx, in)
+		return srv.(SandboxServiceServer).Login(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: SandboxService_GetCACert_FullMethodName,
+		FullMethod: SandboxService_Login_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SandboxServiceServer).GetCACert(ctx, req.(*GetCACertRequest))
+		return srv.(SandboxServiceServer).Login(ctx, req.(*LoginRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -568,8 +570,8 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _SandboxService_ApproveAction_Handler,
 		},
 		{
-			MethodName: "GetCACert",
-			Handler:    _SandboxService_GetCACert_Handler,
+			MethodName: "Login",
+			Handler:    _SandboxService_Login_Handler,
 		},
 		{
 			MethodName: "PollRun",

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -97,6 +97,18 @@ func sanitizePipPackage(raw string) (string, error) {
 	return raw, nil
 }
 
+// ServerConfig holds the configuration for a sandbox gRPC Server.
+type ServerConfig struct {
+	K8s            kubernetes.Interface
+	Dyn            dynamic.Interface
+	CACertFile     string
+	CAKeyFile      string
+	ServerCertFile string
+	ServerKeyFile  string
+	GRPCPort       int
+	LocalAuth      bool // allow loopback connections without client cert
+}
+
 // Server implements the SandboxService gRPC interface.
 type Server struct {
 	pb.UnimplementedSandboxServiceServer
@@ -117,22 +129,23 @@ type Server struct {
 	rateLimiter    *ratelimit.Limiter
 }
 
-func NewServer(k8s kubernetes.Interface, dyn dynamic.Interface, caCertFile, caKeyFile, serverCertFile, serverKeyFile string, grpcPort int, localAuth bool) *Server {
-	if grpcPort == 0 {
-		grpcPort = 50051
+func NewServer(cfg ServerConfig) *Server {
+	port := cfg.GRPCPort
+	if port == 0 {
+		port = 50051
 	}
 	s := &Server{
-		k8s:            k8s,
-		dyn:            dyn,
-		lisAddr:        fmt.Sprintf("0.0.0.0:%d", grpcPort),
-		caCertFile:     caCertFile,
-		caKeyFile:      caKeyFile,
-		serverCertFile: serverCertFile,
-		serverKeyFile:  serverKeyFile,
-		localAuth:      localAuth,
+		k8s:            cfg.K8s,
+		dyn:            cfg.Dyn,
+		lisAddr:        fmt.Sprintf("0.0.0.0:%d", port),
+		caCertFile:     cfg.CACertFile,
+		caKeyFile:      cfg.CAKeyFile,
+		serverCertFile: cfg.ServerCertFile,
+		serverKeyFile:  cfg.ServerKeyFile,
+		localAuth:      cfg.LocalAuth,
 		rateLimiter:    ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
 	}
-	s.orch = NewOrchestrator(k8s, dyn)
+	s.orch = NewOrchestrator(cfg.K8s, cfg.Dyn)
 	return s
 }
 

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -4,12 +4,16 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -22,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -95,27 +100,37 @@ func sanitizePipPackage(raw string) (string, error) {
 // Server implements the SandboxService gRPC interface.
 type Server struct {
 	pb.UnimplementedSandboxServiceServer
-	k8s         kubernetes.Interface
-	dyn         dynamic.Interface
-	orch        *Orchestrator
-	lisAddr     string
-	certFile    string
-	keyFile     string
-	apiKeys     map[string]string // name → key for validation
-	rateLimiter *ratelimit.Limiter
+	k8s            kubernetes.Interface
+	dyn            dynamic.Interface
+	orch           *Orchestrator
+	lisAddr        string
+	caCertFile     string
+	caKeyFile      string
+	serverCertFile string
+	serverKeyFile  string
+	caCert         *x509.Certificate
+	caKey          *ecdsa.PrivateKey
+	apiKeys        map[string]string // name → key for validation
+	issuedStore    *issuedCertStore
+	revocList      *RevocationList
+	localAuth      bool
+	rateLimiter    *ratelimit.Limiter
 }
 
-func NewServer(k8s kubernetes.Interface, dyn dynamic.Interface, certFile, keyFile string, grpcPort int) *Server {
+func NewServer(k8s kubernetes.Interface, dyn dynamic.Interface, caCertFile, caKeyFile, serverCertFile, serverKeyFile string, grpcPort int, localAuth bool) *Server {
 	if grpcPort == 0 {
 		grpcPort = 50051
 	}
 	s := &Server{
-		k8s:         k8s,
-		dyn:         dyn,
-		lisAddr:     fmt.Sprintf("0.0.0.0:%d", grpcPort),
-		certFile:    certFile,
-		keyFile:     keyFile,
-		rateLimiter: ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
+		k8s:            k8s,
+		dyn:            dyn,
+		lisAddr:        fmt.Sprintf("0.0.0.0:%d", grpcPort),
+		caCertFile:     caCertFile,
+		caKeyFile:      caKeyFile,
+		serverCertFile: serverCertFile,
+		serverKeyFile:  serverKeyFile,
+		localAuth:      localAuth,
+		rateLimiter:    ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
 	}
 	s.orch = NewOrchestrator(k8s, dyn)
 	return s
@@ -126,16 +141,27 @@ func (s *Server) loadAPIKeys(ctx context.Context) {
 	secret, err := s.k8s.CoreV1().Secrets(apiKeySecretNS).Get(ctx, apiKeySecretName, metav1.GetOptions{})
 	if err != nil {
 		logrus.Debugf("sandbox gRPC: no api-key secret found, all requests allowed")
+		s.apiKeys = nil
 		return
 	}
 	data, ok := secret.Data["keys.json"]
 	if !ok {
+		s.apiKeys = nil
 		return
 	}
 	var store map[string]string
 	if err := json.Unmarshal(data, &store); err != nil {
 		logrus.Warnf("sandbox gRPC: api-key secret corrupted: %v", err)
 		return
+	}
+	// Detect removed keys and revoke their certificates
+	if s.revocList != nil && s.issuedStore != nil {
+		for name := range s.apiKeys {
+			if _, ok := store[name]; !ok {
+				s.revocList.RevokeByKeyName(s.issuedStore, name)
+				logrus.Infof("sandbox gRPC: revoked certificates for deleted API key %q", name)
+			}
+		}
 	}
 	s.apiKeys = store
 	logrus.Infof("sandbox gRPC: loaded %d API key(s)", len(store))
@@ -210,23 +236,36 @@ func (s *Server) Start(ctx context.Context) error {
 	// Rebuild background run registry from existing Session CRDs
 	go s.orch.RebuildRunRegistry(ctx, "sandbox-matrix")
 
-	creds, err := credentials.NewServerTLSFromFile(s.certFile, s.keyFile)
+	// Initialize sandbox CA and server certificate
+	caKey, caCert, err := ensureCA(s.caCertFile, s.caKeyFile)
 	if err != nil {
-		return fmt.Errorf("grpc tls credentials: %w", err)
+		return fmt.Errorf("sandbox CA: %w", err)
+	}
+	s.caKey = caKey
+	s.caCert = caCert
+
+	if err := ensureServerCert(s.caKey, s.caCert, s.serverCertFile, s.serverKeyFile); err != nil {
+		return fmt.Errorf("sandbox server cert: %w", err)
 	}
 
-	opts := []grpc.ServerOption{grpc.Creds(creds)}
-	if len(s.apiKeys) > 0 {
-		opts = append(opts,
-			grpc.ChainUnaryInterceptor(s.rateLimiter.UnaryInterceptor, s.apiKeyInterceptor),
-			grpc.ChainStreamInterceptor(s.rateLimiter.StreamInterceptor, s.apiStreamInterceptor),
-		)
-	} else {
-		opts = append(opts,
-			grpc.UnaryInterceptor(s.rateLimiter.UnaryInterceptor),
-			grpc.StreamInterceptor(s.rateLimiter.StreamInterceptor),
-		)
+	serverTLS, err := tls.LoadX509KeyPair(s.serverCertFile, s.serverKeyFile)
+	if err != nil {
+		return fmt.Errorf("load server cert: %w", err)
 	}
+
+	creds, err := buildMTLSCreds(s.caCert, serverTLS)
+	if err != nil {
+		return fmt.Errorf("grpc mTLS credentials: %w", err)
+	}
+
+	s.issuedStore = newIssuedCertStore(s.caCertFile[:strings.LastIndex(s.caCertFile, "/")] + "/sandbox-issued.json")
+	s.revocList = newRevocationList()
+
+	opts := []grpc.ServerOption{grpc.Creds(creds)}
+	opts = append(opts,
+		grpc.ChainUnaryInterceptor(s.rateLimiter.UnaryInterceptor, s.mTLSAuthInterceptor),
+		grpc.ChainStreamInterceptor(s.rateLimiter.StreamInterceptor, s.mTLSStreamInterceptor),
+	)
 	gs := grpc.NewServer(opts...)
 	pb.RegisterSandboxServiceServer(gs, s)
 	logrus.Infof("sandbox gRPC gateway listening on %s", s.lisAddr)
@@ -426,19 +465,57 @@ func (s *Server) ApproveAction(ctx context.Context, req *pb.ApproveActionRequest
 	return s.orch.ApproveAction(ctx, req)
 }
 
-// GetCACert returns the server's CA certificate for TLS verification.
-// Requires API key authentication — the cert is only served to authenticated clients.
-func (s *Server) GetCACert(ctx context.Context, req *pb.GetCACertRequest) (*pb.GetCACertResponse, error) {
-	pem, err := os.ReadFile(s.certFile)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "read ca cert: %v", err)
-	}
-	return &pb.GetCACertResponse{Cert: string(pem)}, nil
-}
-
 // PollRun checks the status of a background execution.
 func (s *Server) PollRun(ctx context.Context, req *pb.PollRunRequest) (*pb.PollRunResponse, error) {
 	return s.orch.PollRun(ctx, req.RunId)
+}
+
+// Login authenticates the client (via mTLS or API key) and returns a signed client certificate.
+func (s *Server) Login(ctx context.Context, req *pb.LoginRequest) (*pb.LoginResponse, error) {
+	keyName, _ := peerIdentity(ctx)
+
+	if keyName == "" {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing metadata")
+		}
+		auth := md.Get("authorization")
+		if len(auth) == 0 {
+			return nil, status.Error(codes.Unauthenticated, "missing API key or client certificate")
+		}
+		token := strings.TrimPrefix(auth[0], "Bearer ")
+		for name, key := range s.apiKeys {
+			if key == token {
+				keyName = name
+				break
+			}
+		}
+		if keyName == "" {
+			return nil, status.Error(codes.Unauthenticated, "invalid API key")
+		}
+	}
+
+	certPEM, fingerprint, err := signClientCert(s.caKey, s.caCert, req.Csr, keyName, 30)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "sign certificate: %v", err)
+	}
+
+	s.issuedStore.Add(keyName, fingerprint, time.Now(), time.Now().Add(30*24*time.Hour))
+
+	logrus.WithFields(logrus.Fields{
+		"key_name":         keyName,
+		"device_name":      req.DeviceName,
+		"client_version":   req.ClientVersion,
+		"cert_fingerprint": fingerprint,
+	}).Info("sandbox gRPC: client certificate issued")
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: s.caCert.Raw})
+
+	return &pb.LoginResponse{
+		Cert:      certPEM,
+		CaCert:    string(caPEM),
+		ValidDays: 30,
+	}, nil
 }
 
 func (s *Server) getPodIP(ctx context.Context, sessionID string) (string, error) {
@@ -477,40 +554,48 @@ func (s *Server) getPodIP(ctx context.Context, sessionID string) (string, error)
 	return "", status.Errorf(codes.FailedPrecondition, "session %s has no pod IP after 60s", sessionID)
 }
 
-// validateAPIKey extracts and validates the API key from the gRPC context metadata.
-func (s *Server) validateAPIKey(ctx context.Context) error {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return status.Error(codes.Unauthenticated, "missing metadata")
+// mTLSAuthInterceptor enforces mTLS for all RPCs except Login.
+func (s *Server) mTLSAuthInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	if info.FullMethod == "/sandbox.v1.SandboxService/Login" {
+		return handler(ctx, req)
 	}
-	auth := md.Get("authorization")
-	if len(auth) == 0 {
-		return status.Error(codes.Unauthenticated, "missing authorization header")
-	}
-	token := strings.TrimPrefix(auth[0], "Bearer ")
-	if token == auth[0] {
-		return status.Error(codes.Unauthenticated, "invalid authorization format, expected 'Bearer <key>'")
-	}
-	for _, key := range s.apiKeys {
-		if key == token {
-			return nil
-		}
-	}
-	return status.Error(codes.Unauthenticated, "invalid api key")
-}
-
-// apiKeyInterceptor validates the authorization header against known API keys for unary RPCs.
-func (s *Server) apiKeyInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-	if err := s.validateAPIKey(ctx); err != nil {
+	if err := s.checkMTLSAuth(ctx); err != nil {
 		return nil, err
 	}
 	return handler(ctx, req)
 }
 
-// apiStreamInterceptor validates the authorization header for streaming RPCs.
-func (s *Server) apiStreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	if err := s.validateAPIKey(ss.Context()); err != nil {
+// mTLSStreamInterceptor enforces mTLS for all streaming RPCs except ExecStream.
+func (s *Server) mTLSStreamInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	if err := s.checkMTLSAuth(ss.Context()); err != nil {
 		return err
 	}
 	return handler(srv, ss)
+}
+
+func (s *Server) checkMTLSAuth(ctx context.Context) error {
+	keyName, isLocal := peerIdentity(ctx)
+	if isLocal && s.localAuth {
+		return nil
+	}
+	if keyName == "" {
+		return status.Error(codes.Unauthenticated, "client certificate required for mTLS")
+	}
+	if s.revocList.IsRevoked(certFingerprintFromContext(ctx)) {
+		return status.Error(codes.PermissionDenied, "client certificate has been revoked")
+	}
+	return nil
+}
+
+func certFingerprintFromContext(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return ""
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok || len(tlsInfo.State.PeerCertificates) == 0 {
+		return ""
+	}
+	h := sha256.Sum256(tlsInfo.State.PeerCertificates[0].Raw)
+	return fmt.Sprintf("%x", h[:])
 }

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -14,9 +14,10 @@ service SandboxService {
   rpc RunSubAgent(RunSubAgentRequest)       returns (RunSubAgentResponse);
   rpc ConfirmAction(ConfirmActionRequest)   returns (ConfirmActionResponse);
   rpc ApproveAction(ApproveActionRequest)   returns (ApproveActionResponse);
-  // GetCACert returns the server CA certificate for TLS verification.
-  // No authentication required — the cert is needed to establish trust.
-  rpc GetCACert(GetCACertRequest)           returns (GetCACertResponse);
+  // Login authenticates the client and returns a signed X.509 certificate for mTLS.
+  // First login: pass API key via gRPC metadata (authorization: Bearer <key>).
+  // Renewal: present existing valid client cert via mTLS — no API key needed.
+  rpc Login(LoginRequest) returns (LoginResponse);
   // PollRun checks the status of a background execution.
   rpc PollRun(PollRunRequest)               returns (PollRunResponse);
 }
@@ -97,8 +98,16 @@ message ApproveActionResponse {
   bool ok = 1;
 }
 
-message GetCACertRequest  {}
-message GetCACertResponse { string cert = 1; }
+message LoginRequest {
+  string csr            = 1;  // PEM-encoded PKCS#10 certificate signing request
+  string device_name    = 2;  // e.g. hostname, for audit logging
+  string client_version = 3;  // k8e version, for audit logging
+}
+message LoginResponse {
+  string cert       = 1;  // PEM-encoded signed client certificate
+  string ca_cert    = 2;  // PEM-encoded sandbox CA certificate (trust anchor)
+  int64  valid_days = 3;  // days the certificate is valid
+}
 
 message PollRunRequest  { string run_id = 1; }
 message PollRunResponse {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+# SonarCloud project configuration
+sonar.projectKey=xiaods_k8e
+
+# Exclude generated protobuf code
+sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go


### PR DESCRIPTION
Replace API key bearer tokens with mTLS client certificates for all sandbox gRPC business RPCs. New Login RPC issues short-lived (30-day) ECDSA P-256 client certificates signed by an auto-generated sandbox CA.

- New sandbox CA independent from K8s cluster CA, auto-generated on start
- Single gRPC port with VerifyClientCertIfGiven: Login uses API key or existing mTLS identity; all other RPCs require mTLS
- Client three-state bootstrap: direct mTLS, TLS+Login, insecure+Login
- Lazy renewal at 7 days remaining via mTLS identity (no API key needed)
- In-memory revocation on API key deletion
- Loopback exemption for local connections
- Remove GetCACert RPC, API key interceptor, and TOFU client logic