### PR TITLE
fix(sandbox): resolve DNS failure in gVisor sandbox pods

### DIFF
--- a/manifests/cilium.yaml
+++ b/manifests/cilium.yaml
@@ -23,4 +23,4 @@ spec:
     k8sServiceHost: "%{API_SERVER_HOST}%"
     k8sServicePort: "%{API_SERVER_PORT}%"
     dnsProxy:
-      enabled: true
+      enabled: false

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -662,6 +662,7 @@ func SandboxPodSpec(runtimeClass, pvcName, cpu, memory, image string) corev1.Pod
 			VolumeMounts:    []corev1.VolumeMount{{Name: "workspace", MountPath: "/workspace"}},
 		}},
 		Volumes:       []corev1.Volume{vol},
+		DNSPolicy: corev1.DNSDefault,
 		RestartPolicy: corev1.RestartPolicyNever,
 	}
 	if runtimeClass != "" {
@@ -745,12 +746,7 @@ func (o *Orchestrator) applyCNP(ctx context.Context, session *sandboxv1.SandboxS
 			},
 			"egress": []interface{}{
 				map[string]interface{}{
-					"toEndpoints": []interface{}{
-						map[string]interface{}{"matchLabels": map[string]interface{}{
-							"k8s:io.kubernetes.pod.namespace": "kube-system",
-							"k8s:k8s-app":                    "kube-dns",
-						}},
-					},
+					"toEntities": []interface{}{"world"},
 					"toPorts": []interface{}{
 						map[string]interface{}{
 							"ports": []interface{}{map[string]interface{}{"port": "53", "protocol": "ANY"}},


### PR DESCRIPTION
gVisor host network mode prevents Cilium from performing service load balancing (DNAT) on ClusterIP traffic, so DNS requests to the kube-dns ClusterIP (10.43.0.10) are dropped as "world" identity.

Three coordinated fixes:
- Disable Cilium global DNS proxy (dnsProxy.enabled: false) to stop eBPF-level DNS interception that gVisor cannot handle.
- Change CNP DNS egress rule from toEndpoints (kube-dns label matching) to toEntities: ["world"], matching how Cilium classifies gVisor-originated traffic.
- Set DNSPolicy: Default on sandbox pods so they use the node's DNS resolver instead of the unreachable ClusterIP.