### PR TITLE
chore: gitignore LoopX and agent runtime directories (.loopx/, .codex…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ __pycache__
 .zig-cache
 zig-out
 .claude/*
+/.codex/
+/.loopx/
+/.agents/
 /server
 /sandbox-cli
 /sandboxcli


### PR DESCRIPTION
…/, .agents/)