### PR TITLE
fix(build): remove duplicate bin/ prefix in sandbox-cli output path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -402,7 +402,7 @@ fn addSandboxCLIBuild(b: *std.Build, all_step: *std.Build.Step, v: VersionInfo) 
     );
 
     for (cli_targets) |t| {
-        const out_name = b.fmt("bin/k8e-sandbox-cli-{s}-{s}{s}", .{ t.goos, t.goarch, t.ext });
+        const out_name = b.fmt("k8e-sandbox-cli-{s}-{s}{s}", .{ t.goos, t.goarch, t.ext });
         const out_path = b.getInstallPath(.bin, out_name);
 
         const go_build = b.addSystemCommand(&[_][]const u8{


### PR DESCRIPTION
getInstallPath(.bin, ...) already prepends bin/ to the path, so the fmt string "bin/k8e-sandbox-cli-..." produced zig-out/bin/bin/..., causing the release upload step to find no files at the expected zig-out/bin/... path.