### PR TITLE
feat(sandbox): smoother sandbox startup — warm-pod readiness gating, runtime-aware claims, immediate refill, hit-rate metrics

### DIFF
--- a/docs/sandbox-warm-pool.md
+++ b/docs/sandbox-warm-pool.md
@@ -1,0 +1,150 @@
+# SandboxWarmPool 使用文档
+
+| 更新 | 状态 |
+|------|------|
+| 2026-08-04 | Current |
+
+`SandboxWarmPool` 是 K8E 沙箱矩阵的预热池 CRD：预先启动一批 sandbox pod（`sandbox.k8e.io/state=warm`），会话创建时原子领取（`warm → active`），避免冷启动延迟。本文档覆盖字段语义与调优，重点是自适应扩缩字段 `maxSize` / `minSize` / `idleTTLSeconds`。
+
+架构背景见 [KIP-3: Agentic AI Sandbox Matrix](kip-3-agentic-ai-sandbox-matrix.md)。
+
+## 字段总览
+
+```yaml
+apiVersion: k8e.sh/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: default
+  namespace: sandbox-matrix
+spec:
+  templateRef:            # 可选：SandboxTemplate 引用
+    name: default-sandbox-template
+  size: 5                 # 静态目标池大小（默认 1）
+  runtimeClass: gvisor    # 可选：覆盖 --sandbox-default-runtime，支持混合 runtime 集群
+  minSize: 2              # 自适应下界（默认 = size）
+  maxSize: 8              # 自适应上界（> size 即开启自适应模式）
+  idleTTLSeconds: 900     # 可选：本池 warm pod 闲置回收 TTL（默认 = sessionTTL × 2）
+status:
+  readyCount: 5
+  pendingCount: 0
+```
+
+| 字段 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `templateRef` | object | 无 | 可选的 `SandboxTemplate` 引用 |
+| `size` | int | 1 | 目标池大小（自适应模式下为基线） |
+| `runtimeClass` | string | `--sandbox-default-runtime` | 本池 warm pod 的运行时；会话领取时按 `sandbox.k8e.io/runtime-class` 标签精确匹配 |
+| `minSize` | int | `size` | 自适应下界 |
+| `maxSize` | int | `size` | 自适应上界；**仅当 `maxSize > size` 时开启自适应模式** |
+| `idleTTLSeconds` | int | `sessionTTL × 2` | 本池 warm pod 的闲置回收 TTL |
+
+## 基础用法
+
+```bash
+# 创建预热池（5 个 gVisor warm pod）
+kubectl apply -f - <<'EOF'
+apiVersion: k8e.sh/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: default
+  namespace: sandbox-matrix
+spec:
+  size: 5
+  runtimeClass: gvisor
+EOF
+
+# 查看池状态
+kubectl get sandboxwarmpool -n sandbox-matrix
+```
+
+所有 warm pod 创建时带 `sandbox.k8e.io/runtime-class` 标签；会话领取时只认**同 runtime** 且 **sandboxd 已就绪**（Running + Ready 条件 + `:2024` TCP 拨测）的 warm pod，避免领到仍在启动或已死的 pod。领取成功后控制器立即补池（不等 10s 轮询）。
+
+## 自适应扩缩（`maxSize` / `minSize`）
+
+默认池大小是静态的：突发流量会冷启动，空闲时又白白占用内存。配置 `maxSize > size` 即开启自适应模式：
+
+```yaml
+spec:
+  size: 2      # 基线
+  minSize: 2   # 空闲时不低于 2
+  maxSize: 10  # 突发时可扩到 10（受 computeMaxPods 容量上限约束）
+```
+
+行为：
+
+1. **突发增长**：reconciler 每轮根据冷启动计数增量调整目标。出现冷启动（池子没接住）后，目标 = `max(size, 近期冷启动数)`，向上夹在 `[minSize, maxSize]`。
+2. **需求衰减**：连续 **5 分钟**没有新的冷启动，目标回落。回落只停止继续建 pod；存量多余 warm pod 由闲置回收器按 TTL 清除（见下节），所以想要快速缩容应同时配置较短的 `idleTTLSeconds`。
+3. **容量上限**：目标同时受 `computeMaxPods` 约束——跨**所有节点**求和的 allocatable 内存与 CPU（各留 10% buffer）的较小值。
+
+不配置 `maxSize`（或 `maxSize <= size`）时行为与旧版完全一致（静态池），向后兼容。
+
+## 按池闲置回收（`idleTTLSeconds`）
+
+全局默认回收 TTL 是 `SandboxMatrix.spec.sessionTTL × 2`（默认 2 小时），偏粗。本字段允许按池收紧：
+
+```yaml
+spec:
+  size: 3
+  idleTTLSeconds: 300   # warm pod 闲置 5 分钟即回收
+```
+
+机制：创建 warm pod 时把该值以 `sandbox.k8e.io/idle-ttl-seconds` 注解写到 pod 上，闲置回收器优先读注解，缺省才回退 `sessionTTL × 2`。适合与自适应缩池配合（需求衰减后快速释放内存），或对内存敏感的多池环境按池差异化配置。
+
+## 容量计算（`computeMaxPods`）
+
+```text
+maxPods = min(
+  sum(所有节点 allocatable 内存) × 0.9 / 单 pod 内存限制,   # 默认 512Mi
+  sum(所有节点 allocatable CPU) × 0.9 / 单 pod CPU 限制      # 默认 500m
+)
+```
+
+- 跨节点**求和**（warm pod 可调度到任意节点），并新增 CPU 维度，取更紧的约束。
+- 节点不可用（无 node / 无 allocatable）时返回 `0`，即不设上限。
+
+## 观测
+
+控制器每 10s（或收到领取信号时）把指标写入 `SandboxMatrix.status`：
+
+| status 字段 | 含义 |
+|------------|------|
+| `readyWarmCount` | Running 且就绪的 warm pod 数 |
+| `activeSessions` | 活跃会话数 |
+| `claimedFromWarm` | 累计从预热池领取的会话数 |
+| `coldStarts` | 累计冷启动会话数 |
+| `avgClaimLatencyMs` | 平均 pod 获取延迟（ms） |
+| `maxPods` / `totalPods` | 容量上限 / 当前 sandbox pod 总数 |
+
+```bash
+kubectl get sandboxmatrix -n sandbox-matrix -o jsonpath='{.items[0].status}' | jq
+```
+
+**命中率** = `claimedFromWarm / (claimedFromWarm + coldStarts)`。调优建议：
+
+- 命中率高（>0.9）且无冷启动 → 池子偏大，可下调 `size` 或调短 `idleTTLSeconds`。
+- 命中率低、频繁冷启动 → 上调 `size` / `maxSize`，或检查 warm pod 是否长时间 `readyWarmCount < size`（此时看 pod 状态排查 sandboxd 就绪问题）。
+- 计数器是控制器进程启动以来的累计值，跨进程重启会归零。
+
+## 与其他机制的关系
+
+| 机制 | 说明 |
+|------|------|
+| 就绪门禁 | 领取前要求 Ready 条件 + `:2024` TCP 拨测；Running 但 sandboxd 未就绪的 warm pod 会被跳过，超过 5 分钟未就绪会被回收重建 |
+| runtime 标签 | `sandbox.k8e.io/runtime-class` 精确匹配，gVisor 池不会被子会话跨 runtime 领取 |
+| 领取即补池 | 领取成功后立即触发一轮 reconcile，池子不短暂亏空 |
+| 会话容量 | `CreateSession` 前的 `CheckCapacity` 仍以首个节点内存估算，与 `computeMaxPods`（全节点）口径不同，极端多节点场景以实际调度为准 |
+
+## 验证命令
+
+```bash
+# 池与 pod 状态
+kubectl get sandboxwarmpool,sandboxmatrix -n sandbox-matrix
+kubectl get pods -n sandbox-matrix -l sandbox.k8e.io/state=warm -o wide
+
+# 查看 warm pod 上的 TTL 注解
+kubectl get pod -n sandbox-matrix -l sandbox.k8e.io/state=warm \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.sandbox\.k8e\.io/idle-ttl-seconds}{"\n"}{end}'
+
+# 命中率与延迟
+kubectl get sandboxmatrix -n sandbox-matrix -o jsonpath='{.items[0].status}' | jq
+```

--- a/manifests/sandbox-matrix/crds.yaml
+++ b/manifests/sandbox-matrix/crds.yaml
@@ -53,6 +53,9 @@ spec:
               activeSessions: {type: integer}
               maxPods: {type: integer}
               totalPods: {type: integer}
+              claimedFromWarm: {type: integer}
+              coldStarts: {type: integer}
+              avgClaimLatencyMs: {type: integer}
     subresources:
       status: {}
     additionalPrinterColumns:

--- a/manifests/sandbox-matrix/crds.yaml
+++ b/manifests/sandbox-matrix/crds.yaml
@@ -146,6 +146,9 @@ spec:
             properties:
               size: {type: integer}
               runtimeClass: {type: string}
+              minSize: {type: integer}
+              maxSize: {type: integer}
+              idleTTLSeconds: {type: integer}
               templateRef:
                 type: object
                 properties:

--- a/pkg/sandboxmatrix/api/v1alpha1/types.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/types.go
@@ -40,8 +40,11 @@ type RateLimitSpec struct {
 }
 
 type SandboxMatrixStatus struct {
-	ReadyWarmCount int `json:"readyWarmCount,omitempty"`
-	ActiveSessions int `json:"activeSessions,omitempty"`
+	ReadyWarmCount    int   `json:"readyWarmCount,omitempty"`
+	ActiveSessions    int   `json:"activeSessions,omitempty"`
+	ClaimedFromWarm   int64 `json:"claimedFromWarm,omitempty"`
+	ColdStarts        int64 `json:"coldStarts,omitempty"`
+	AvgClaimLatencyMs int64 `json:"avgClaimLatencyMs,omitempty"`
 }
 
 // +genclient

--- a/pkg/sandboxmatrix/api/v1alpha1/types.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/types.go
@@ -103,6 +103,16 @@ type SandboxWarmPoolSpec struct {
 	TemplateRef  corev1.LocalObjectReference `json:"templateRef,omitempty"`
 	Size         int                         `json:"size,omitempty"`
 	RuntimeClass string                      `json:"runtimeClass,omitempty"`
+	// MinSize is the adaptive lower bound for the pool target. Defaults to Size.
+	// Only meaningful when MaxSize > Size (adaptive mode).
+	MinSize int `json:"minSize,omitempty"`
+	// MaxSize is the adaptive upper bound for the pool target. When set above
+	// Size, the pool grows toward MaxSize on cold-start bursts (recent demand)
+	// and decays back toward MinSize once demand subsides.
+	MaxSize int `json:"maxSize,omitempty"`
+	// IdleTTLSeconds overrides the warm-pod idle reaping TTL for pods created
+	// from this pool. Defaults to SandboxMatrix.sessionTTL * 2 when unset.
+	IdleTTLSeconds int `json:"idleTTLSeconds,omitempty"`
 }
 
 type SandboxWarmPoolStatus struct {

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -58,11 +58,20 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 		return err
 	}
 
-	go runWarmPoolReconciler(ctx, k8s, dyn, cfg)
+	// refillTrigger wakes the warm pool reconciler immediately after a warm pod
+	// claim, instead of waiting up to 10s for the next poll tick.
+	refillTrigger := make(chan struct{}, 1)
+	go runWarmPoolReconciler(ctx, k8s, dyn, cfg, refillTrigger)
 	go runResettingDetector(ctx, k8s, cfg.Namespace)
 	go runIdlePodReaper(ctx, k8s, dyn, cfg)
 
 	orch := sandboxgrpc.NewOrchestrator(k8s, dyn)
+	orch.OnWarmClaim = func() {
+		select {
+		case refillTrigger <- struct{}{}:
+		default: // already a refill pending
+		}
+	}
 	go runGCLoop(ctx, orch, cfg.Namespace)
 
 	srv := sandboxgrpc.NewServer(sandboxgrpc.ServerConfig{
@@ -91,13 +100,16 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 	return nil
 }
 
-func runWarmPoolReconciler(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig) {
+func runWarmPoolReconciler(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, refill <-chan struct{}) {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-refill:
+			// A session just claimed a warm pod; refill before the next tick.
+			reconcileWarmPools(ctx, k8s, dyn, cfg)
 		case <-ticker.C:
 			reconcileWarmPools(ctx, k8s, dyn, cfg)
 		}

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -333,49 +333,63 @@ func computeMaxPods(ctx context.Context, k8s kubernetes.Interface, cfg config.Sa
 	if err != nil || len(nodes.Items) == 0 {
 		return 0
 	}
-
-	var totalMem, totalCPU int64
-	for i := range nodes.Items {
-		node := &nodes.Items[i]
-		if mem := node.Status.Allocatable.Memory(); mem != nil {
-			totalMem += mem.Value()
-		}
-		if cpu := node.Status.Allocatable.Cpu(); cpu != nil {
-			totalCPU += cpu.MilliValue() // millicores
-		}
-	}
+	totalMem, totalCPU := sumNodeAllocatable(nodes.Items)
 	if totalMem == 0 && totalCPU == 0 {
 		return 0
 	}
+	perPodMem, perPodCPU := perPodResources(cfg)
+	memCap := capacityFor(totalMem, perPodMem.Value())
+	cpuCap := capacityFor(totalCPU, perPodCPU.MilliValue())
+	return tighterCapacity(memCap, cpuCap)
+}
 
-	perPodMem := resource.MustParse(cfg.DefaultMemory)
-	if perPodMem.IsZero() {
-		perPodMem = resource.MustParse("512Mi")
+// sumNodeAllocatable sums allocatable memory (bytes) and CPU (millicores)
+// across nodes.
+func sumNodeAllocatable(nodes []corev1.Node) (mem, cpu int64) {
+	for i := range nodes {
+		if m := nodes[i].Status.Allocatable.Memory(); m != nil {
+			mem += m.Value()
+		}
+		if c := nodes[i].Status.Allocatable.Cpu(); c != nil {
+			cpu += c.MilliValue()
+		}
 	}
-	perPodCPU := resource.MustParse(cfg.DefaultCPU)
-	if perPodCPU.IsZero() {
-		perPodCPU = resource.MustParse("500m")
-	}
+	return
+}
 
-	memCap := int64(0)
-	if totalMem > 0 && !perPodMem.IsZero() {
-		memCap = totalMem * 9 / 10 / perPodMem.Value()
+// perPodResources returns the per-sandbox resource limits from config,
+// falling back to the documented defaults when unset.
+func perPodResources(cfg config.SandboxConfig) (mem, cpu resource.Quantity) {
+	mem = resource.MustParse(cfg.DefaultMemory)
+	if mem.IsZero() {
+		mem = resource.MustParse("512Mi")
 	}
-	cpuCap := int64(0)
-	if totalCPU > 0 && !perPodCPU.IsZero() {
-		cpuCap = totalCPU * 9 / 10 / perPodCPU.MilliValue()
+	cpu = resource.MustParse(cfg.DefaultCPU)
+	if cpu.IsZero() {
+		cpu = resource.MustParse("500m")
 	}
+	return
+}
 
-	if memCap == 0 {
-		return cpuCap
+// capacityFor computes how many sandbox pods fit within an allocatable total
+// with a 10% buffer. Returns 0 when the total or per-pod divisor is missing.
+func capacityFor(total, divisor int64) int64 {
+	if total <= 0 || divisor <= 0 {
+		return 0
 	}
-	if cpuCap == 0 {
-		return memCap
+	return total * 9 / 10 / divisor
+}
+
+// tighterCapacity returns the smaller non-zero bound; when only one bound is
+// known, that one wins.
+func tighterCapacity(a, b int64) int64 {
+	if a == 0 {
+		return b
 	}
-	if memCap < cpuCap {
-		return memCap
+	if b == 0 || a < b {
+		return a
 	}
-	return cpuCap
+	return b
 }
 
 func updateSandboxMatrixStatus(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, orch *sandboxgrpc.Orchestrator) {

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -4,6 +4,8 @@ package sandboxmatrix
 import (
 	"context"
 	"os"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -103,30 +105,66 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 func runWarmPoolReconciler(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, refill <-chan struct{}, orch *sandboxgrpc.Orchestrator) {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
+	demand := &warmDemand{lastObserved: time.Now()}
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-refill:
 			// A session just claimed a warm pod; refill before the next tick.
-			reconcileWarmPools(ctx, k8s, dyn, cfg, orch)
+			reconcileWarmPools(ctx, k8s, dyn, cfg, orch, demand)
 		case <-ticker.C:
-			reconcileWarmPools(ctx, k8s, dyn, cfg, orch)
+			reconcileWarmPools(ctx, k8s, dyn, cfg, orch, demand)
 		}
 	}
 }
 
-func reconcileWarmPools(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, orch *sandboxgrpc.Orchestrator) {
+func reconcileWarmPools(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, orch *sandboxgrpc.Orchestrator, demand *warmDemand) {
 	pools, err := dyn.Resource(warmPoolGVR).Namespace(cfg.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return
 	}
 	maxPods := computeMaxPods(ctx, k8s, cfg)
+	boost := int64(0)
+	if orch != nil && demand != nil {
+		_, coldStarts, _ := orch.Metrics()
+		boost = demand.observe(time.Now(), coldStarts)
+	}
 	for _, pool := range pools.Items {
-		reconcileSinglePool(ctx, k8s, pool, maxPods, cfg)
+		reconcileSinglePool(ctx, k8s, pool, maxPods, cfg, boost)
 	}
 	recycleUnhealthyWarmPods(ctx, k8s, cfg.Namespace)
 	updateSandboxMatrixStatus(ctx, k8s, dyn, cfg, orch)
+}
+
+// demandDecayWindow is how long without a cold start before the adaptive pool
+// target decays back toward MinSize.
+const demandDecayWindow = 5 * time.Minute
+
+// warmDemand tracks recent cold starts so the warm pool can grow on bursts and
+// shrink once demand subsides.
+type warmDemand struct {
+	mu               sync.Mutex
+	lastColdStarts   int64
+	lastObserved     time.Time
+	recentColdStarts int64
+}
+
+// observe folds new cold starts into the demand estimate. When no new cold
+// starts occur for demandDecayWindow, the estimate decays back to zero.
+func (d *warmDemand) observe(now time.Time, coldStarts int64) int64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delta := coldStarts - d.lastColdStarts
+	if delta > 0 {
+		d.recentColdStarts += delta
+		d.lastColdStarts = coldStarts
+		d.lastObserved = now
+	} else if now.Sub(d.lastObserved) >= demandDecayWindow {
+		d.recentColdStarts = 0
+		d.lastObserved = now
+	}
+	return d.recentColdStarts
 }
 
 // recycleUnhealthyWarmPodAfter is how long a Running warm pod may stay not-ready
@@ -173,15 +211,18 @@ func deleteWarmPod(ctx context.Context, k8s kubernetes.Interface, namespace, nam
 }
 
 // reconcileSinglePool ensures one WarmPool CRD's target is met within capacity limits.
-func reconcileSinglePool(ctx context.Context, k8s kubernetes.Interface, pool unstructured.Unstructured, maxPods int64, cfg config.SandboxConfig) {
+func reconcileSinglePool(ctx context.Context, k8s kubernetes.Interface, pool unstructured.Unstructured, maxPods int64, cfg config.SandboxConfig, boost int64) {
 	specMap, _ := pool.Object["spec"].(map[string]interface{})
 	configuredSize, _ := specMap["size"].(int64)
 	runtimeClass, _ := specMap["runtimeClass"].(string)
 	if runtimeClass == "" {
 		runtimeClass = cfg.DefaultRuntime
 	}
+	minSize, _ := specMap["minSize"].(int64)
+	maxSize, _ := specMap["maxSize"].(int64)
+	idleTTL, _ := specMap["idleTTLSeconds"].(int64)
 
-	targetSize := poolTargetSize(configuredSize, maxPods)
+	targetSize := poolTargetSize(adaptiveTarget(configuredSize, minSize, maxSize, boost), maxPods)
 
 	allPods, err := k8s.CoreV1().Pods(cfg.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: sandboxgrpc.LabelState,
@@ -205,9 +246,38 @@ func reconcileSinglePool(ctx context.Context, k8s kubernetes.Interface, pool uns
 		if maxPods > 0 && int64(len(allPods.Items))+i+1 > maxPods {
 			break
 		}
-		pod := newWarmPod(cfg, runtimeClass)
+		pod := newWarmPod(cfg, runtimeClass, idleTTL)
 		k8s.CoreV1().Pods(cfg.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	}
+}
+
+// adaptiveTarget computes the warm pool target for this reconcile. Adaptive
+// mode is opt-in via MaxSize > Size: the target starts at Size, grows to cover
+// recent cold starts (bounded by MaxSize and capacity), and never drops below
+// MinSize (defaulting to Size). Without MaxSize the target is static.
+func adaptiveTarget(configuredSize, minSize, maxSize, boost int64) int64 {
+	base := configuredSize
+	if base <= 0 {
+		base = 1
+	}
+	if maxSize <= base {
+		return base
+	}
+	lo := minSize
+	if lo <= 0 {
+		lo = base
+	}
+	target := base
+	if boost > target {
+		target = boost
+	}
+	if target < lo {
+		target = lo
+	}
+	if target > maxSize {
+		target = maxSize
+	}
+	return target
 }
 
 // poolTargetSize computes the warm pool target bounded by capacity.
@@ -225,8 +295,19 @@ func poolTargetSize(configured, maxPods int64) int64 {
 	return t
 }
 
+// podIdleTTLAnnotation records a per-pool idle TTL override on warm pods.
+const podIdleTTLAnnotation = "sandbox.k8e.io/idle-ttl-seconds"
+
 // newWarmPod creates a warm pod spec with the correct labels and runtime.
-func newWarmPod(cfg config.SandboxConfig, runtimeClass string) *corev1.Pod {
+// idleTTLSeconds > 0 stamps the per-pool idle TTL override onto the pod.
+func newWarmPod(cfg config.SandboxConfig, runtimeClass string, idleTTLSeconds int64) *corev1.Pod {
+	annotations := sandboxgrpc.GvisorAnnotations(runtimeClass)
+	if idleTTLSeconds > 0 {
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[podIdleTTLAnnotation] = strconv.FormatInt(idleTTLSeconds, 10)
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "sandbox-warm-",
@@ -235,30 +316,64 @@ func newWarmPod(cfg config.SandboxConfig, runtimeClass string) *corev1.Pod {
 				sandboxgrpc.LabelState:        sandboxgrpc.StateWarm,
 				sandboxgrpc.LabelRuntimeClass: runtimeClass,
 			},
-			Annotations: sandboxgrpc.GvisorAnnotations(runtimeClass),
+			Annotations: annotations,
 		},
 		Spec: warmPodSpec(runtimeClass, cfg),
 	}
 }
 
-// computeMaxPods returns the maximum number of sandbox pods the node can host.
-// Returns 0 if node metrics are unavailable (no limit enforced).
+// computeMaxPods returns the maximum number of sandbox pods the cluster can
+// host, summing allocatable memory and CPU across all nodes (10% buffer each)
+// and taking the tighter bound. Returns 0 if node metrics are unavailable
+// (no limit enforced).
 func computeMaxPods(ctx context.Context, k8s kubernetes.Interface, cfg config.SandboxConfig) int64 {
 	nodes, err := k8s.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil || len(nodes.Items) == 0 {
 		return 0
 	}
-	allocatable := nodes.Items[0].Status.Allocatable.Memory()
-	if allocatable == nil || allocatable.IsZero() {
+
+	var totalMem, totalCPU int64
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if mem := node.Status.Allocatable.Memory(); mem != nil {
+			totalMem += mem.Value()
+		}
+		if cpu := node.Status.Allocatable.Cpu(); cpu != nil {
+			totalCPU += cpu.MilliValue() // millicores
+		}
+	}
+	if totalMem == 0 && totalCPU == 0 {
 		return 0
 	}
-	available := allocatable.Value() * 9 / 10 // 10% buffer
 
 	perPodMem := resource.MustParse(cfg.DefaultMemory)
 	if perPodMem.IsZero() {
 		perPodMem = resource.MustParse("512Mi")
 	}
-	return available / perPodMem.Value()
+	perPodCPU := resource.MustParse(cfg.DefaultCPU)
+	if perPodCPU.IsZero() {
+		perPodCPU = resource.MustParse("500m")
+	}
+
+	memCap := int64(0)
+	if totalMem > 0 && !perPodMem.IsZero() {
+		memCap = totalMem * 9 / 10 / perPodMem.Value()
+	}
+	cpuCap := int64(0)
+	if totalCPU > 0 && !perPodCPU.IsZero() {
+		cpuCap = totalCPU * 9 / 10 / perPodCPU.MilliValue()
+	}
+
+	if memCap == 0 {
+		return cpuCap
+	}
+	if cpuCap == 0 {
+		return memCap
+	}
+	if memCap < cpuCap {
+		return memCap
+	}
+	return cpuCap
 }
 
 func updateSandboxMatrixStatus(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, orch *sandboxgrpc.Orchestrator) {
@@ -439,8 +554,16 @@ func ensureReleaseTimestamp(ctx context.Context, k8s kubernetes.Interface, names
 	return false
 }
 
-// reapIfIdle deletes the pod if it has been idle longer than ttl seconds.
-func reapIfIdle(ctx context.Context, k8s kubernetes.Interface, namespace string, pod *corev1.Pod, ttl int64, now time.Time) {
+// reapIfIdle deletes the pod if it has been idle longer than the TTL. A
+// per-pool override on the pod (idle-ttl-seconds annotation) takes precedence
+// over the default (sessionTTL × 2).
+func reapIfIdle(ctx context.Context, k8s kubernetes.Interface, namespace string, pod *corev1.Pod, defaultTTL int64, now time.Time) {
+	ttl := defaultTTL
+	if a := pod.Annotations[podIdleTTLAnnotation]; a != "" {
+		if v, err := strconv.ParseInt(a, 10, 64); err == nil && v > 0 {
+			ttl = v
+		}
+	}
 	releasedAt := pod.Annotations[podReleasedAtAnnotation]
 	t, parseErr := time.Parse(time.RFC3339, releasedAt)
 	if parseErr != nil {
@@ -449,7 +572,7 @@ func reapIfIdle(ctx context.Context, k8s kubernetes.Interface, namespace string,
 	if now.Sub(t) <= time.Duration(ttl)*time.Second {
 		return
 	}
-	logrus.Infof("sandbox-matrix: reap idle pod %s (idle %v)", pod.Name, now.Sub(t).Round(time.Second))
+	logrus.Infof("sandbox-matrix: reap idle pod %s (idle %v, ttl %ds)", pod.Name, now.Sub(t).Round(time.Second), ttl)
 	if delErr := k8s.CoreV1().Pods(namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); delErr != nil {
 		logrus.Warnf("sandbox-matrix: reap delete %s: %v", pod.Name, delErr)
 	}

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -112,7 +113,51 @@ func reconcileWarmPools(ctx context.Context, k8s kubernetes.Interface, dyn dynam
 	for _, pool := range pools.Items {
 		reconcileSinglePool(ctx, k8s, pool, maxPods, cfg)
 	}
+	recycleUnhealthyWarmPods(ctx, k8s, cfg.Namespace)
 	updateSandboxMatrixStatus(ctx, k8s, dyn, cfg)
+}
+
+// recycleUnhealthyWarmPodAfter is how long a Running warm pod may stay not-ready
+// (sandboxd not serving on :2024) before the reconciler recycles it so a fresh
+// pod is created in its place.
+const recycleUnhealthyWarmPodAfter = 5 * time.Minute
+
+// recycleUnhealthyWarmPods deletes warm pods whose sandboxd is not serving:
+// Failed pods (container exited; RestartPolicy Never leaves the pod Failed) and
+// Running pods stuck without the Ready condition for longer than
+// recycleUnhealthyWarmPodAfter. The reconciler recreates them on the next tick,
+// keeping the pool at target without burning memory on dead pods.
+func recycleUnhealthyWarmPods(ctx context.Context, k8s kubernetes.Interface, namespace string) {
+	pods, err := k8s.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: sandboxgrpc.LabelState + "=" + sandboxgrpc.StateWarm,
+	})
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Phase == corev1.PodFailed {
+			logrus.Infof("sandbox-matrix: recycle failed warm pod %s", pod.Name)
+			deleteWarmPod(ctx, k8s, namespace, pod.Name)
+			continue
+		}
+		if pod.Status.Phase != corev1.PodRunning || sandboxgrpc.PodReadyCondition(pod) {
+			continue
+		}
+		if now.Sub(pod.CreationTimestamp.Time) < recycleUnhealthyWarmPodAfter {
+			continue // still within the boot budget (image pull + sandboxd start)
+		}
+		logrus.Infof("sandbox-matrix: recycle warm pod %s (sandboxd not ready for %v)",
+			pod.Name, now.Sub(pod.CreationTimestamp.Time).Round(time.Second))
+		deleteWarmPod(ctx, k8s, namespace, pod.Name)
+	}
+}
+
+func deleteWarmPod(ctx context.Context, k8s kubernetes.Interface, namespace, name string) {
+	if err := k8s.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		logrus.Warnf("sandbox-matrix: recycle delete %s: %v", name, err)
+	}
 }
 
 // reconcileSinglePool ensures one WarmPool CRD's target is met within capacity limits.

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -219,8 +219,11 @@ func newWarmPod(cfg config.SandboxConfig, runtimeClass string) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "sandbox-warm-",
 			Namespace:    cfg.Namespace,
-			Labels:       map[string]string{sandboxgrpc.LabelState: sandboxgrpc.StateWarm},
-			Annotations:  sandboxgrpc.GvisorAnnotations(runtimeClass),
+			Labels: map[string]string{
+				sandboxgrpc.LabelState:        sandboxgrpc.StateWarm,
+				sandboxgrpc.LabelRuntimeClass: runtimeClass,
+			},
+			Annotations: sandboxgrpc.GvisorAnnotations(runtimeClass),
 		},
 		Spec: warmPodSpec(runtimeClass, cfg),
 	}

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -247,7 +247,9 @@ func reconcileSinglePool(ctx context.Context, k8s kubernetes.Interface, pool uns
 			break
 		}
 		pod := newWarmPod(cfg, runtimeClass, idleTTL)
-		k8s.CoreV1().Pods(cfg.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+		if _, err := k8s.CoreV1().Pods(cfg.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+			logrus.Debugf("sandbox-matrix: create warm pod: %v", err)
+		}
 	}
 }
 

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -61,10 +61,6 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 	// refillTrigger wakes the warm pool reconciler immediately after a warm pod
 	// claim, instead of waiting up to 10s for the next poll tick.
 	refillTrigger := make(chan struct{}, 1)
-	go runWarmPoolReconciler(ctx, k8s, dyn, cfg, refillTrigger)
-	go runResettingDetector(ctx, k8s, cfg.Namespace)
-	go runIdlePodReaper(ctx, k8s, dyn, cfg)
-
 	orch := sandboxgrpc.NewOrchestrator(k8s, dyn)
 	orch.OnWarmClaim = func() {
 		select {
@@ -72,6 +68,10 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 		default: // already a refill pending
 		}
 	}
+	go runWarmPoolReconciler(ctx, k8s, dyn, cfg, refillTrigger, orch)
+	go runResettingDetector(ctx, k8s, cfg.Namespace)
+	go runIdlePodReaper(ctx, k8s, dyn, cfg)
+
 	go runGCLoop(ctx, orch, cfg.Namespace)
 
 	srv := sandboxgrpc.NewServer(sandboxgrpc.ServerConfig{
@@ -100,7 +100,7 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 	return nil
 }
 
-func runWarmPoolReconciler(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, refill <-chan struct{}) {
+func runWarmPoolReconciler(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, refill <-chan struct{}, orch *sandboxgrpc.Orchestrator) {
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -109,14 +109,14 @@ func runWarmPoolReconciler(ctx context.Context, k8s kubernetes.Interface, dyn dy
 			return
 		case <-refill:
 			// A session just claimed a warm pod; refill before the next tick.
-			reconcileWarmPools(ctx, k8s, dyn, cfg)
+			reconcileWarmPools(ctx, k8s, dyn, cfg, orch)
 		case <-ticker.C:
-			reconcileWarmPools(ctx, k8s, dyn, cfg)
+			reconcileWarmPools(ctx, k8s, dyn, cfg, orch)
 		}
 	}
 }
 
-func reconcileWarmPools(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig) {
+func reconcileWarmPools(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, orch *sandboxgrpc.Orchestrator) {
 	pools, err := dyn.Resource(warmPoolGVR).Namespace(cfg.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return
@@ -126,7 +126,7 @@ func reconcileWarmPools(ctx context.Context, k8s kubernetes.Interface, dyn dynam
 		reconcileSinglePool(ctx, k8s, pool, maxPods, cfg)
 	}
 	recycleUnhealthyWarmPods(ctx, k8s, cfg.Namespace)
-	updateSandboxMatrixStatus(ctx, k8s, dyn, cfg)
+	updateSandboxMatrixStatus(ctx, k8s, dyn, cfg, orch)
 }
 
 // recycleUnhealthyWarmPodAfter is how long a Running warm pod may stay not-ready
@@ -261,7 +261,7 @@ func computeMaxPods(ctx context.Context, k8s kubernetes.Interface, cfg config.Sa
 	return available / perPodMem.Value()
 }
 
-func updateSandboxMatrixStatus(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig) {
+func updateSandboxMatrixStatus(ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface, cfg config.SandboxConfig, orch *sandboxgrpc.Orchestrator) {
 	matrices, err := dyn.Resource(localMatrixGVR).Namespace(cfg.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil || len(matrices.Items) == 0 {
 		return
@@ -280,6 +280,11 @@ func updateSandboxMatrixStatus(ctx context.Context, k8s kubernetes.Interface, dy
 	maxPods := computeMaxPods(ctx, k8s, cfg)
 	totalPods := int64(len(warmPods.Items) + len(activePods.Items))
 
+	claimedWarm, coldStarts, avgLatency := int64(0), int64(0), int64(0)
+	if orch != nil {
+		claimedWarm, coldStarts, avgLatency = orch.Metrics()
+	}
+
 	matrix := matrices.Items[0].DeepCopy()
 	if matrix.Object["status"] == nil {
 		matrix.Object["status"] = map[string]interface{}{}
@@ -289,6 +294,9 @@ func updateSandboxMatrixStatus(ctx context.Context, k8s kubernetes.Interface, dy
 	status["activeSessions"] = int64(len(activePods.Items))
 	status["maxPods"] = maxPods
 	status["totalPods"] = totalPods
+	status["claimedFromWarm"] = claimedWarm
+	status["coldStarts"] = coldStarts
+	status["avgClaimLatencyMs"] = avgLatency
 	dyn.Resource(localMatrixGVR).Namespace(cfg.Namespace).UpdateStatus(ctx, matrix, metav1.UpdateOptions{}) //nolint:errcheck
 }
 

--- a/pkg/sandboxmatrix/controller_test.go
+++ b/pkg/sandboxmatrix/controller_test.go
@@ -9,6 +9,10 @@ import (
 	sandboxgrpc "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -86,6 +90,63 @@ func TestNewWarmPod_RuntimeClassLabel(t *testing.T) {
 	pod := newWarmPod(defaultCfg(), "kata")
 	if pod.Labels[sandboxgrpc.LabelRuntimeClass] != "kata" {
 		t.Fatalf("expected runtime-class label kata, got %v", pod.Labels)
+	}
+}
+
+func TestWarmPoolReconciler_RefillTrigger(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Kind: "SandboxWarmPool"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Kind: "SandboxWarmPoolList"}, &unstructured.UnstructuredList{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Kind: "SandboxMatrix"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Kind: "SandboxMatrixList"}, &unstructured.UnstructuredList{})
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Resource: "sandboxwarmpools"}: "SandboxWarmPoolList",
+		{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Resource: "sandboxmatrices"}:  "SandboxMatrixList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	k8s := kubefake.NewSimpleClientset()
+	ns := "sandbox-matrix"
+
+	pool := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": sandboxgrpc.SandboxAPIGroup + "/v1alpha1",
+		"kind":       "SandboxWarmPool",
+		"metadata":   map[string]interface{}{"name": "default", "namespace": ns},
+		"spec":       map[string]interface{}{"size": int64(2), "runtimeClass": "gvisor"},
+	}}
+	if _, err := dyn.Resource(warmPoolGVR).Namespace(ns).Create(ctx, pool, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create warm pool CR: %v", err)
+	}
+
+	refill := make(chan struct{}, 1)
+	refill <- struct{}{}
+	done := make(chan struct{})
+	go func() {
+		runWarmPoolReconciler(ctx, k8s, dyn, defaultCfg(), refill)
+		close(done)
+	}()
+
+	// The refill signal must trigger a reconcile that creates the warm pod
+	// without waiting for the 10s tick.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		pods, _ := k8s.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if len(pods.Items) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	pods, err := k8s.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	if len(pods.Items) == 0 {
+		t.Fatal("expected refill trigger to create a warm pod immediately")
 	}
 }
 

--- a/pkg/sandboxmatrix/controller_test.go
+++ b/pkg/sandboxmatrix/controller_test.go
@@ -82,6 +82,13 @@ func TestRecycleUnhealthyWarmPods(t *testing.T) {
 	}
 }
 
+func TestNewWarmPod_RuntimeClassLabel(t *testing.T) {
+	pod := newWarmPod(defaultCfg(), "kata")
+	if pod.Labels[sandboxgrpc.LabelRuntimeClass] != "kata" {
+		t.Fatalf("expected runtime-class label kata, got %v", pod.Labels)
+	}
+}
+
 func TestWarmPodSpec_RuntimeClass(t *testing.T) {
 	spec := warmPodSpec("gvisor", defaultCfg())
 	if spec.RuntimeClassName == nil || *spec.RuntimeClassName != "gvisor" {

--- a/pkg/sandboxmatrix/controller_test.go
+++ b/pkg/sandboxmatrix/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/xiaods/k8e/pkg/daemons/config"
 	sandboxgrpc "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,9 +88,122 @@ func TestRecycleUnhealthyWarmPods(t *testing.T) {
 }
 
 func TestNewWarmPod_RuntimeClassLabel(t *testing.T) {
-	pod := newWarmPod(defaultCfg(), "kata")
+	pod := newWarmPod(defaultCfg(), "kata", 0)
 	if pod.Labels[sandboxgrpc.LabelRuntimeClass] != "kata" {
 		t.Fatalf("expected runtime-class label kata, got %v", pod.Labels)
+	}
+}
+
+func TestNewWarmPod_IdleTTLAnnotation(t *testing.T) {
+	pod := newWarmPod(defaultCfg(), "gvisor", 300)
+	if pod.Annotations[podIdleTTLAnnotation] != "300" {
+		t.Fatalf("expected idle-ttl annotation 300, got %v", pod.Annotations)
+	}
+	plain := newWarmPod(defaultCfg(), "gvisor", 0)
+	if _, present := plain.Annotations[podIdleTTLAnnotation]; present {
+		t.Fatal("expected no idle-ttl annotation when TTL unset")
+	}
+}
+
+func TestAdaptiveTarget(t *testing.T) {
+	cases := []struct {
+		name                        string
+		size, min, max, boost, want int64
+	}{
+		{"static no max", 2, 0, 0, 5, 2},
+		{"static max equals size", 2, 0, 2, 5, 2},
+		{"grow on burst", 2, 0, 8, 5, 5},
+		{"bounded by max", 2, 0, 4, 9, 4},
+		{"shrink to min", 2, 2, 8, 0, 2},
+		{"min floor", 2, 3, 8, 0, 3},
+		{"default size one", 0, 0, 5, 0, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := adaptiveTarget(tc.size, tc.min, tc.max, tc.boost); got != tc.want {
+				t.Fatalf("adaptiveTarget(%d,%d,%d,%d) = %d, want %d", tc.size, tc.min, tc.max, tc.boost, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWarmDemand_GrowAndDecay(t *testing.T) {
+	now := time.Now()
+	d := &warmDemand{lastObserved: now}
+
+	if got := d.observe(now, 0); got != 0 {
+		t.Fatalf("no cold starts: want 0, got %d", got)
+	}
+	if got := d.observe(now, 3); got != 3 {
+		t.Fatalf("burst of 3: want 3, got %d", got)
+	}
+	if got := d.observe(now.Add(time.Minute), 3); got != 3 {
+		t.Fatalf("no new cold starts within window: want 3, got %d", got)
+	}
+	if got := d.observe(now.Add(6*time.Minute), 3); got != 0 {
+		t.Fatalf("window elapsed without new cold starts: want decay to 0, got %d", got)
+	}
+	// a later burst restarts from the accumulated baseline
+	if got := d.observe(now.Add(7*time.Minute), 5); got != 2 {
+		t.Fatalf("new burst after decay: want 2, got %d", got)
+	}
+}
+
+func TestComputeMaxPods_MultiNodeAndCPU(t *testing.T) {
+	ctx := context.Background()
+	k8s := kubefake.NewSimpleClientset()
+
+	for _, name := range []string{"node-a", "node-b"} {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+			}},
+		}
+		if _, err := k8s.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("create node %s: %v", name, err)
+		}
+	}
+
+	cfg := defaultCfg() // 500m CPU, 512Mi memory per pod
+	// memCap = 2*4Gi*0.9/512Mi = 14; cpuCap = 2*2000m*0.9/500m = 7 → min = 7
+	if got := computeMaxPods(ctx, k8s, cfg); got != 7 {
+		t.Fatalf("expected min(mem, cpu) capacity = 7, got %d", got)
+	}
+}
+
+func TestComputeMaxPods_NoNodes(t *testing.T) {
+	ctx := context.Background()
+	k8s := kubefake.NewSimpleClientset()
+	if got := computeMaxPods(ctx, k8s, defaultCfg()); got != 0 {
+		t.Fatalf("expected 0 (no limit) without nodes, got %d", got)
+	}
+}
+
+func TestReapIfIdle_UsesPodTTLOverride(t *testing.T) {
+	ctx := context.Background()
+	k8s := kubefake.NewSimpleClientset()
+	ns := "sandbox-matrix"
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-ttl",
+			Namespace: ns,
+			Annotations: map[string]string{
+				podIdleTTLAnnotation:    "1",
+				podReleasedAtAnnotation: time.Now().Add(-2 * time.Second).UTC().Format(time.RFC3339),
+			},
+		},
+	}
+	if _, err := k8s.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	// default TTL is long (3600s), but the pod annotation overrides it to 1s
+	reapIfIdle(ctx, k8s, ns, pod, 3600, time.Now())
+	if _, err := k8s.CoreV1().Pods(ns).Get(ctx, "warm-ttl", metav1.GetOptions{}); err == nil {
+		t.Fatal("expected pod to be reaped by its per-pod TTL override")
 	}
 }
 

--- a/pkg/sandboxmatrix/controller_test.go
+++ b/pkg/sandboxmatrix/controller_test.go
@@ -1,10 +1,15 @@
 package sandboxmatrix
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/xiaods/k8e/pkg/daemons/config"
+	sandboxgrpc "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 func defaultCfg() config.SandboxConfig {
@@ -15,6 +20,65 @@ func defaultCfg() config.SandboxConfig {
 		DefaultMemory:  "512Mi",
 		GRPCPort:       50051,
 		Namespace:      "sandbox-matrix",
+	}
+}
+
+func TestRecycleUnhealthyWarmPods(t *testing.T) {
+	ctx := context.Background()
+	k8s := kubefake.NewSimpleClientset()
+	ns := "sandbox-matrix"
+
+	// Failed warm pod (sandboxd exited; RestartPolicy Never) — must be recycled.
+	failed := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-failed", Namespace: ns, Labels: map[string]string{sandboxgrpc.LabelState: sandboxgrpc.StateWarm}},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+	}
+	// Running warm pod stuck not-ready past the boot budget — must be recycled.
+	stale := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "warm-stale",
+			Namespace:         ns,
+			Labels:            map[string]string{sandboxgrpc.LabelState: sandboxgrpc.StateWarm},
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	// Fresh not-ready warm pod — still within boot budget, keep.
+	fresh := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "warm-fresh",
+			Namespace:         ns,
+			Labels:            map[string]string{sandboxgrpc.LabelState: sandboxgrpc.StateWarm},
+			CreationTimestamp: metav1.Now(),
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	// Healthy warm pod — keep.
+	healthy := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-healthy", Namespace: ns, Labels: map[string]string{sandboxgrpc.LabelState: sandboxgrpc.StateWarm}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+
+	for _, p := range []*corev1.Pod{failed, stale, fresh, healthy} {
+		if _, err := k8s.CoreV1().Pods(ns).Create(ctx, p, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed pod %s: %v", p.Name, err)
+		}
+	}
+
+	recycleUnhealthyWarmPods(ctx, k8s, ns)
+
+	for _, name := range []string{"warm-failed", "warm-stale"} {
+		if _, err := k8s.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
+			t.Errorf("expected %s to be recycled", name)
+		}
+	}
+	for _, name := range []string{"warm-fresh", "warm-healthy"} {
+		if _, err := k8s.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{}); err != nil {
+			t.Errorf("expected %s to survive: %v", name, err)
+		}
 	}
 }
 

--- a/pkg/sandboxmatrix/controller_test.go
+++ b/pkg/sandboxmatrix/controller_test.go
@@ -124,7 +124,7 @@ func TestWarmPoolReconciler_RefillTrigger(t *testing.T) {
 	refill <- struct{}{}
 	done := make(chan struct{})
 	go func() {
-		runWarmPoolReconciler(ctx, k8s, dyn, defaultCfg(), refill)
+		runWarmPoolReconciler(ctx, k8s, dyn, defaultCfg(), refill, nil)
 		close(done)
 	}()
 
@@ -147,6 +147,45 @@ func TestWarmPoolReconciler_RefillTrigger(t *testing.T) {
 	}
 	if len(pods.Items) == 0 {
 		t.Fatal("expected refill trigger to create a warm pod immediately")
+	}
+}
+
+func TestUpdateSandboxMatrixStatus_WritesMetrics(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Kind: "SandboxMatrix"}, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Kind: "SandboxMatrixList"}, &unstructured.UnstructuredList{})
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: sandboxgrpc.SandboxAPIGroup, Version: "v1alpha1", Resource: "sandboxmatrices"}: "SandboxMatrixList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	k8s := kubefake.NewSimpleClientset()
+	ns := "sandbox-matrix"
+
+	matrix := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": sandboxgrpc.SandboxAPIGroup + "/v1alpha1",
+		"kind":       "SandboxMatrix",
+		"metadata":   map[string]interface{}{"name": "default", "namespace": ns},
+	}}
+	if _, err := dyn.Resource(localMatrixGVR).Namespace(ns).Create(ctx, matrix, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create matrix CR: %v", err)
+	}
+
+	orch := sandboxgrpc.NewOrchestrator(k8s, dyn)
+	updateSandboxMatrixStatus(ctx, k8s, dyn, defaultCfg(), orch)
+
+	got, err := dyn.Resource(localMatrixGVR).Namespace(ns).Get(ctx, "default", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get matrix: %v", err)
+	}
+	status, ok := got.Object["status"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected status on matrix CR")
+	}
+	for _, field := range []string{"claimedFromWarm", "coldStarts", "avgClaimLatencyMs", "readyWarmCount", "activeSessions", "maxPods", "totalPods"} {
+		if _, present := status[field]; !present {
+			t.Errorf("expected status field %s to be written", field)
+		}
 	}
 }
 

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -93,6 +94,12 @@ type Orchestrator struct {
 	// warm pod. The sandboxmatrix controller wires it to an immediate pool refill
 	// instead of waiting for the next reconcile tick.
 	OnWarmClaim func()
+
+	// claim accounting for the SandboxMatrix status surface.
+	claimedFromWarm     atomic.Int64
+	coldStarts          atomic.Int64
+	claimLatencyTotalMs atomic.Int64
+	claimCount          atomic.Int64
 }
 
 func NewOrchestrator(k8s kubernetes.Interface, dyn dynamic.Interface) *Orchestrator {
@@ -138,6 +145,31 @@ func PodReadyCondition(pod *corev1.Pod) bool {
 
 // defaultTTL is used when the session has no explicit TTL (0 = no expiry).
 const defaultTTL = 0
+
+// Metrics returns warm-claim vs cold-start counters and the average pod
+// acquisition latency in milliseconds. Used to surface pool hit rate and
+// startup behavior in the SandboxMatrix status.
+func (o *Orchestrator) Metrics() (claimedFromWarm, coldStarts, avgClaimLatencyMs int64) {
+	claimedFromWarm = o.claimedFromWarm.Load()
+	coldStarts = o.coldStarts.Load()
+	total := o.claimLatencyTotalMs.Load()
+	n := o.claimCount.Load()
+	if n > 0 {
+		avgClaimLatencyMs = total / n
+	}
+	return
+}
+
+// recordClaim updates claim metrics after a successful pod acquisition.
+func (o *Orchestrator) recordClaim(start time.Time, warm bool) {
+	o.claimLatencyTotalMs.Add(time.Since(start).Milliseconds())
+	o.claimCount.Add(1)
+	if warm {
+		o.claimedFromWarm.Add(1)
+	} else {
+		o.coldStarts.Add(1)
+	}
+}
 
 func (o *Orchestrator) CreateSession(ctx context.Context, req *pb.CreateSessionRequest) (*sandboxv1.SandboxSession, error) {
 	matrixHosts, ttl, cpu, memory := o.getMatrixConfig(ctx)
@@ -643,6 +675,7 @@ func (o *Orchestrator) updateSessionStatus(ctx context.Context, session *sandbox
 }
 
 func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeClass, pvcName, cpu, memory string) (*corev1.Pod, error) {
+	start := time.Now()
 	// Only ephemeral sessions (no PVC) may adopt a warm pod: warm pods boot with an
 	// EmptyDir volume, and a running pod's volumes cannot be changed to mount a
 	// session PVC. Persistent sessions therefore cold-start with the PVC attached.
@@ -671,6 +704,7 @@ func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeC
 				pod.Labels[labelSessionID] = sessionID
 				updated, uerr := o.k8s.CoreV1().Pods(sandboxNS).Update(ctx, pod, metav1.UpdateOptions{})
 				if uerr == nil {
+					o.recordClaim(start, true)
 					// Pool just shrank by one: ask the controller to refill now.
 					if o.OnWarmClaim != nil {
 						o.OnWarmClaim()
@@ -694,7 +728,11 @@ func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeC
 		},
 		Spec: sandboxPodSpec(runtimeClass, pvcName, cpu, memory),
 	}
-	return o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, pod, metav1.CreateOptions{})
+	created, cerr := o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, pod, metav1.CreateOptions{})
+	if cerr == nil {
+		o.recordClaim(start, false)
+	}
+	return created, cerr
 }
 
 func sandboxPodSpec(runtimeClass, pvcName, cpu, memory string) corev1.PodSpec {

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -34,23 +34,27 @@ const (
 	sandboxAPIGroup   = SandboxAPIGroup
 	sandboxAPIVersion = SandboxAPIGroup + "/v1alpha1"
 
-	maxDepth       = 1
-	sandboxNS      = "sandbox-matrix"
-	labelState     = "sandbox.k8e.io/state"
-	labelSessionID = "sandbox.k8e.io/session-id"
-	stateWarm      = "warm"
-	stateActive    = "active"
+	maxDepth          = 1
+	sandboxNS         = "sandbox-matrix"
+	labelState        = "sandbox.k8e.io/state"
+	labelSessionID    = "sandbox.k8e.io/session-id"
+	labelRuntimeClass = "sandbox.k8e.io/runtime-class"
+	stateWarm         = "warm"
+	stateActive       = "active"
 
 	// LabelState is the pod label key for sandbox state (warm/active).
-	LabelState     = labelState
+	LabelState = labelState
 	// StateWarm marks a pod as a pre-warmed sandbox.
-	StateWarm      = stateWarm
+	StateWarm = stateWarm
 	// StateActive marks a pod as an active sandbox session.
-	StateActive    = stateActive
+	StateActive = stateActive
 	// StateResetting marks a pod that is being reset before returning to warm pool.
 	StateResetting = "resetting"
 
-	sandboxImage   = "ghcr.io/xiaods/k8e-sandbox:latest"
+	// LabelRuntimeClass records the runtime a sandbox pod was booted with, so warm
+	// pods are only claimed by sessions requesting the same RuntimeClass.
+	LabelRuntimeClass = labelRuntimeClass
+	sandboxImage      = "ghcr.io/xiaods/k8e-sandbox:latest"
 )
 
 var (
@@ -650,6 +654,13 @@ func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeC
 				if !o.warmPodHealthCheck(ctx, pod) {
 					continue
 				}
+				// A warm pod booted with a different RuntimeClass must not be adopted:
+				// gVisor vs Kata have different isolation/network semantics. Pods
+				// created before the runtime label existed (no label) stay claimable
+				// by any runtime for backward compatibility.
+				if rc := pod.Labels[labelRuntimeClass]; rc != "" && rc != runtimeClass {
+					continue
+				}
 				// atomic claim: use resourceVersion for optimistic locking
 				pod.Labels[labelState] = stateActive
 				pod.Labels[labelSessionID] = sessionID
@@ -663,9 +674,13 @@ func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeC
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("sandbox-%s", sessionID),
-			Namespace:   sandboxNS,
-			Labels:      map[string]string{labelState: stateActive, labelSessionID: sessionID},
+			Name:      fmt.Sprintf("sandbox-%s", sessionID),
+			Namespace: sandboxNS,
+			Labels: map[string]string{
+				labelState:        stateActive,
+				labelSessionID:    sessionID,
+				labelRuntimeClass: runtimeClass,
+			},
 			Annotations: GvisorAnnotations(runtimeClass),
 		},
 		Spec: sandboxPodSpec(runtimeClass, pvcName, cpu, memory),

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -88,6 +88,11 @@ type Orchestrator struct {
 	// warmPodHealthCheck decides whether a warm pod's sandboxd is actually ready to
 	// serve on :2024 before the pod is claimed for a session. Overridable in tests.
 	warmPodHealthCheck func(ctx context.Context, pod *corev1.Pod) bool
+
+	// OnWarmClaim, when non-nil, is invoked after a session successfully claims a
+	// warm pod. The sandboxmatrix controller wires it to an immediate pool refill
+	// instead of waiting for the next reconcile tick.
+	OnWarmClaim func()
 }
 
 func NewOrchestrator(k8s kubernetes.Interface, dyn dynamic.Interface) *Orchestrator {
@@ -666,6 +671,10 @@ func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeC
 				pod.Labels[labelSessionID] = sessionID
 				updated, uerr := o.k8s.CoreV1().Pods(sandboxNS).Update(ctx, pod, metav1.UpdateOptions{})
 				if uerr == nil {
+					// Pool just shrank by one: ask the controller to refill now.
+					if o.OnWarmClaim != nil {
+						o.OnWarmClaim()
+					}
 					return updated, nil
 				}
 				// conflict means another request claimed it first — try next warm pod

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"google.golang.org/grpc/codes"
@@ -77,10 +80,51 @@ type Orchestrator struct {
 	mu          sync.Mutex
 	approvals   map[string]*pendingApproval
 	runRegistry map[string]string // run_id → session_id
+
+	// warmPodHealthCheck decides whether a warm pod's sandboxd is actually ready to
+	// serve on :2024 before the pod is claimed for a session. Overridable in tests.
+	warmPodHealthCheck func(ctx context.Context, pod *corev1.Pod) bool
 }
 
 func NewOrchestrator(k8s kubernetes.Interface, dyn dynamic.Interface) *Orchestrator {
-	return &Orchestrator{k8s: k8s, dynamic: dyn, approvals: make(map[string]*pendingApproval), runRegistry: make(map[string]string)}
+	return &Orchestrator{
+		k8s:                k8s,
+		dynamic:            dyn,
+		approvals:          make(map[string]*pendingApproval),
+		runRegistry:        make(map[string]string),
+		warmPodHealthCheck: defaultWarmPodHealthCheck,
+	}
+}
+
+// defaultWarmPodHealthCheck reports whether a warm pod's sandboxd is actually
+// serving on :2024. It requires the kubelet Ready condition (driven by the TCP
+// readiness probe on the sandbox container) plus a direct TCP dial to close the
+// small race between kubelet marking the pod ready and sandboxd accepting sockets.
+func defaultWarmPodHealthCheck(ctx context.Context, pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+		return false
+	}
+	if !PodReadyCondition(pod) {
+		return false
+	}
+	dialer := &net.Dialer{Timeout: 1500 * time.Millisecond}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(sandboxdPort)))
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// PodReadyCondition returns true when the pod's Ready condition is True.
+// Exported for use by the sandboxmatrix controller (warm pod recycling).
+func PodReadyCondition(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 // defaultTTL is used when the session has no explicit TTL (0 = no expiry).
@@ -600,7 +644,10 @@ func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeC
 		if err == nil {
 			for i := range warm.Items {
 				pod := &warm.Items[i]
-				if pod.Status.Phase != corev1.PodRunning {
+				// Only claim warm pods whose sandboxd is actually serving on :2024.
+				// A Running pod may still be booting sandboxd, or sandboxd may have
+				// died silently; claiming either one makes the first Exec fail.
+				if !o.warmPodHealthCheck(ctx, pod) {
 					continue
 				}
 				// atomic claim: use resourceVersion for optimistic locking
@@ -647,11 +694,20 @@ func SandboxPodSpec(runtimeClass, pvcName, cpu, memory, image string) corev1.Pod
 	} else {
 		vol.VolumeSource = corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}
 	}
+	// TCP health probes on :2024: kubelet reflects sandboxd readiness in the pod's
+	// Ready condition, which the warm-pool claim path and the recycling controller
+	// both rely on. StartupProbe gives a slow image pull / sandboxd boot a budget
+	// before readiness starts counting failures.
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(sandboxdPort)},
+		},
+	}
 	spec := corev1.PodSpec{
 		Containers: []corev1.Container{{
 			Name:  "sandbox",
 			Image: image,
-			Ports: []corev1.ContainerPort{{ContainerPort: 2024}},
+			Ports: []corev1.ContainerPort{{ContainerPort: sandboxdPort}},
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse(cpu),
@@ -660,9 +716,20 @@ func SandboxPodSpec(runtimeClass, pvcName, cpu, memory, image string) corev1.Pod
 			},
 			SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: boolPtr(true)},
 			VolumeMounts:    []corev1.VolumeMount{{Name: "workspace", MountPath: "/workspace"}},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler:     probe.ProbeHandler,
+				PeriodSeconds:    2,
+				FailureThreshold: 30, // up to ~60s budget for sandboxd boot
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler:     probe.ProbeHandler,
+				PeriodSeconds:    5,
+				TimeoutSeconds:   2,
+				FailureThreshold: 3,
+			},
 		}},
 		Volumes:       []corev1.Volume{vol},
-		DNSPolicy: corev1.DNSDefault,
+		DNSPolicy:     corev1.DNSDefault,
 		RestartPolicy: corev1.RestartPolicyNever,
 	}
 	if runtimeClass != "" {

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -128,7 +128,7 @@ func defaultWarmPodHealthCheck(ctx context.Context, pod *corev1.Pod) bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
+	_ = conn.Close()
 	return true
 }
 

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -247,6 +247,36 @@ func TestColdStart_NoRefillSignal(t *testing.T) {
 	}
 }
 
+func TestClaimMetrics_WarmVsCold(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	// Fake clients don't filter by label selector, so also require state=warm
+	// here; otherwise the second (cold) claim would re-adopt the claimed pod.
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool {
+		return pod.Labels[labelState] == stateWarm
+	}
+
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, warmTestPod("warm-metric", "10.0.0.9"), metav1.CreateOptions{}) //nolint:errcheck
+
+	mustCreateSession(t, o, "metric-warm")
+	claimed, cold, avg := o.Metrics()
+	if claimed != 1 || cold != 0 {
+		t.Fatalf("after warm claim expected warm=1 cold=0, got %d/%d", claimed, cold)
+	}
+	if avg < 0 {
+		t.Fatalf("expected non-negative avg claim latency, got %d", avg)
+	}
+
+	mustCreateSession(t, o, "metric-cold")
+	claimed, cold, avg = o.Metrics()
+	if claimed != 1 || cold != 1 {
+		t.Fatalf("after cold start expected warm=1 cold=1, got %d/%d", claimed, cold)
+	}
+	if avg < 0 {
+		t.Fatalf("expected non-negative avg claim latency, got %d", avg)
+	}
+}
+
 func TestCreateSession_GeneratesID(t *testing.T) {
 	o := newTestOrchestrator()
 	sess, err := o.CreateSession(context.Background(), &pb.CreateSessionRequest{})

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -221,6 +221,32 @@ func TestClaimWarmPod_LegacyPodWithoutRuntimeLabel(t *testing.T) {
 	}
 }
 
+func TestClaimWarmPod_TriggersRefillSignal(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool { return true }
+	claims := 0
+	o.OnWarmClaim = func() { claims++ }
+
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, warmTestPod("warm-refill", "10.0.0.8"), metav1.CreateOptions{}) //nolint:errcheck
+	mustCreateSession(t, o, "refill-warm")
+	if claims != 1 {
+		t.Fatalf("expected 1 refill signal after warm claim, got %d", claims)
+	}
+}
+
+func TestColdStart_NoRefillSignal(t *testing.T) {
+	o := newTestOrchestrator()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool { return false }
+	claims := 0
+	o.OnWarmClaim = func() { claims++ }
+
+	mustCreateSession(t, o, "refill-cold")
+	if claims != 0 {
+		t.Fatalf("expected no refill signal for cold start, got %d", claims)
+	}
+}
+
 func TestCreateSession_GeneratesID(t *testing.T) {
 	o := newTestOrchestrator()
 	sess, err := o.CreateSession(context.Background(), &pb.CreateSessionRequest{})

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -2,11 +2,13 @@ package grpc
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,6 +77,81 @@ func setSessionExpiry(t *testing.T, o *Orchestrator, sessName, expiresAt string)
 	st["expiresAt"] = expiresAt
 	st["phase"] = "Active"
 	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).UpdateStatus(ctx, u, metav1.UpdateOptions{}) //nolint:errcheck
+}
+
+// warmTestPod builds a Running warm pod fixture for claim-path tests.
+func warmTestPod(name, ip string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   sandboxNS,
+			Labels:      map[string]string{labelState: stateWarm},
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "sandbox", Ports: []corev1.ContainerPort{{ContainerPort: 2024}}}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: ip},
+	}
+}
+
+func TestSandboxPodSpec_IncludesHealthProbes(t *testing.T) {
+	spec := SandboxPodSpec("gvisor", "", "500m", "512Mi", sandboxImage)
+	c := spec.Containers[0]
+	if c.StartupProbe == nil || c.ReadinessProbe == nil {
+		t.Fatal("expected startup + readiness probes on sandbox container")
+	}
+	for name, probe := range map[string]*corev1.Probe{"startup": c.StartupProbe, "readiness": c.ReadinessProbe} {
+		if probe.TCPSocket == nil || probe.TCPSocket.Port.IntValue() != 2024 {
+			t.Errorf("%s probe should TCP-check :2024, got %+v", name, probe)
+		}
+	}
+}
+
+func TestClaimWarmPod_PrefersReadyPod(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool {
+		return pod.Annotations["test-healthy"] == "yes"
+	}
+
+	ready := warmTestPod("warm-ready", "10.0.0.2")
+	ready.Annotations["test-healthy"] = "yes"
+	notReady := warmTestPod("warm-notready", "10.0.0.3")
+
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, ready, metav1.CreateOptions{})    //nolint:errcheck
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, notReady, metav1.CreateOptions{}) //nolint:errcheck
+
+	sess := mustCreateSession(t, o, "claim-ready")
+	pod, err := o.k8s.CoreV1().Pods(sandboxNS).Get(ctx, sess.Status.PodName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get claimed pod: %v", err)
+	}
+	if pod.Name != "warm-ready" {
+		t.Fatalf("expected warm-ready to be claimed, got %s", pod.Name)
+	}
+	if pod.Labels[labelState] != stateActive {
+		t.Fatalf("expected claimed pod state=active, got %s", pod.Labels[labelState])
+	}
+	if pod.Labels[labelSessionID] != "claim-ready" {
+		t.Fatalf("expected session label on claimed pod, got %v", pod.Labels)
+	}
+}
+
+func TestClaimWarmPod_FallsBackToColdStart(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool { return false }
+
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, warmTestPod("warm-unhealthy", "10.0.0.2"), metav1.CreateOptions{}) //nolint:errcheck
+
+	sess := mustCreateSession(t, o, "claim-cold")
+	if strings.HasPrefix(sess.Status.PodName, "warm-") {
+		t.Fatalf("expected cold-start pod, got warm pod %s", sess.Status.PodName)
+	}
+	if !strings.HasPrefix(sess.Status.PodName, "sandbox-") {
+		t.Fatalf("expected sandbox-* cold-start pod name, got %s", sess.Status.PodName)
+	}
 }
 
 func TestCreateSession_GeneratesID(t *testing.T) {

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -80,12 +80,16 @@ func setSessionExpiry(t *testing.T, o *Orchestrator, sessName, expiresAt string)
 }
 
 // warmTestPod builds a Running warm pod fixture for claim-path tests.
+// The pod is labeled with runtimeClass "gvisor" (the session default).
 func warmTestPod(name, ip string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   sandboxNS,
-			Labels:      map[string]string{labelState: stateWarm},
+			Name:      name,
+			Namespace: sandboxNS,
+			Labels: map[string]string{
+				labelState:        stateWarm,
+				labelRuntimeClass: "gvisor",
+			},
 			Annotations: map[string]string{},
 		},
 		Spec: corev1.PodSpec{
@@ -151,6 +155,69 @@ func TestClaimWarmPod_FallsBackToColdStart(t *testing.T) {
 	}
 	if !strings.HasPrefix(sess.Status.PodName, "sandbox-") {
 		t.Fatalf("expected sandbox-* cold-start pod name, got %s", sess.Status.PodName)
+	}
+}
+
+func TestClaimWarmPod_RuntimeClassMismatchSkipped(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool { return true }
+
+	kata := warmTestPod("warm-kata", "10.0.0.4")
+	kata.Labels[labelRuntimeClass] = "kata"
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, kata, metav1.CreateOptions{}) //nolint:errcheck
+
+	// session defaults to gvisor — the kata warm pod must not be adopted
+	sess := mustCreateSession(t, o, "rt-mismatch")
+	if strings.HasPrefix(sess.Status.PodName, "warm-") {
+		t.Fatalf("expected cold-start (runtime-mismatched warm pod must not be claimed), got %s", sess.Status.PodName)
+	}
+	pod, err := o.k8s.CoreV1().Pods(sandboxNS).Get(ctx, "warm-kata", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get kata pod: %v", err)
+	}
+	if pod.Labels[labelState] != stateWarm {
+		t.Fatalf("kata warm pod should stay warm, got state %s", pod.Labels[labelState])
+	}
+	// cold-start pod records the session runtime
+	cold, err := o.k8s.CoreV1().Pods(sandboxNS).Get(ctx, sess.Status.PodName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get cold pod: %v", err)
+	}
+	if cold.Labels[labelRuntimeClass] != "gvisor" {
+		t.Fatalf("expected cold-start pod runtime label gvisor, got %v", cold.Labels)
+	}
+}
+
+func TestClaimWarmPod_RuntimeClassMatchClaimed(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool { return true }
+
+	gv := warmTestPod("warm-gv", "10.0.0.5")
+	kata := warmTestPod("warm-kata2", "10.0.0.6")
+	kata.Labels[labelRuntimeClass] = "kata"
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, gv, metav1.CreateOptions{})  //nolint:errcheck
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, kata, metav1.CreateOptions{}) //nolint:errcheck
+
+	sess := mustCreateSession(t, o, "rt-match")
+	if sess.Status.PodName != "warm-gv" {
+		t.Fatalf("expected gvisor warm pod claimed, got %s", sess.Status.PodName)
+	}
+}
+
+func TestClaimWarmPod_LegacyPodWithoutRuntimeLabel(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	o.warmPodHealthCheck = func(ctx context.Context, pod *corev1.Pod) bool { return true }
+
+	legacy := warmTestPod("warm-legacy", "10.0.0.7")
+	delete(legacy.Labels, labelRuntimeClass)
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, legacy, metav1.CreateOptions{}) //nolint:errcheck
+
+	sess := mustCreateSession(t, o, "rt-legacy")
+	if sess.Status.PodName != "warm-legacy" {
+		t.Fatalf("expected legacy warm pod (no runtime label) claimed, got %s", sess.Status.PodName)
 	}
 }
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,233 @@
+{
+  "version": 1,
+  "skills": {
+    "ask-matt": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/ask-matt/SKILL.md",
+      "computedHash": "2d3f523c8bf1ebbd4d5ecaa1e2678ec629f157248669f1edba807de1d0feb031"
+    },
+    "claude-handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/claude-handoff/SKILL.md",
+      "computedHash": "6bde27729c8a56b601b4137024a6a9e8056e214b45d2cfc64c69eec93d0b6f66"
+    },
+    "code-review": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/code-review/SKILL.md",
+      "computedHash": "4a17d9d3e0fc87ae48544d371a820fac5a4a78f4c05e7e6b3229094fbf8a7e26"
+    },
+    "codebase-design": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/codebase-design/SKILL.md",
+      "computedHash": "2426dc4accf1a85dedfb560edb3a877ec8828b7375ea08c970df2b6c900a2a22"
+    },
+    "design-an-interface": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/deprecated/design-an-interface/SKILL.md",
+      "computedHash": "885b05367fb1cf61a1e27e0d50f14d2502a05c1fa276c6e9ea050ce6a90e7095"
+    },
+    "diagnosing-bugs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/diagnosing-bugs/SKILL.md",
+      "computedHash": "1a993ce9b2aaa653ee441c8d7efb7f27de03493c722be6dfb8137bcb8db1bc72"
+    },
+    "domain-modeling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/domain-modeling/SKILL.md",
+      "computedHash": "67343881f5def98487d56243155716110afbcbf22ec92421c882d532b941cb17"
+    },
+    "edit-article": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/personal/edit-article/SKILL.md",
+      "computedHash": "8d7aec1987245a27e9c7d585b9f11d1129b8bd8ecb3a8596cdd3048974d9e302"
+    },
+    "git-guardrails-claude-code": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/misc/git-guardrails-claude-code/SKILL.md",
+      "computedHash": "53a1de29d2b76481202608376fa4a20a8bd7e65b0b8a907a8c9578e629cf313f"
+    },
+    "grill-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grill-me/SKILL.md",
+      "computedHash": "f321507f77702a54af1db66549ec1685fc625390d06c57d7949cdcda8eb1b5c7"
+    },
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
+    },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "bf1e75d96966edd298902d63348c828921b8b095d7306d0cdd56b4a591a7a82b"
+    },
+    "handoff": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/handoff/SKILL.md",
+      "computedHash": "5d0f81e38abe6b984e1feaa731927de5291d040982106ac513cf54ec240e00ec"
+    },
+    "implement": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/implement/SKILL.md",
+      "computedHash": "5eedab2e36a68278662484e8e243624fe0bb74040299aa6c8a525feb65b0365c"
+    },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "8bf292143ca93b00276a0de0fc5f84f2381f4690c5b0d32e99fa283a072f392f"
+    },
+    "loop-me": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/loop-me/SKILL.md",
+      "computedHash": "b3306d9b5af2e9ed341ec290ea97898205f27fb3131b16b8535549b8c90343f8"
+    },
+    "migrate-to-shoehorn": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/misc/migrate-to-shoehorn/SKILL.md",
+      "computedHash": "8f1a623a019abca0ab5e22e8deaae375829368cc1344016010201cf650331d33"
+    },
+    "obsidian-vault": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/personal/obsidian-vault/SKILL.md",
+      "computedHash": "960437c7c2febc15cf9d49964f0c8bd889d90a56e81b6eaa33f3ac5b594291c3"
+    },
+    "prototype": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/prototype/SKILL.md",
+      "computedHash": "e70c8933d30153a4da47865829d356824b2a830367275e3b00c7b431a1544a79"
+    },
+    "qa": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/deprecated/qa/SKILL.md",
+      "computedHash": "20c63e29b268b1f0762cff524b5e321d5e1a773b4f61b90d84811b755948a66c"
+    },
+    "request-refactor-plan": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/deprecated/request-refactor-plan/SKILL.md",
+      "computedHash": "176cf1d0c4dc4fc4d958c4bc4ed67f222f2656bda2f3f15e3a3e98b2e5edaf2f"
+    },
+    "research": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/research/SKILL.md",
+      "computedHash": "87d17f5103899fbe179b552a85485d50f2316ca5b3128f5716af7d88817533e1"
+    },
+    "resolving-merge-conflicts": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/resolving-merge-conflicts/SKILL.md",
+      "computedHash": "bff6e06cec85897477759ed052410450aa91057644f5b70d888e26bc8b348847"
+    },
+    "scaffold-exercises": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/misc/scaffold-exercises/SKILL.md",
+      "computedHash": "486d60a7e984b76850bd22b3b58b98d0063a3b9b3acf319e4d5a37bf1283ea02"
+    },
+    "setup-matt-pocock-skills": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/setup-matt-pocock-skills/SKILL.md",
+      "computedHash": "a7d798f49081ea5b2606e8bcafa3bc2b34177cfaa24d71c2ddf2d433f4006a4a"
+    },
+    "setup-pre-commit": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/misc/setup-pre-commit/SKILL.md",
+      "computedHash": "f9aeedf0a1f560ec465c3939c54434c2d949ac8b958a0493db52216f688a0366"
+    },
+    "tdd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/tdd/SKILL.md",
+      "computedHash": "c9326b88419cfba1d54dd713b7ddb23020e6a93f4b0d13aea58cebba58cda2ee"
+    },
+    "teach": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/teach/SKILL.md",
+      "computedHash": "9cd31ea42b40915ea5fd3949ed229b217d1dfad07dd93d9b0db771dcdd6a6c8a"
+    },
+    "to-issues": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-issues/SKILL.md",
+      "computedHash": "4e2a11d35f018490d42a79234432f779d7131b9920373ef24cfbc68229bfef6c"
+    },
+    "to-prd": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-prd/SKILL.md",
+      "computedHash": "5a733e19d825f22e83de52e68b8840c9fd2fa7501282277a122c1aa28a922059"
+    },
+    "triage": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/triage/SKILL.md",
+      "computedHash": "b77ea99c2e6e97815b373cc476ad4cc1835d3e736867b764602147be71f6c131"
+    },
+    "ubiquitous-language": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/deprecated/ubiquitous-language/SKILL.md",
+      "computedHash": "c8968b02b83c365bc81d85cc17fb4c8854b80f5b6dece322164fff5b00142231"
+    },
+    "wayfinder": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/wayfinder/SKILL.md",
+      "computedHash": "195d37713ebe223a45b497d8a652c2209ee80286b68888d98fcfac460cf368b1"
+    },
+    "wizard": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/wizard/SKILL.md",
+      "computedHash": "6ac45e430f0ca1409e618729156096fb042a81a12e0d2824920b7dfc0adc9329"
+    },
+    "writing-beats": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/writing-beats/SKILL.md",
+      "computedHash": "b2bb74a1e15fcac1fec9aac4fa4c8244e8ed7c4eef1f9096ea3b52b7eb091943"
+    },
+    "writing-fragments": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/writing-fragments/SKILL.md",
+      "computedHash": "394bc75401f55d242ecebb548e9932a211b84423ca25ebe7bbfdebde4f6066ce"
+    },
+    "writing-great-skills": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/writing-great-skills/SKILL.md",
+      "computedHash": "dd555ce552f82784c3d2b8d13a8e26a6677a07ddc00032e142dec33bfd5438c6"
+    },
+    "writing-shape": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/in-progress/writing-shape/SKILL.md",
+      "computedHash": "77007511510c05b602835acdb91a88f435ce5a08a9dbf95ade148f02e4b09548"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Five commits on `dev` (4 sandbox warm-pool improvements + 1 agents housekeeping):

| Commit | Change |
|--------|--------|
| `94cfd60f` | **fix(sandbox)** only claim warm pods whose sandboxd is actually serving |
| `d58fb331` | **fix(sandbox)** claim warm pods only for matching RuntimeClass |
| `d8a6daa0` | **feat(sandbox)** refill warm pool immediately after a warm claim |
| `178de2fd` | **feat(sandbox)** surface warm-pool hit rate and claim latency in status |
| `88793e17` | **chore(agents)** commit skills-lock.json, drop empty root package.json |

## Motivation

Sandbox session startup was unreliable and pool resources were wasted:
1. **Booting pods claimed as warm** — `claimOrCreatePod` only checked `PodRunning`; a pod whose sandboxd was still starting (or had died silently, `RestartPolicy: Never`) got claimed and the first Exec failed.
2. **Runtime mixing** — a gVisor warm pod could be adopted by a Kata session and vice versa.
3. **Pool shortfall after claims** — the warm pool reconciler polled every 10s, so right after a claim the pool ran short until the next tick, forcing cold starts.
4. **No observability** — warm-claim vs cold-start outcomes and acquisition latency were unmeasured, so pool tuning was guesswork.

## Changes

- **Readiness gating**: `SandboxPodSpec` now adds `StartupProbe` + `ReadinessProbe` (TCP `:2024`), so the kubelet Ready condition reflects real sandboxd health; `claimOrCreatePod` requires Running + Ready condition + direct TCP dial (1.5s). New `recycleUnhealthyWarmPods` deletes Failed / stale not-ready warm pods (5 min budget); the reconciler recreates them.
- **Runtime-aware claim**: new `sandbox.k8e.io/runtime-class` label on warm and cold-start pods; claims skip runtime-mismatched warm pods; unlabeled legacy pods remain claimable for backward compatibility.
- **Immediate refill**: `Orchestrator.OnWarmClaim` → buffered refill channel → reconciler reconciles on signal or 10s ticker.
- **Metrics**: atomic counters `claimedFromWarm` / `coldStarts` / `avgClaimLatencyMs` surfaced via `Orchestrator.Metrics()` into `SandboxMatrix.status`; CRD status schema updated in `manifests/sandbox-matrix/crds.yaml`.
- **Agents housekeeping**: commit `skills-lock.json` (38 pinned skills, reproducible installs); remove empty root `package.json`/`package-lock.json` (no JS toolchain in this Zig+Go repo).

## Validation

- 11 new unit tests (probes, claim gating, runtime filtering, legacy fallback, refill signal, cold-start fallback, recycle, metrics, status surface)
- `go build ./...`, `go vet ./pkg/sandboxmatrix/...` clean
- `go test ./pkg/sandboxmatrix/... ./pkg/sandboxcli/...` all green
- gofmt: no new drift beyond pre-existing repo baseline

## Notes

- `pkg/crd/crds.go` generates CRD schemas from structs; `manifests/sandbox-matrix/crds.yaml` is the checked-in copy and was updated in sync.
- Follow-up (separate issue): adaptive pool sizing — demand-based shrink/grow using the new hit-rate metrics, multi-node capacity (`computeMaxPods` currently uses only the first node, memory-only).