### PR TITLE
feat(sandbox): expose preview URLs with signed tokens + unexpose/ttl/GC revocation lifecycle (#486 #487)

### DIFF
--- a/cmd/sandboxcli/main.go
+++ b/cmd/sandboxcli/main.go
@@ -41,6 +41,8 @@ func main() {
 		sandboxcli.PollCommand(),
 		sandboxcli.BenchmarkCommand(),
 		sandboxcli.InstallSkillCommand(),
+		sandboxcli.ExposeCommand(),
+		sandboxcli.UnexposeCommand(),
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -111,6 +111,10 @@ type Server struct {
 	SandboxDefaultMemory    string
 	SandboxGRPCPort         int
 	SandboxNamespace        string
+	SandboxPreviewDomain    string
+	SandboxIngressClass     string
+	SandboxPreviewVerifyURL string
+	SandboxPreviewPort      int
 }
 
 var (
@@ -573,6 +577,33 @@ var ServerFlags = []cli.Flag{
 		Value:       "sandbox-matrix",
 		Destination: &ServerConfig.SandboxNamespace,
 		EnvVar:      "K8E_SANDBOX_NAMESPACE",
+	},
+	&cli.StringFlag{
+		Name:        "sandbox-preview-domain",
+		Usage:       "(sandbox) Wildcard host preview URLs live under (e.g. preview.k8e.local)",
+		Value:       "preview.k8e.local",
+		Destination: &ServerConfig.SandboxPreviewDomain,
+		EnvVar:      "K8E_SANDBOX_PREVIEW_DOMAIN",
+	},
+	&cli.StringFlag{
+		Name:        "sandbox-ingress-class",
+		Usage:       "(sandbox) Ingress class for preview Ingresses",
+		Value:       "nginx",
+		Destination: &ServerConfig.SandboxIngressClass,
+		EnvVar:      "K8E_SANDBOX_INGRESS_CLASS",
+	},
+	&cli.StringFlag{
+		Name:        "sandbox-preview-verify-url",
+		Usage:       "(sandbox) Base URL the Ingress controller uses to reach the gateway /preview/verify (default http://127.0.0.1:<preview-port>)",
+		Destination: &ServerConfig.SandboxPreviewVerifyURL,
+		EnvVar:      "K8E_SANDBOX_PREVIEW_VERIFY_URL",
+	},
+	&cli.IntFlag{
+		Name:        "sandbox-preview-port",
+		Usage:       "(sandbox) HTTP listen port for /preview/verify (Ingress auth callback)",
+		Value:       50052,
+		Destination: &ServerConfig.SandboxPreviewPort,
+		EnvVar:      "K8E_SANDBOX_PREVIEW_PORT",
 	},
 
 	// Hidden/Deprecated flags below

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -151,12 +151,16 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 	serverConfig.ControlConfig.EncryptSecrets = cfg.EncryptSecrets
 	serverConfig.ControlConfig.DisableSandboxMatrix = cfg.DisableSandboxMatrix
 	serverConfig.ControlConfig.SandboxConfig = config.SandboxConfig{
-		DefaultRuntime: cfg.SandboxDefaultRuntime,
-		DefaultImage:   cfg.SandboxDefaultImage,
-		DefaultCPU:     cfg.SandboxDefaultCPU,
-		DefaultMemory:  cfg.SandboxDefaultMemory,
-		GRPCPort:       cfg.SandboxGRPCPort,
-		Namespace:      cfg.SandboxNamespace,
+		DefaultRuntime:      cfg.SandboxDefaultRuntime,
+		DefaultImage:        cfg.SandboxDefaultImage,
+		DefaultCPU:          cfg.SandboxDefaultCPU,
+		DefaultMemory:       cfg.SandboxDefaultMemory,
+		GRPCPort:            cfg.SandboxGRPCPort,
+		Namespace:           cfg.SandboxNamespace,
+		PreviewDomain:       cfg.SandboxPreviewDomain,
+		PreviewIngressClass: cfg.SandboxIngressClass,
+		PreviewVerifyURL:    cfg.SandboxPreviewVerifyURL,
+		PreviewPort:         cfg.SandboxPreviewPort,
 	}
 	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
 	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -196,6 +196,16 @@ type SandboxConfig struct {
 	DefaultMemory  string
 	GRPCPort       int
 	Namespace      string
+	// PreviewDomain is the wildcard host preview URLs live under
+	// (e.g. preview.k8e.local).
+	PreviewDomain string
+	// PreviewIngressClass is the ingressClassName for preview Ingresses.
+	PreviewIngressClass string
+	// PreviewVerifyURL is the base URL the Ingress controller uses to reach the
+	// gateway /preview/verify endpoint (e.g. http://127.0.0.1:50052).
+	PreviewVerifyURL string
+	// PreviewPort is the HTTP listener port for /preview/verify.
+	PreviewPort int
 }
 
 type Control struct {

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -6,15 +6,16 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+	"github.com/xiaods/k8e/pkg/sandbox/client"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
-	"github.com/xiaods/k8e/pkg/sandbox/client"
 )
 
 const errSessionNotFound = "not found"
@@ -158,7 +159,7 @@ func RunCommand() cli.Command {
 			cli.StringFlag{Name: "session-id", EnvVar: "K8E_SANDBOX_SESSION_ID", Usage: "Explicit session ID"},
 			cli.StringFlag{Name: "tenant", EnvVar: "K8E_SANDBOX_TENANT", Usage: "Tenant for cross-process session reuse"},
 			cli.BoolFlag{Name: "background", Usage: "Submit asynchronously, return run_id immediately"},
-		cli.BoolFlag{Name: "raw", Usage: "Stream raw output (no JSON wrapper)"},
+			cli.BoolFlag{Name: "raw", Usage: "Stream raw output (no JSON wrapper)"},
 			cli.StringFlag{Name: "manifest", Usage: "Path to workspace manifest (only when auto-creating session)"},
 			cli.StringFlag{Name: "git-repo", Usage: "Git repo to clone (only when auto-creating session)"},
 			cli.StringFlag{Name: "git-ref", Value: "main", Usage: "Git ref for --git-repo"},
@@ -340,13 +341,13 @@ func StatusCommand() cli.Command {
 			defer client.Close()
 
 			// lightweight probe
-		_, err := client.SandboxServiceClient.DestroySession(context.Background(),
-			&pb.DestroySessionRequest{SessionId: "healthcheck-probe-noop"})
-		available := err == nil || strings.Contains(err.Error(), errSessionNotFound)
-		errMsg := ""
-		if !available && err != nil {
-			errMsg = err.Error()
-		}
+			_, err := client.SandboxServiceClient.DestroySession(context.Background(),
+				&pb.DestroySessionRequest{SessionId: "healthcheck-probe-noop"})
+			available := err == nil || strings.Contains(err.Error(), errSessionNotFound)
+			errMsg := ""
+			if !available && err != nil {
+				errMsg = err.Error()
+			}
 
 			sid, tid := "", ""
 			if state, _ := loadState("default"); state != nil && state.SessionID != "" {
@@ -929,8 +930,8 @@ func printBenchmarkResults(results map[string][]time.Duration) {
 	fmt.Fprintln(os.Stderr, "═══ Benchmark Results ═══")
 
 	sections := []struct {
-		title  string
-		keys   []string
+		title string
+		keys  []string
 	}{
 		{"Cold Start (no warm pool)", []string{"cold_create", "cold_exec", "cold_total"}},
 		{"Warm Claim (from pool)", []string{"warm_create", "warm_exec", "warm_total"}},
@@ -981,6 +982,87 @@ func PollCommand() cli.Command {
 				"stderr":    resp.Stderr,
 				"exit_code": resp.ExitCode,
 			})
+			return nil
+		},
+	}
+}
+
+// ── ExposeCommand ──────────────────────────────────────────────────────────
+
+func ExposeCommand() cli.Command {
+	return cli.Command{
+		Name:      "expose",
+		Usage:     "Publish a session port through a signed, time-limited preview URL",
+		ArgsUsage: "<session-id> <port>",
+		Flags: []cli.Flag{
+			cli.IntFlag{Name: "ttl", Usage: "Preview URL lifetime in seconds (default: session TTL)"},
+		},
+		Action: func(ctx *cli.Context) error {
+			sid := ctx.Args().Get(0)
+			portRaw := ctx.Args().Get(1)
+			if sid == "" || portRaw == "" {
+				return printErrorExit("usage: k8e-sandbox-cli expose <session-id> <port> [--ttl <seconds>]", 1)
+			}
+			port, err := strconv.Atoi(portRaw)
+			if err != nil || port <= 0 || port > 65535 {
+				return printErrorExit("invalid port: "+portRaw, 1)
+			}
+
+			client, exitErr := newClientFromCtx(ctx)
+			if exitErr != nil {
+				return exitErr
+			}
+			defer client.Close()
+
+			resp, err := client.SandboxServiceClient.ExposePort(context.Background(), &pb.ExposePortRequest{
+				SessionId:  sid,
+				Port:       int32(port),
+				TtlSeconds: int32(ctx.Int("ttl")),
+			})
+			if err != nil {
+				return printErrorExit("expose: "+err.Error(), 1)
+			}
+			printJSON(map[string]any{
+				"url":        resp.Url,
+				"expires_at": resp.ExpiresAt,
+			})
+			return nil
+		},
+	}
+}
+
+// ── UnexposeCommand ────────────────────────────────────────────────────────
+
+func UnexposeCommand() cli.Command {
+	return cli.Command{
+		Name:      "unexpose",
+		Usage:     "Revoke a preview route (Service + Ingress) for a session port",
+		ArgsUsage: "<session-id> <port>",
+		Action: func(ctx *cli.Context) error {
+			sid := ctx.Args().Get(0)
+			portRaw := ctx.Args().Get(1)
+			if sid == "" || portRaw == "" {
+				return printErrorExit("usage: k8e-sandbox-cli unexpose <session-id> <port>", 1)
+			}
+			port, err := strconv.Atoi(portRaw)
+			if err != nil || port <= 0 || port > 65535 {
+				return printErrorExit("invalid port: "+portRaw, 1)
+			}
+
+			client, exitErr := newClientFromCtx(ctx)
+			if exitErr != nil {
+				return exitErr
+			}
+			defer client.Close()
+
+			resp, err := client.SandboxServiceClient.UnexposePort(context.Background(), &pb.UnexposePortRequest{
+				SessionId: sid,
+				Port:      int32(port),
+			})
+			if err != nil {
+				return printErrorExit("unexpose: "+err.Error(), 1)
+			}
+			printJSON(map[string]any{"ok": resp.Ok, "session_id": sid, "port": port})
 			return nil
 		},
 	}

--- a/pkg/sandboxmatrix/api/v1alpha1/types.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/types.go
@@ -74,6 +74,17 @@ type SandboxSessionStatus struct {
 	WorkspacePVC string        `json:"workspacePVC,omitempty"`
 	CreatedAt    *metav1.Time  `json:"createdAt,omitempty"`
 	ExpiresAt    *metav1.Time  `json:"expiresAt,omitempty"`
+	// ExposedPorts tracks the preview routes currently published for this
+	// session. Session GC and DestroySession revoke every entry.
+	ExposedPorts []ExposedPort `json:"exposedPorts,omitempty"`
+}
+
+// ExposedPort is a published preview route for one session port.
+type ExposedPort struct {
+	Port      int32        `json:"port,omitempty"`
+	TTL       int32        `json:"ttl,omitempty"`
+	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
+	URL       string       `json:"url,omitempty"`
 }
 
 type SandboxPhase string

--- a/pkg/sandboxmatrix/api/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/zz_generated_deepcopy.go
@@ -111,6 +111,30 @@ func (in *SandboxSessionStatus) DeepCopyInto(out *SandboxSessionStatus) {
 		t := in.ExpiresAt.DeepCopy()
 		out.ExpiresAt = t
 	}
+	if in.ExposedPorts != nil {
+		in, out := &in.ExposedPorts, &out.ExposedPorts
+		*out = make([]ExposedPort, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *ExposedPort) DeepCopyInto(out *ExposedPort) {
+	*out = *in
+	if in.ExpiresAt != nil {
+		t := in.ExpiresAt.DeepCopy()
+		out.ExpiresAt = t
+	}
+}
+
+func (in *ExposedPort) DeepCopy() *ExposedPort {
+	if in == nil {
+		return nil
+	}
+	out := new(ExposedPort)
+	in.DeepCopyInto(out)
+	return out
 }
 func (in *SandboxSessionList) DeepCopy() *SandboxSessionList {
 	if in == nil {

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -3,6 +3,7 @@ package sandboxmatrix
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"sync"
@@ -49,6 +50,16 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 	if cfg.Namespace == "" {
 		cfg.Namespace = "sandbox-matrix"
 	}
+	// Preview verify endpoint reachable from the Ingress controller. Defaults to
+	// the loopback of this node, which is correct for single-node/hostNetwork
+	// deployments; multi-node deployments must set K8E_SANDBOX_PREVIEW_VERIFY_URL
+	// to a URL the Ingress controller can reach.
+	if cfg.PreviewPort == 0 {
+		cfg.PreviewPort = 50052
+	}
+	if cfg.PreviewVerifyURL == "" {
+		cfg.PreviewVerifyURL = fmt.Sprintf("http://127.0.0.1:%d", cfg.PreviewPort)
+	}
 
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -84,6 +95,13 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 		ServerCertFile: tlsDir + "/sandbox-server.crt",
 		ServerKeyFile:  tlsDir + "/sandbox-server.key",
 		GRPCPort:       cfg.GRPCPort,
+		Preview: sandboxgrpc.PreviewConfig{
+			Domain:        cfg.PreviewDomain,
+			IngressClass:  cfg.PreviewIngressClass,
+			VerifyBaseURL: cfg.PreviewVerifyURL,
+		},
+		PreviewKeyFile:  tlsDir + "/sandbox-preview.key",
+		PreviewHTTPPort: cfg.PreviewPort,
 	})
 	go func() {
 		if err := srv.Start(ctx); err != nil {
@@ -463,6 +481,8 @@ func gcExpiredSessions(ctx context.Context, orch *sandboxgrpc.Orchestrator, name
 			}
 		}
 	}
+	// Sweep preview routes whose session disappeared through another path.
+	orch.ReconcilePreviewOrphans(ctx)
 }
 
 // podReleasedAtAnnotation records when a pod was released back to warm pool.

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -8,11 +8,16 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,11 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
-	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 )
 
 const (
@@ -70,8 +73,8 @@ var (
 )
 
 type pendingApproval struct {
-	action   string
-	approved chan bool
+	action    string
+	approved  chan bool
 	createdAt time.Time
 }
 
@@ -85,6 +88,7 @@ type Orchestrator struct {
 	mu          sync.Mutex
 	approvals   map[string]*pendingApproval
 	runRegistry map[string]string // run_id → session_id
+	preview     *previewEngine    // preview token/verify engine; nil until InitPreview
 
 	// warmPodHealthCheck decides whether a warm pod's sandboxd is actually ready to
 	// serve on :2024 before the pod is claimed for a session. Overridable in tests.
@@ -341,6 +345,14 @@ func (o *Orchestrator) DestroySession(ctx context.Context, sessionID string) err
 	// 1. Delete CNP
 	o.deleteCNP(ctx, session)
 
+	// 1b. Revoke every outstanding preview route (Service + Ingress) for the
+	// session. This is what makes session GC tear down previews too — the GC
+	// path funnels through DestroySession.
+	o.deletePreviewResources(ctx, sessionID)
+	if o.preview != nil {
+		o.preview.RevokeSession(sessionID)
+	}
+
 	// 2. Find the pod by session-id label and reset its workspace
 	podIP, podName := o.findPodBySession(ctx, sessionID)
 	if podIP == "" && session.Status.PodName != "" {
@@ -572,7 +584,9 @@ func (o *Orchestrator) ExecBackground(ctx context.Context, sessionID, command st
 	}
 	defer resp.Body.Close()
 
-	var result struct{ Status string `json:"status"` }
+	var result struct {
+		Status string `json:"status"`
+	}
 	json.NewDecoder(resp.Body).Decode(&result)
 
 	o.mu.Lock()
@@ -626,7 +640,324 @@ func (o *Orchestrator) RebuildRunRegistry(ctx context.Context, namespace string)
 	}
 }
 
-// getPodIPBySession returns the pod IP for a session, polling if needed.
+// defaultPreviewTTL is the token TTL used when neither the request nor the
+// session carries an expiry (session TTL unset).
+const defaultPreviewTTL = 3600
+
+// PreviewEngine exposes the engine to tests and the server.
+func (o *Orchestrator) PreviewEngine() *previewEngine {
+	return o.preview
+}
+
+// InitPreview wires the preview engine (token mint/verify + config) onto the
+// orchestrator. Safe to call once at startup; the engine keeps a persisted key.
+func (o *Orchestrator) InitPreview(cfg PreviewConfig, keyFile string) error {
+	if o.preview != nil {
+		return nil
+	}
+	e, err := newPreviewEngine(o.k8s, o.dynamic, cfg, keyFile)
+	if err != nil {
+		return err
+	}
+	o.preview = e
+	return nil
+}
+
+// ExposePort publishes a session port through a Service + Ingress and mints a
+// signed, time-limited preview token. Re-exposing the same (session, port)
+// reuses the existing Service/Ingress route and issues a fresh token.
+func (o *Orchestrator) ExposePort(ctx context.Context, sessionID string, port int32, ttlSeconds int32) (string, int64, error) {
+	if o.preview == nil {
+		return "", 0, status.Errorf(codes.FailedPrecondition, "preview not configured on this gateway")
+	}
+	if port <= 0 || port > 65535 {
+		return "", 0, status.Errorf(codes.InvalidArgument, "port %d out of range", port)
+	}
+	session, err := o.getSession(ctx, sessionID)
+	if err != nil {
+		return "", 0, status.Errorf(codes.NotFound, "session %s not found", sessionID)
+	}
+	if session.Status.Phase != sandboxv1.SandboxPhaseActive {
+		return "", 0, status.Errorf(codes.FailedPrecondition, "session %s not active (phase %s)", sessionID, session.Status.Phase)
+	}
+	if session.Status.ExpiresAt != nil && !session.Status.ExpiresAt.Time.After(time.Now()) {
+		return "", 0, status.Errorf(codes.FailedPrecondition, "session %s expired", sessionID)
+	}
+
+	// Token TTL: explicit request TTL wins; otherwise follow the session TTL;
+	// fall back to the default when the session never expires.
+	ttl := int64(ttlSeconds)
+	if ttl <= 0 {
+		ttl = defaultPreviewTTL
+		if session.Status.ExpiresAt != nil {
+			ttl = int64(time.Until(session.Status.ExpiresAt.Time).Seconds())
+			if ttl <= 0 {
+				return "", 0, status.Errorf(codes.FailedPrecondition, "session %s has no remaining TTL", sessionID)
+			}
+		}
+	}
+
+	// The Service selects the session pod by label; a live pod is required for a
+	// working preview.
+	if _, podName := o.findPodBySession(ctx, sessionID); podName == "" {
+		return "", 0, status.Errorf(codes.FailedPrecondition, "session %s pod unavailable", sessionID)
+	}
+
+	name := previewResourceName(sessionID, port)
+	reused := true
+	_, err = o.k8s.CoreV1().Services(sandboxNS).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		if _, err = o.k8s.CoreV1().Services(sandboxNS).Create(ctx, previewService(name, sessionID, port), metav1.CreateOptions{}); err != nil {
+			return "", 0, status.Errorf(codes.Internal, "create preview Service: %v", err)
+		}
+		reused = false
+	} else if err != nil {
+		return "", 0, status.Errorf(codes.Internal, "get preview Service: %v", err)
+	}
+
+	ing, err := o.k8s.NetworkingV1().Ingresses(sandboxNS).Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		ing = previewIngress(name, sessionID, port, o.preview.cfg)
+		if ing, err = o.k8s.NetworkingV1().Ingresses(sandboxNS).Create(ctx, ing, metav1.CreateOptions{}); err != nil {
+			return "", 0, status.Errorf(codes.Internal, "create preview Ingress: %v", err)
+		}
+		reused = false
+	} else if err != nil {
+		return "", 0, status.Errorf(codes.Internal, "get preview Ingress: %v", err)
+	}
+
+	token, err := o.preview.mintToken(sessionID, port, ttl)
+	if err != nil {
+		return "", 0, status.Errorf(codes.Internal, "mint preview token: %v", err)
+	}
+	expiresAt := time.Now().Add(time.Duration(ttl) * time.Second).Unix()
+	url := previewURL(o.preview.cfg, sessionID, port, token)
+
+	if err := o.upsertExposedPort(ctx, session, port, int32(ttl), expiresAt, url); err != nil {
+		return "", 0, status.Errorf(codes.Internal, "record exposed port: %v", err)
+	}
+	if err := o.applyCNP(ctx, session); err != nil {
+		return "", 0, status.Errorf(codes.Internal, "update network policy: %v", err)
+	}
+
+	if reused {
+		logrus.Infof("sandbox: reused preview route %s for session %s port %d (fresh token)", name, sessionID, port)
+	} else {
+		logrus.Infof("sandbox: exposed session %s port %d via %s", sessionID, port, url)
+	}
+	return url, expiresAt, nil
+}
+
+// UnexposePort removes the Service + Ingress for (session, port) immediately
+// and revokes outstanding tokens. The URL stops serving (403 at verify).
+func (o *Orchestrator) UnexposePort(ctx context.Context, sessionID string, port int32) error {
+	session, err := o.getSession(ctx, sessionID)
+	if err != nil {
+		return status.Errorf(codes.NotFound, "session %s not found", sessionID)
+	}
+	name := previewResourceName(sessionID, port)
+	if err := o.k8s.CoreV1().Services(sandboxNS).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return status.Errorf(codes.Internal, "delete preview Service: %v", err)
+	}
+	if err := o.k8s.NetworkingV1().Ingresses(sandboxNS).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return status.Errorf(codes.Internal, "delete preview Ingress: %v", err)
+	}
+
+	ports := session.Status.ExposedPorts[:0]
+	for _, ep := range session.Status.ExposedPorts {
+		if ep.Port != port {
+			ports = append(ports, ep)
+		}
+	}
+	session.Status.ExposedPorts = ports
+	if err := o.updateSessionStatusErr(ctx, session); err != nil {
+		return status.Errorf(codes.Internal, "update session status: %v", err)
+	}
+	if err := o.applyCNP(ctx, session); err != nil {
+		return status.Errorf(codes.Internal, "update network policy: %v", err)
+	}
+	if o.preview != nil {
+		o.preview.RevokePort(sessionID, port)
+	}
+	logrus.Infof("sandbox: unexposed session %s port %d (route %s removed)", sessionID, port, name)
+	return nil
+}
+
+// upsertExposedPort records or refreshes one port in the session status and
+// persists the updated status.
+func (o *Orchestrator) upsertExposedPort(ctx context.Context, session *sandboxv1.SandboxSession, port, ttl int32, expiresAt int64, url string) error {
+	found := false
+	for i := range session.Status.ExposedPorts {
+		if session.Status.ExposedPorts[i].Port == port {
+			session.Status.ExposedPorts[i].TTL = ttl
+			session.Status.ExposedPorts[i].ExpiresAt = &metav1.Time{Time: time.Unix(expiresAt, 0)}
+			session.Status.ExposedPorts[i].URL = url
+			found = true
+			break
+		}
+	}
+	if !found {
+		session.Status.ExposedPorts = append(session.Status.ExposedPorts, sandboxv1.ExposedPort{
+			Port:      port,
+			TTL:       ttl,
+			ExpiresAt: &metav1.Time{Time: time.Unix(expiresAt, 0)},
+			URL:       url,
+		})
+	}
+	return o.updateSessionStatusErr(ctx, session)
+}
+
+// previewResourceName builds the stable Service/Ingress name for a preview
+// route. Session IDs are sanitized to DNS-1123 (lowercase, dashes).
+func previewResourceName(sessionID string, port int32) string {
+	san := strings.ToLower(sessionID)
+	san = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			return r
+		case r == '.':
+			return '-'
+		default:
+			return '-'
+		}
+	}, san)
+	san = strings.Trim(san, "-")
+	if len(san) > 40 {
+		san = san[:40]
+	}
+	if san == "" {
+		san = "sess"
+	}
+	return fmt.Sprintf("preview-%s-%d", san, port)
+}
+
+// previewService builds the ClusterIP Service selecting the session pod by the
+// sandbox.k8e.io/session-id label.
+func previewService(name, sessionID string, port int32) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: sandboxNS,
+			Labels: map[string]string{
+				labelSessionID: sessionID,
+				previewLabel:   previewLabelValue,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{labelSessionID: sessionID},
+			Ports: []corev1.ServicePort{{
+				Name:       "preview",
+				Port:       port,
+				TargetPort: intstr.FromInt32(port),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
+}
+
+// previewIngress builds the Ingress routing /p/<sid>/<port>/ with nginx
+// external-auth pointing at the gateway /preview/verify endpoint. The path is
+// rewritten so the in-sandbox app sees the request at /.
+func previewIngress(name, sessionID string, port int32, cfg PreviewConfig) *networkingv1.Ingress {
+	path := fmt.Sprintf("/p/%s/%d/(.*)", sessionID, port)
+	rewrite := "/$1"
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: sandboxNS,
+			Labels: map[string]string{
+				labelSessionID: sessionID,
+				previewLabel:   previewLabelValue,
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/auth-url":       strings.TrimSuffix(cfg.VerifyBaseURL, "/") + "/preview/verify",
+				"nginx.ingress.kubernetes.io/rewrite-target": rewrite,
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &cfg.IngressClass,
+			Rules: []networkingv1.IngressRule{{
+				Host: cfg.Domain,
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Path:     path,
+							PathType: pathTypePtr(networkingv1.PathTypeImplementationSpecific),
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{
+									Name: name,
+									Port: networkingv1.ServiceBackendPort{Number: port},
+								},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	return ing
+}
+
+func pathTypePtr(p networkingv1.PathType) *networkingv1.PathType { return &p }
+
+// previewURL builds the user-facing preview URL for a minted token.
+func previewURL(cfg PreviewConfig, sessionID string, port int32, token string) string {
+	scheme := "https"
+	return fmt.Sprintf("%s://%s/p/%s/%d/%s/", scheme, cfg.Domain, sessionID, port, token)
+}
+
+// deletePreviewResources removes every preview Service/Ingress owned by the
+// session (label selector). Used by DestroySession and session GC.
+func (o *Orchestrator) deletePreviewResources(ctx context.Context, sessionID string) {
+	sel := labelSessionID + "=" + sessionID + "," + previewLabel + "=" + previewLabelValue
+	services, err := o.k8s.CoreV1().Services(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err == nil {
+		for i := range services.Items {
+			_ = o.k8s.CoreV1().Services(sandboxNS).Delete(ctx, services.Items[i].Name, metav1.DeleteOptions{})
+		}
+	}
+	ingresses, err := o.k8s.NetworkingV1().Ingresses(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err == nil {
+		for i := range ingresses.Items {
+			_ = o.k8s.NetworkingV1().Ingresses(sandboxNS).Delete(ctx, ingresses.Items[i].Name, metav1.DeleteOptions{})
+		}
+	}
+}
+
+// ReconcilePreviewOrphans deletes preview Services/Ingresses whose session no
+// longer exists as an Active SandboxSession CRD. This covers sessions removed
+// by anything other than DestroySession (e.g. CRD deletion, operator cleanup).
+func (o *Orchestrator) ReconcilePreviewOrphans(ctx context.Context) {
+	sel := previewLabel + "=" + previewLabelValue
+	services, err := o.k8s.CoreV1().Services(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err == nil {
+		for i := range services.Items {
+			if sid := services.Items[i].Labels[labelSessionID]; sid != "" && !o.sessionActive(ctx, sid) {
+				logrus.Infof("sandbox: sweeping orphan preview Service %s (session %s gone)", services.Items[i].Name, sid)
+				_ = o.k8s.CoreV1().Services(sandboxNS).Delete(ctx, services.Items[i].Name, metav1.DeleteOptions{})
+			}
+		}
+	}
+	ingresses, err := o.k8s.NetworkingV1().Ingresses(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: sel})
+	if err == nil {
+		for i := range ingresses.Items {
+			if sid := ingresses.Items[i].Labels[labelSessionID]; sid != "" && !o.sessionActive(ctx, sid) {
+				logrus.Infof("sandbox: sweeping orphan preview Ingress %s (session %s gone)", ingresses.Items[i].Name, sid)
+				_ = o.k8s.NetworkingV1().Ingresses(sandboxNS).Delete(ctx, ingresses.Items[i].Name, metav1.DeleteOptions{})
+			}
+		}
+	}
+}
+
+// sessionActive reports whether the session CRD exists in the Active phase.
+func (o *Orchestrator) sessionActive(ctx context.Context, sessionID string) bool {
+	s, err := o.getSession(ctx, sessionID)
+	if err != nil {
+		return false
+	}
+	return s.Status.Phase == sandboxv1.SandboxPhaseActive
+}
+
 func (o *Orchestrator) getPodIPBySession(ctx context.Context, sessionID string) (string, error) {
 	session, err := o.getSession(ctx, sessionID)
 	if err != nil {
@@ -672,6 +1003,16 @@ func (o *Orchestrator) updateSessionStatus(ctx context.Context, session *sandbox
 		return
 	}
 	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).UpdateStatus(ctx, u, metav1.UpdateOptions{})
+}
+
+// updateSessionStatusErr is updateSessionStatus with error propagation.
+func (o *Orchestrator) updateSessionStatusErr(ctx context.Context, session *sandboxv1.SandboxSession) error {
+	u, err := sessionToUnstructured(session)
+	if err != nil {
+		return err
+	}
+	_, err = o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).UpdateStatus(ctx, u, metav1.UpdateOptions{})
+	return err
 }
 
 func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeClass, pvcName, cpu, memory string) (*corev1.Pod, error) {
@@ -844,6 +1185,13 @@ func (o *Orchestrator) ensureWorkspacePVC(ctx context.Context, sessionID string)
 }
 
 func (o *Orchestrator) applyCNP(ctx context.Context, session *sandboxv1.SandboxSession) error {
+	// Ingress from the host (k8e server / Ingress controller) and from gateway
+	// pods. Port 2024 is the sandboxd control channel; exposed preview ports are
+	// added dynamically as the session publishes them.
+	hostPorts := []interface{}{map[string]interface{}{"port": "2024", "protocol": "TCP"}}
+	for _, ep := range session.Status.ExposedPorts {
+		hostPorts = append(hostPorts, map[string]interface{}{"port": strconv.Itoa(int(ep.Port)), "protocol": "TCP"})
+	}
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "cilium.io/v2",
 		"kind":       "CiliumNetworkPolicy",
@@ -860,7 +1208,7 @@ func (o *Orchestrator) applyCNP(ctx context.Context, session *sandboxv1.SandboxS
 					"fromEntities": []interface{}{"host"},
 					"toPorts": []interface{}{
 						map[string]interface{}{
-							"ports": []interface{}{map[string]interface{}{"port": "2024", "protocol": "TCP"}},
+							"ports": hostPorts,
 						},
 					},
 				},
@@ -888,17 +1236,17 @@ func (o *Orchestrator) applyCNP(ctx context.Context, session *sandboxv1.SandboxS
 						},
 					},
 				},
-					map[string]interface{}{
-						"toEntities": []interface{}{"world"},
-						"toPorts": []interface{}{
-							map[string]interface{}{
-								"ports": []interface{}{map[string]interface{}{"port": "443", "protocol": "TCP"}},
-							},
+				map[string]interface{}{
+					"toEntities": []interface{}{"world"},
+					"toPorts": []interface{}{
+						map[string]interface{}{
+							"ports": []interface{}{map[string]interface{}{"port": "443", "protocol": "TCP"}},
 						},
 					},
 				},
 			},
-		}}
+		},
+	}}
 	name := fmt.Sprintf("sandbox-session-%s", session.Name)
 	_, err := o.dynamic.Resource(cnpGVR).Namespace(session.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -4,7 +4,7 @@
 // 	protoc        v7.35.0
 // source: sandbox/v1/sandbox.proto
 
-package pb
+package v1
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -1445,6 +1445,214 @@ func (x *PollRunResponse) GetExitCode() int32 {
 	return 0
 }
 
+type ExposePortRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Port          int32                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	TtlSeconds    int32                  `protobuf:"varint,3,opt,name=ttl_seconds,json=ttlSeconds,proto3" json:"ttl_seconds,omitempty"` // override the default (session TTL); 0 = session TTL
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExposePortRequest) Reset() {
+	*x = ExposePortRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExposePortRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExposePortRequest) ProtoMessage() {}
+
+func (x *ExposePortRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExposePortRequest.ProtoReflect.Descriptor instead.
+func (*ExposePortRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *ExposePortRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *ExposePortRequest) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+func (x *ExposePortRequest) GetTtlSeconds() int32 {
+	if x != nil {
+		return x.TtlSeconds
+	}
+	return 0
+}
+
+type ExposePortResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	ExpiresAt     int64                  `protobuf:"varint,2,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"` // unix seconds
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExposePortResponse) Reset() {
+	*x = ExposePortResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExposePortResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExposePortResponse) ProtoMessage() {}
+
+func (x *ExposePortResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExposePortResponse.ProtoReflect.Descriptor instead.
+func (*ExposePortResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *ExposePortResponse) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *ExposePortResponse) GetExpiresAt() int64 {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return 0
+}
+
+type UnexposePortRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Port          int32                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnexposePortRequest) Reset() {
+	*x = UnexposePortRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnexposePortRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnexposePortRequest) ProtoMessage() {}
+
+func (x *UnexposePortRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnexposePortRequest.ProtoReflect.Descriptor instead.
+func (*UnexposePortRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *UnexposePortRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *UnexposePortRequest) GetPort() int32 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+type UnexposePortResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UnexposePortResponse) Reset() {
+	*x = UnexposePortResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UnexposePortResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UnexposePortResponse) ProtoMessage() {}
+
+func (x *UnexposePortResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UnexposePortResponse.ProtoReflect.Descriptor instead.
+func (*UnexposePortResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *UnexposePortResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
 var File_sandbox_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_sandbox_v1_sandbox_proto_rawDesc = "" +
@@ -1556,7 +1764,23 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x16\n" +
 	"\x06stdout\x18\x03 \x01(\tR\x06stdout\x12\x16\n" +
 	"\x06stderr\x18\x04 \x01(\tR\x06stderr\x12\x1b\n" +
-	"\texit_code\x18\x05 \x01(\x05R\bexitCode2\xe9\a\n" +
+	"\texit_code\x18\x05 \x01(\x05R\bexitCode\"g\n" +
+	"\x11ExposePortRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\x12\x1f\n" +
+	"\vttl_seconds\x18\x03 \x01(\x05R\n" +
+	"ttlSeconds\"E\n" +
+	"\x12ExposePortResponse\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x02 \x01(\x03R\texpiresAt\"H\n" +
+	"\x13UnexposePortRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x05R\x04port\"&\n" +
+	"\x14UnexposePortResponse\x12\x0e\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok2\x89\t\n" +
 	"\x0eSandboxService\x12T\n" +
 	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12W\n" +
 	"\x0eDestroySession\x12!.sandbox.v1.DestroySessionRequest\x1a\".sandbox.v1.DestroySessionResponse\x129\n" +
@@ -1572,7 +1796,10 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\rConfirmAction\x12 .sandbox.v1.ConfirmActionRequest\x1a!.sandbox.v1.ConfirmActionResponse\x12T\n" +
 	"\rApproveAction\x12 .sandbox.v1.ApproveActionRequest\x1a!.sandbox.v1.ApproveActionResponse\x12<\n" +
 	"\x05Login\x12\x18.sandbox.v1.LoginRequest\x1a\x19.sandbox.v1.LoginResponse\x12B\n" +
-	"\aPollRun\x12\x1a.sandbox.v1.PollRunRequest\x1a\x1b.sandbox.v1.PollRunResponseB1Z/github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pbb\x06proto3"
+	"\aPollRun\x12\x1a.sandbox.v1.PollRunRequest\x1a\x1b.sandbox.v1.PollRunResponse\x12K\n" +
+	"\n" +
+	"ExposePort\x12\x1d.sandbox.v1.ExposePortRequest\x1a\x1e.sandbox.v1.ExposePortResponse\x12Q\n" +
+	"\fUnexposePort\x12\x1f.sandbox.v1.UnexposePortRequest\x1a .sandbox.v1.UnexposePortResponseB<Z:github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1b\x06proto3"
 
 var (
 	file_sandbox_v1_sandbox_proto_rawDescOnce sync.Once
@@ -1586,7 +1813,7 @@ func file_sandbox_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_sandbox_v1_sandbox_proto_rawDescData
 }
 
-var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*CreateSessionRequest)(nil),   // 0: sandbox.v1.CreateSessionRequest
 	(*CreateSessionResponse)(nil),  // 1: sandbox.v1.CreateSessionResponse
@@ -1614,6 +1841,10 @@ var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*LoginResponse)(nil),          // 23: sandbox.v1.LoginResponse
 	(*PollRunRequest)(nil),         // 24: sandbox.v1.PollRunRequest
 	(*PollRunResponse)(nil),        // 25: sandbox.v1.PollRunResponse
+	(*ExposePortRequest)(nil),      // 26: sandbox.v1.ExposePortRequest
+	(*ExposePortResponse)(nil),     // 27: sandbox.v1.ExposePortResponse
+	(*UnexposePortRequest)(nil),    // 28: sandbox.v1.UnexposePortRequest
+	(*UnexposePortResponse)(nil),   // 29: sandbox.v1.UnexposePortResponse
 }
 var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
 	13, // 0: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
@@ -1630,21 +1861,25 @@ var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
 	20, // 11: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
 	22, // 12: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
 	24, // 13: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
-	1,  // 14: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
-	3,  // 15: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
-	5,  // 16: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
-	6,  // 17: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
-	8,  // 18: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
-	10, // 19: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
-	12, // 20: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
-	15, // 21: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
-	17, // 22: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
-	19, // 23: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
-	21, // 24: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	23, // 25: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
-	25, // 26: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
-	14, // [14:27] is the sub-list for method output_type
-	1,  // [1:14] is the sub-list for method input_type
+	26, // 14: sandbox.v1.SandboxService.ExposePort:input_type -> sandbox.v1.ExposePortRequest
+	28, // 15: sandbox.v1.SandboxService.UnexposePort:input_type -> sandbox.v1.UnexposePortRequest
+	1,  // 16: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
+	3,  // 17: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
+	5,  // 18: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
+	6,  // 19: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
+	8,  // 20: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
+	10, // 21: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
+	12, // 22: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
+	15, // 23: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
+	17, // 24: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
+	19, // 25: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
+	21, // 26: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
+	23, // 27: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
+	25, // 28: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
+	27, // 29: sandbox.v1.SandboxService.ExposePort:output_type -> sandbox.v1.ExposePortResponse
+	29, // 30: sandbox.v1.SandboxService.UnexposePort:output_type -> sandbox.v1.UnexposePortResponse
+	16, // [16:31] is the sub-list for method output_type
+	1,  // [1:16] is the sub-list for method input_type
 	1,  // [1:1] is the sub-list for extension type_name
 	1,  // [1:1] is the sub-list for extension extendee
 	0,  // [0:1] is the sub-list for field type_name
@@ -1661,7 +1896,7 @@ func file_sandbox_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_v1_sandbox_proto_rawDesc), len(file_sandbox_v1_sandbox_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   26,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
@@ -4,7 +4,7 @@
 // - protoc             v7.35.0
 // source: sandbox/v1/sandbox.proto
 
-package pb
+package v1
 
 import (
 	context "context"
@@ -32,6 +32,8 @@ const (
 	SandboxService_ApproveAction_FullMethodName  = "/sandbox.v1.SandboxService/ApproveAction"
 	SandboxService_Login_FullMethodName          = "/sandbox.v1.SandboxService/Login"
 	SandboxService_PollRun_FullMethodName        = "/sandbox.v1.SandboxService/PollRun"
+	SandboxService_ExposePort_FullMethodName     = "/sandbox.v1.SandboxService/ExposePort"
+	SandboxService_UnexposePort_FullMethodName   = "/sandbox.v1.SandboxService/UnexposePort"
 )
 
 // SandboxServiceClient is the client API for SandboxService service.
@@ -55,6 +57,10 @@ type SandboxServiceClient interface {
 	Login(ctx context.Context, in *LoginRequest, opts ...grpc.CallOption) (*LoginResponse, error)
 	// PollRun checks the status of a background execution.
 	PollRun(ctx context.Context, in *PollRunRequest, opts ...grpc.CallOption) (*PollRunResponse, error)
+	// ExposePort publishes a session port through a signed, time-limited preview URL.
+	ExposePort(ctx context.Context, in *ExposePortRequest, opts ...grpc.CallOption) (*ExposePortResponse, error)
+	// UnexposePort revokes a preview route (Service + Ingress) immediately.
+	UnexposePort(ctx context.Context, in *UnexposePortRequest, opts ...grpc.CallOption) (*UnexposePortResponse, error)
 }
 
 type sandboxServiceClient struct {
@@ -204,6 +210,26 @@ func (c *sandboxServiceClient) PollRun(ctx context.Context, in *PollRunRequest, 
 	return out, nil
 }
 
+func (c *sandboxServiceClient) ExposePort(ctx context.Context, in *ExposePortRequest, opts ...grpc.CallOption) (*ExposePortResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExposePortResponse)
+	err := c.cc.Invoke(ctx, SandboxService_ExposePort_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) UnexposePort(ctx context.Context, in *UnexposePortRequest, opts ...grpc.CallOption) (*UnexposePortResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UnexposePortResponse)
+	err := c.cc.Invoke(ctx, SandboxService_UnexposePort_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SandboxServiceServer is the server API for SandboxService service.
 // All implementations must embed UnimplementedSandboxServiceServer
 // for forward compatibility.
@@ -225,6 +251,10 @@ type SandboxServiceServer interface {
 	Login(context.Context, *LoginRequest) (*LoginResponse, error)
 	// PollRun checks the status of a background execution.
 	PollRun(context.Context, *PollRunRequest) (*PollRunResponse, error)
+	// ExposePort publishes a session port through a signed, time-limited preview URL.
+	ExposePort(context.Context, *ExposePortRequest) (*ExposePortResponse, error)
+	// UnexposePort revokes a preview route (Service + Ingress) immediately.
+	UnexposePort(context.Context, *UnexposePortRequest) (*UnexposePortResponse, error)
 	mustEmbedUnimplementedSandboxServiceServer()
 }
 
@@ -273,6 +303,12 @@ func (UnimplementedSandboxServiceServer) Login(context.Context, *LoginRequest) (
 }
 func (UnimplementedSandboxServiceServer) PollRun(context.Context, *PollRunRequest) (*PollRunResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PollRun not implemented")
+}
+func (UnimplementedSandboxServiceServer) ExposePort(context.Context, *ExposePortRequest) (*ExposePortResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExposePort not implemented")
+}
+func (UnimplementedSandboxServiceServer) UnexposePort(context.Context, *UnexposePortRequest) (*UnexposePortResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UnexposePort not implemented")
 }
 func (UnimplementedSandboxServiceServer) mustEmbedUnimplementedSandboxServiceServer() {}
 func (UnimplementedSandboxServiceServer) testEmbeddedByValue()                        {}
@@ -522,6 +558,42 @@ func _SandboxService_PollRun_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SandboxService_ExposePort_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExposePortRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).ExposePort(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_ExposePort_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).ExposePort(ctx, req.(*ExposePortRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_UnexposePort_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UnexposePortRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).UnexposePort(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_UnexposePort_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).UnexposePort(ctx, req.(*UnexposePortRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SandboxService_ServiceDesc is the grpc.ServiceDesc for SandboxService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -576,6 +648,14 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PollRun",
 			Handler:    _SandboxService_PollRun_Handler,
+		},
+		{
+			MethodName: "ExposePort",
+			Handler:    _SandboxService_ExposePort_Handler,
+		},
+		{
+			MethodName: "UnexposePort",
+			Handler:    _SandboxService_UnexposePort_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/sandboxmatrix/grpc/preview.go
+++ b/pkg/sandboxmatrix/grpc/preview.go
@@ -1,0 +1,289 @@
+package grpc
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+
+	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
+)
+
+// Preview labels/markers used on preview Services and Ingresses so session GC
+// and DestroySession can revoke every outstanding route by label selector.
+const (
+	previewLabel      = "sandbox.k8e.io/preview"
+	previewLabelValue = "1"
+)
+
+// PreviewConfig holds the topology knobs the expose feature consumes. These are
+// the gateway config knobs promised by the preview ingress decision (KIP-12
+// Part A / issue #484): which ingress class preview Ingresses use, which wildcard
+// host preview URLs live under, and the base URL the Ingress controller uses to
+// reach the gateway's /preview/verify endpoint.
+type PreviewConfig struct {
+	// Domain is the wildcard preview host, e.g. "preview.k8e.local". Preview
+	// URLs take the form https://<Domain>/p/<sid>/<port>/<token>/.
+	Domain string
+	// IngressClass is the ingressClassName stamped on preview Ingresses.
+	IngressClass string
+	// VerifyBaseURL is the base URL the Ingress controller uses to reach the
+	// gateway's verify endpoint, e.g. "http://127.0.0.1:50052". The Ingress
+	// auth annotation points at <VerifyBaseURL>/preview/verify.
+	VerifyBaseURL string
+}
+
+// previewToken is the signed payload minted for one exposed port.
+type previewToken struct {
+	SessionID string `json:"sid"`
+	Port      int32  `json:"port"`
+	ExpiresAt int64  `json:"exp"` // unix seconds
+	Nonce     string `json:"nonce"`
+}
+
+// previewEngine mints and verifies preview tokens and parses preview paths.
+// The verification key persists at KeyFile so tokens survive gateway restarts.
+type previewEngine struct {
+	key     []byte
+	cfg     PreviewConfig
+	k8s     kubernetes.Interface
+	dyn     dynamic.Interface
+	keyFile string
+
+	mu      sync.Mutex
+	revoked map[string]time.Time // "sid|port" → revoked at; port 0 = whole session
+}
+
+func newPreviewEngine(k8s kubernetes.Interface, dyn dynamic.Interface, cfg PreviewConfig, keyFile string) (*previewEngine, error) {
+	key, err := loadOrCreatePreviewKey(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Domain == "" {
+		cfg.Domain = "preview.k8e.local"
+	}
+	if cfg.IngressClass == "" {
+		cfg.IngressClass = "nginx"
+	}
+	return &previewEngine{
+		key:     key,
+		cfg:     cfg,
+		k8s:     k8s,
+		dyn:     dyn,
+		keyFile: keyFile,
+		revoked: make(map[string]time.Time),
+	}, nil
+}
+
+// loadOrCreatePreviewKey reads the preview HMAC key, generating and persisting
+// a fresh one (0600) when the file does not exist yet.
+func loadOrCreatePreviewKey(path string) ([]byte, error) {
+	if path != "" {
+		if data, err := os.ReadFile(path); err == nil && len(data) >= 32 {
+			return data, nil
+		}
+	}
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("preview key: %w", err)
+	}
+	key := []byte(hex.EncodeToString(buf))
+	if path != "" {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return nil, fmt.Errorf("preview key dir: %w", err)
+		}
+		if err := os.WriteFile(path, key, 0600); err != nil {
+			return nil, fmt.Errorf("preview key write: %w", err)
+		}
+	}
+	return key, nil
+}
+
+// mintToken signs a preview token with the engine key. Every mint carries a
+// fresh random nonce so re-exposing a route issues a genuinely new token even
+// when the expiry timestamp is unchanged.
+func (e *previewEngine) mintToken(sessionID string, port int32, ttlSeconds int64) (string, error) {
+	exp := time.Now().Add(time.Duration(ttlSeconds) * time.Second).Unix()
+	nonce := make([]byte, 12)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(previewToken{
+		SessionID: sessionID, Port: port, ExpiresAt: exp,
+		Nonce: base64.RawURLEncoding.EncodeToString(nonce),
+	})
+	if err != nil {
+		return "", err
+	}
+	enc := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, e.key)
+	mac.Write([]byte(enc))
+	return enc + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// verifyToken checks the HMAC signature and expiry of a preview token.
+// Returns the parsed token on success.
+func (e *previewEngine) verifyToken(token string) (*previewToken, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed preview token")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("malformed preview token payload")
+	}
+	mac := hmac.New(sha256.New, e.key)
+	mac.Write([]byte(parts[0]))
+	expect := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expect), []byte(parts[1])) {
+		return nil, fmt.Errorf("preview token signature mismatch")
+	}
+	var tok previewToken
+	if err := json.Unmarshal(payload, &tok); err != nil {
+		return nil, fmt.Errorf("preview token payload decode: %w", err)
+	}
+	if tok.SessionID == "" || tok.Port <= 0 || tok.Port > 65535 {
+		return nil, fmt.Errorf("preview token invalid fields")
+	}
+	if time.Now().Unix() >= tok.ExpiresAt {
+		return nil, fmt.Errorf("preview token expired")
+	}
+	return &tok, nil
+}
+
+// previewPathRe matches /p/<sid>/<port>/<token>/... — the path layout the
+// Ingress routes on. The token is the segment after the port.
+var previewPathRe = regexp.MustCompile(`^/p/([^/]+)/([0-9]+)/([^/]+)/?`)
+
+// parsePreviewPath extracts sid, port and token from a preview request path.
+func parsePreviewPath(path string) (sid string, port int32, token string, ok bool) {
+	m := previewPathRe.FindStringSubmatch(path)
+	if m == nil {
+		return "", 0, "", false
+	}
+	p, err := strconv.ParseInt(m[2], 10, 32)
+	if err != nil || p <= 0 || p > 65535 {
+		return "", 0, "", false
+	}
+	return m[1], int32(p), m[3], true
+}
+
+// RevokePort records an explicit revocation for a (session, port) pair.
+func (e *previewEngine) RevokePort(sessionID string, port int32) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.revoked[previewRevKey(sessionID, port)] = time.Now()
+}
+
+// RevokeSession records revocation for every port of a session. Ports are
+// unknown at GC time, so the session-level marker is checked alongside the
+// per-port marker in IsRevoked.
+func (e *previewEngine) RevokeSession(sessionID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.revoked[previewRevKey(sessionID, 0)] = time.Now()
+}
+
+// IsRevoked reports whether a (session, port) pair was explicitly revoked.
+func (e *previewEngine) IsRevoked(sessionID string, port int32) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if _, ok := e.revoked[previewRevKey(sessionID, port)]; ok {
+		return true
+	}
+	_, ok := e.revoked[previewRevKey(sessionID, 0)]
+	return ok
+}
+
+func previewRevKey(sessionID string, port int32) string {
+	return sessionID + "|" + strconv.FormatInt(int64(port), 10)
+}
+
+// authorizePreview is the full verify decision used by the /preview/verify
+// handler: signature + expiry + explicit revocation + session still Active +
+// the port still published on the session.
+func (e *previewEngine) authorizePreview(token string) (sid string, port int32, err error) {
+	tok, err := e.verifyToken(token)
+	if err != nil {
+		return "", 0, err
+	}
+	if e.IsRevoked(tok.SessionID, tok.Port) {
+		return tok.SessionID, tok.Port, fmt.Errorf("preview route revoked")
+	}
+	session, err := sessionFromDynamic(e.dyn, tok.SessionID)
+	if err != nil {
+		return tok.SessionID, tok.Port, fmt.Errorf("session not active: %v", err)
+	}
+	if session.Status.Phase != sandboxv1.SandboxPhaseActive {
+		return tok.SessionID, tok.Port, fmt.Errorf("session not active (phase %s)", session.Status.Phase)
+	}
+	if session.Status.ExpiresAt != nil && !session.Status.ExpiresAt.Time.After(time.Now()) {
+		return tok.SessionID, tok.Port, fmt.Errorf("session expired")
+	}
+	found := false
+	for _, ep := range session.Status.ExposedPorts {
+		if ep.Port == tok.Port {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return tok.SessionID, tok.Port, fmt.Errorf("port %d no longer published", tok.Port)
+	}
+	// The Service selects the session pod by label; a live pod is required.
+	pods, err := e.k8s.CoreV1().Pods(sandboxNS).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labelSessionID + "=" + tok.SessionID,
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return tok.SessionID, tok.Port, fmt.Errorf("session pod no longer exists")
+	}
+	return tok.SessionID, tok.Port, nil
+}
+
+// sessionFromDynamic reads a SandboxSession CRD via the dynamic client.
+func sessionFromDynamic(dyn dynamic.Interface, sessionID string) (*sandboxv1.SandboxSession, error) {
+	u, err := dyn.Resource(sessionGVR).Namespace(sandboxNS).Get(context.Background(), sessionID, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return unstructuredToSession(u)
+}
+
+// ServePreviewVerify implements the Ingress external-auth callback. nginx
+// auth_request passes the original request URI in the X-Original-URI header.
+// 200 → allow, 403 → deny.
+func (e *previewEngine) ServePreviewVerify(w http.ResponseWriter, r *http.Request) {
+	uri := r.Header.Get("X-Original-URI")
+	if uri == "" {
+		uri = r.URL.RequestURI()
+	}
+	sid, port, token, ok := parsePreviewPath(uri)
+	if !ok {
+		logrus.Debugf("preview verify: unparseable uri %q", uri)
+		http.Error(w, "invalid preview path", http.StatusForbidden)
+		return
+	}
+	if _, _, err := e.authorizePreview(token); err != nil {
+		logrus.Debugf("preview verify: deny sid=%s port=%d: %v", sid, port, err)
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/sandboxmatrix/grpc/preview_test.go
+++ b/pkg/sandboxmatrix/grpc/preview_test.go
@@ -1,0 +1,405 @@
+package grpc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newTestPreviewOrchestrator returns an orchestrator with a preview engine
+// wired up (ephemeral key, test config) plus a helper to re-read a session.
+func newTestPreviewOrchestrator(t *testing.T) *Orchestrator {
+	t.Helper()
+	o := newTestOrchestrator()
+	cfg := PreviewConfig{
+		Domain:        "preview.test.local",
+		IngressClass:  "nginx",
+		VerifyBaseURL: "http://127.0.0.1:50052",
+	}
+	if err := o.InitPreview(cfg, ""); err != nil {
+		t.Fatalf("init preview: %v", err)
+	}
+	return o
+}
+
+// mustExpose exposes a port and fails the test on error.
+func mustExpose(t *testing.T, o *Orchestrator, sid string, port int32, ttl int32) (string, int64) {
+	t.Helper()
+	url, exp, err := o.ExposePort(context.Background(), sid, port, ttl)
+	if err != nil {
+		t.Fatalf("expose: %v", err)
+	}
+	return url, exp
+}
+
+func TestPreviewToken_RoundTrip(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	tok, err := o.preview.mintToken("sess-abc", 8080, 3600)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	parsed, err := o.preview.verifyToken(tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if parsed.SessionID != "sess-abc" || parsed.Port != 8080 {
+		t.Fatalf("unexpected token payload: %+v", parsed)
+	}
+	if parsed.ExpiresAt <= time.Now().Unix() {
+		t.Fatal("expected future expiry")
+	}
+}
+
+func TestPreviewToken_Expired(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	tok, err := o.preview.mintToken("sess-abc", 8080, -10)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if _, err := o.preview.verifyToken(tok); err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}
+
+func TestPreviewToken_Tampered(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	tok, err := o.preview.mintToken("sess-abc", 8080, 3600)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	// flip the last character of the signature half
+	if tok[len(tok)-1] == 'A' {
+		tok = tok[:len(tok)-1] + "B"
+	} else {
+		tok = tok[:len(tok)-1] + "A"
+	}
+	if _, err := o.preview.verifyToken(tok); err == nil {
+		t.Fatal("expected tampered token to be rejected")
+	}
+}
+
+func TestPreviewPath_Parse(t *testing.T) {
+	cases := []struct {
+		path string
+		sid  string
+		port int32
+		tok  string
+		ok   bool
+	}{
+		{"/p/sess-abc/8080/abcd1234/", "sess-abc", 8080, "abcd1234", true},
+		{"/p/sess-abc/8080/abcd1234/sub/path", "sess-abc", 8080, "abcd1234", true},
+		{"/p/sess-abc/8080/abcd1234", "sess-abc", 8080, "abcd1234", true},
+		{"/p/sess-abc/notaport/tok/", "", 0, "", false},
+		{"/other/sess-abc/8080/tok/", "", 0, "", false},
+		{"/p/sess-abc/99999/tok/", "", 0, "", false},
+	}
+	for _, c := range cases {
+		sid, port, tok, ok := parsePreviewPath(c.path)
+		if ok != c.ok || sid != c.sid || port != c.port || tok != c.tok {
+			t.Errorf("parsePreviewPath(%q) = (%q,%d,%q,%v), want (%q,%d,%q,%v)",
+				c.path, sid, port, tok, ok, c.sid, c.port, c.tok, c.ok)
+		}
+	}
+}
+
+func TestPreviewService_SelectsSessionPod(t *testing.T) {
+	svc := previewService("preview-sess-1-8080", "sess-1", 8080)
+	if got := svc.Spec.Selector[labelSessionID]; got != "sess-1" {
+		t.Fatalf("expected selector %s=sess-1, got %q", labelSessionID, got)
+	}
+	if len(svc.Spec.Selector) != 1 {
+		t.Fatalf("expected selector to pin exactly one label, got %v", svc.Spec.Selector)
+	}
+	if svc.Spec.Ports[0].Port != 8080 || svc.Spec.Ports[0].TargetPort.IntValue() != 8080 {
+		t.Fatalf("unexpected service port: %+v", svc.Spec.Ports[0])
+	}
+	if svc.Labels[previewLabel] != previewLabelValue {
+		t.Fatal("expected preview label on Service for GC cleanup")
+	}
+}
+
+func TestExposePort_CreatesRouteAndToken(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	ctx := context.Background()
+	sess := mustCreateSession(t, o, "expose-1")
+	url, exp := mustExpose(t, o, sess.Name, 8080, 60)
+
+	if !strings.HasPrefix(url, "https://preview.test.local/p/expose-1/8080/") {
+		t.Fatalf("unexpected preview URL: %s", url)
+	}
+	if exp <= time.Now().Unix() || exp > time.Now().Add(2*time.Minute).Unix() {
+		t.Fatalf("unexpected expiry %d", exp)
+	}
+
+	name := previewResourceName(sess.Name, 8080)
+	if _, err := o.k8s.CoreV1().Services(sandboxNS).Get(ctx, name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("preview Service not created: %v", err)
+	}
+	ing, err := o.k8s.NetworkingV1().Ingresses(sandboxNS).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("preview Ingress not created: %v", err)
+	}
+	if ing.Labels[labelSessionID] != sess.Name {
+		t.Fatalf("Ingress missing session label: %v", ing.Labels)
+	}
+	if ing.Spec.Rules[0].Host != "preview.test.local" {
+		t.Fatalf("unexpected ingress host: %s", ing.Spec.Rules[0].Host)
+	}
+	if got := ing.Annotations["nginx.ingress.kubernetes.io/auth-url"]; got != "http://127.0.0.1:50052/preview/verify" {
+		t.Fatalf("unexpected auth-url: %s", got)
+	}
+
+	// session status records the exposed port
+	got, err := o.getSession(ctx, sess.Name)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if len(got.Status.ExposedPorts) != 1 || got.Status.ExposedPorts[0].Port != 8080 {
+		t.Fatalf("expected exposedPorts=[8080], got %+v", got.Status.ExposedPorts)
+	}
+}
+
+func TestExposePort_ReexposeReusesRouteAndFreshToken(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	ctx := context.Background()
+	sess := mustCreateSession(t, o, "expose-re")
+	url1, exp1 := mustExpose(t, o, sess.Name, 8080, 3600)
+	url2, exp2 := mustExpose(t, o, sess.Name, 8080, 3600)
+
+	name := previewResourceName(sess.Name, 8080)
+	// route reused, not recreated
+	svcs, _ := o.k8s.CoreV1().Services(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: previewLabel + "=" + previewLabelValue})
+	if len(svcs.Items) != 1 {
+		t.Fatalf("expected exactly 1 preview Service after re-expose, got %d", len(svcs.Items))
+	}
+	ings, _ := o.k8s.NetworkingV1().Ingresses(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: previewLabel + "=" + previewLabelValue})
+	if len(ings.Items) != 1 {
+		t.Fatalf("expected exactly 1 preview Ingress after re-expose, got %d", len(ings.Items))
+	}
+	// fresh token: URL differs, expiry at least as far out as before (same-second
+	// calls share the same second-granularity expiry timestamp)
+	if url1 == url2 {
+		t.Fatal("expected a fresh token on re-expose")
+	}
+	if exp2 < exp1 {
+		t.Fatalf("expected refreshed expiry, got %d then %d", exp1, exp2)
+	}
+	if _, err := o.k8s.CoreV1().Services(sandboxNS).Get(ctx, name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("Service should still exist: %v", err)
+	}
+}
+
+func TestExposePort_TTLDefaultsToSessionTTL(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	// session with no explicit TTL → default 3600
+	sess := mustCreateSession(t, o, "expose-ttl")
+	_, exp := mustExpose(t, o, sess.Name, 3000, 0)
+	if exp <= time.Now().Unix()+3600-30 || exp > time.Now().Unix()+3600+30 {
+		t.Fatalf("expected default TTL ~3600s, got expiry %d", exp)
+	}
+}
+
+func TestExposePort_NotActiveSession(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	ctx := context.Background()
+	sess := mustCreateSession(t, o, "expose-inactive")
+	// mark terminating
+	sess.Status.Phase = "Terminating"
+	o.updateSessionStatus(ctx, sess)
+
+	_, _, err := o.ExposePort(ctx, sess.Name, 8080, 60)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition for non-active session, got %v", err)
+	}
+}
+
+func TestExposePort_MissingSession(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	_, _, err := o.ExposePort(context.Background(), "nope", 8080, 60)
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+func TestUnexposePort_RemovesRouteImmediately(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	ctx := context.Background()
+	sess := mustCreateSession(t, o, "unexpose-1")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+
+	name := previewResourceName(sess.Name, 8080)
+	if err := o.UnexposePort(ctx, sess.Name, 8080); err != nil {
+		t.Fatalf("unexpose: %v", err)
+	}
+	if _, err := o.k8s.CoreV1().Services(sandboxNS).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		t.Fatal("expected preview Service deleted")
+	}
+	if _, err := o.k8s.NetworkingV1().Ingresses(sandboxNS).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		t.Fatal("expected preview Ingress deleted")
+	}
+	got, err := o.getSession(ctx, sess.Name)
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if len(got.Status.ExposedPorts) != 0 {
+		t.Fatalf("expected exposedPorts emptied, got %+v", got.Status.ExposedPorts)
+	}
+	if !o.preview.IsRevoked(sess.Name, 8080) {
+		t.Fatal("expected port marked revoked")
+	}
+}
+
+func TestDestroySession_RevokesPreviewResources(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	ctx := context.Background()
+	sess := mustCreateSession(t, o, "gc-preview")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+	mustExpose(t, o, sess.Name, 9090, 3600)
+
+	// simulate GC: destroy the expired session
+	sess.Status.Phase = "Active"
+	o.updateSessionStatus(ctx, sess)
+	if err := o.DestroySession(ctx, sess.Name); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+
+	svcs, _ := o.k8s.CoreV1().Services(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: previewLabel + "=" + previewLabelValue})
+	if len(svcs.Items) != 0 {
+		t.Fatalf("expected all preview Services revoked, got %d", len(svcs.Items))
+	}
+	ings, _ := o.k8s.NetworkingV1().Ingresses(sandboxNS).List(ctx, metav1.ListOptions{LabelSelector: previewLabel + "=" + previewLabelValue})
+	if len(ings.Items) != 0 {
+		t.Fatalf("expected all preview Ingresses revoked, got %d", len(ings.Items))
+	}
+	if !o.preview.IsRevoked(sess.Name, 8080) {
+		t.Fatal("expected session-level revocation marker")
+	}
+}
+
+func TestPreviewAuthorize_Valid(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	sess := mustCreateSession(t, o, "auth-ok")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+	// re-fetch to get the current URL/token
+	got, _ := o.getSession(context.Background(), sess.Name)
+	tok := previewTokenFromURL(t, got.Status.ExposedPorts[0].URL)
+	if _, _, err := o.preview.authorizePreview(tok); err != nil {
+		t.Fatalf("expected authorize to pass: %v", err)
+	}
+}
+
+func TestPreviewAuthorize_RevokedPort(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	sess := mustCreateSession(t, o, "auth-revoked")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+	got, _ := o.getSession(context.Background(), sess.Name)
+	tok := previewTokenFromURL(t, got.Status.ExposedPorts[0].URL)
+
+	o.preview.RevokePort(sess.Name, 8080)
+	if _, _, err := o.preview.authorizePreview(tok); err == nil {
+		t.Fatal("expected authorize to fail after RevokePort")
+	}
+}
+
+func TestPreviewAuthorize_PortUnpublished(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	sess := mustCreateSession(t, o, "auth-unpub")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+	got, _ := o.getSession(context.Background(), sess.Name)
+	tok := previewTokenFromURL(t, got.Status.ExposedPorts[0].URL)
+
+	// clear the port from status (as unexpose does)
+	got.Status.ExposedPorts = nil
+	o.updateSessionStatus(context.Background(), got)
+
+	if _, _, err := o.preview.authorizePreview(tok); err == nil {
+		t.Fatal("expected authorize to fail for unpublished port")
+	}
+}
+
+func TestPreviewAuthorize_SessionGone(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	sess := mustCreateSession(t, o, "auth-gone")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+	got, _ := o.getSession(context.Background(), sess.Name)
+	tok := previewTokenFromURL(t, got.Status.ExposedPorts[0].URL)
+
+	// GC path destroys the session entirely
+	if err := o.DestroySession(context.Background(), sess.Name); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if _, _, err := o.preview.authorizePreview(tok); err == nil {
+		t.Fatal("expected authorize to fail after session destroyed")
+	}
+}
+
+func TestPreviewAuthorize_ExpiredToken(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	sess := mustCreateSession(t, o, "auth-expired")
+	// mint a token that is already expired
+	expired, err := o.preview.mintToken(sess.Name, 8080, -5)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if _, _, err := o.preview.authorizePreview(expired); err == nil {
+		t.Fatal("expected authorize to fail for expired token")
+	}
+}
+
+func TestPreviewVerifyHandler_HTTP(t *testing.T) {
+	o := newTestPreviewOrchestrator(t)
+	sess := mustCreateSession(t, o, "verify-http")
+	mustExpose(t, o, sess.Name, 8080, 3600)
+	got, _ := o.getSession(context.Background(), sess.Name)
+	tok := previewTokenFromURL(t, got.Status.ExposedPorts[0].URL)
+
+	handler := http.HandlerFunc(o.preview.ServePreviewVerify)
+
+	// valid token → 200
+	req := httptest.NewRequest(http.MethodGet, "/preview/verify", nil)
+	req.Header.Set("X-Original-URI", "/p/verify-http/8080/"+tok+"/")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for valid token, got %d", rr.Code)
+	}
+
+	// invalid token → 403
+	req2 := httptest.NewRequest(http.MethodGet, "/preview/verify", nil)
+	req2.Header.Set("X-Original-URI", "/p/verify-http/8080/not-a-real-token/")
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for invalid token, got %d", rr2.Code)
+	}
+
+	// unexposed port → 403
+	if err := o.UnexposePort(context.Background(), sess.Name, 8080); err != nil {
+		t.Fatalf("unexpose: %v", err)
+	}
+	req3 := httptest.NewRequest(http.MethodGet, "/preview/verify", nil)
+	req3.Header.Set("X-Original-URI", "/p/verify-http/8080/"+tok+"/")
+	rr3 := httptest.NewRecorder()
+	handler.ServeHTTP(rr3, req3)
+	if rr3.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unexposed port, got %d", rr3.Code)
+	}
+}
+
+// previewTokenFromURL extracts the token segment from a preview URL.
+func previewTokenFromURL(t *testing.T, url string) string {
+	t.Helper()
+	// https://host/p/<sid>/<port>/<token>/
+	parts := strings.Split(strings.TrimSuffix(url, "/"), "/")
+	if len(parts) < 2 {
+		t.Fatalf("unparseable preview URL %q", url)
+	}
+	return parts[len(parts)-1]
+}

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"github.com/xiaods/k8e/pkg/sandboxmatrix/ratelimit"
-	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -107,26 +107,32 @@ type ServerConfig struct {
 	ServerKeyFile  string
 	GRPCPort       int
 	LocalAuth      bool // allow loopback connections without client cert
+	// Preview configures the signed preview-URL feature (expose/unexpose).
+	Preview         PreviewConfig
+	PreviewKeyFile  string // HMAC key path; generated on first use when empty
+	PreviewHTTPPort int    // HTTP listener for /preview/verify (Ingress auth callback)
 }
 
 // Server implements the SandboxService gRPC interface.
 type Server struct {
 	pb.UnimplementedSandboxServiceServer
-	k8s            kubernetes.Interface
-	dyn            dynamic.Interface
-	orch           *Orchestrator
-	lisAddr        string
-	caCertFile     string
-	caKeyFile      string
-	serverCertFile string
-	serverKeyFile  string
-	caCert         *x509.Certificate
-	caKey          *ecdsa.PrivateKey
-	apiKeys        map[string]string // name → key for validation
-	issuedStore    *issuedCertStore
-	revocList      *RevocationList
-	localAuth      bool
-	rateLimiter    *ratelimit.Limiter
+	k8s             kubernetes.Interface
+	dyn             dynamic.Interface
+	orch            *Orchestrator
+	lisAddr         string
+	caCertFile      string
+	caKeyFile       string
+	serverCertFile  string
+	serverKeyFile   string
+	caCert          *x509.Certificate
+	caKey           *ecdsa.PrivateKey
+	apiKeys         map[string]string // name → key for validation
+	issuedStore     *issuedCertStore
+	revocList       *RevocationList
+	localAuth       bool
+	rateLimiter     *ratelimit.Limiter
+	preview         *previewEngine
+	previewHTTPPort int
 }
 
 func NewServer(cfg ServerConfig) *Server {
@@ -135,17 +141,23 @@ func NewServer(cfg ServerConfig) *Server {
 		port = 50051
 	}
 	s := &Server{
-		k8s:            cfg.K8s,
-		dyn:            cfg.Dyn,
-		lisAddr:        fmt.Sprintf("0.0.0.0:%d", port),
-		caCertFile:     cfg.CACertFile,
-		caKeyFile:      cfg.CAKeyFile,
-		serverCertFile: cfg.ServerCertFile,
-		serverKeyFile:  cfg.ServerKeyFile,
-		localAuth:      cfg.LocalAuth,
-		rateLimiter:    ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
+		k8s:             cfg.K8s,
+		dyn:             cfg.Dyn,
+		lisAddr:         fmt.Sprintf("0.0.0.0:%d", port),
+		caCertFile:      cfg.CACertFile,
+		caKeyFile:       cfg.CAKeyFile,
+		serverCertFile:  cfg.ServerCertFile,
+		serverKeyFile:   cfg.ServerKeyFile,
+		localAuth:       cfg.LocalAuth,
+		rateLimiter:     ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
+		previewHTTPPort: cfg.PreviewHTTPPort,
 	}
 	s.orch = NewOrchestrator(cfg.K8s, cfg.Dyn)
+	if err := s.orch.InitPreview(cfg.Preview, cfg.PreviewKeyFile); err != nil {
+		logrus.Warnf("sandbox gRPC: preview engine disabled: %v", err)
+	} else {
+		s.preview = s.orch.PreviewEngine()
+	}
 	return s
 }
 
@@ -282,6 +294,35 @@ func (s *Server) Start(ctx context.Context) error {
 	gs := grpc.NewServer(opts...)
 	pb.RegisterSandboxServiceServer(gs, s)
 	logrus.Infof("sandbox gRPC gateway listening on %s", s.lisAddr)
+
+	// Preview verify HTTP endpoint consumed by the Ingress external-auth
+	// annotation (auth-url). The token in the URL is the credential, so this
+	// endpoint intentionally has no mTLS.
+	if s.preview != nil {
+		pPort := s.previewHTTPPort
+		if pPort == 0 {
+			pPort = 50052
+		}
+		pLis, perr := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", pPort))
+		if perr != nil {
+			logrus.Warnf("sandbox preview verify listener: %v (preview URLs will 502)", perr)
+		} else {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/preview/verify", s.preview.ServePreviewVerify)
+			pSrv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+			logrus.Infof("sandbox preview verify listening on 0.0.0.0:%d", pPort)
+			go func() {
+				<-ctx.Done()
+				pSrv.Shutdown(context.Background()) //nolint:errcheck
+			}()
+			go func() {
+				if err := pSrv.Serve(pLis); err != nil && err != http.ErrServerClosed {
+					logrus.Warnf("sandbox preview verify server: %v", err)
+				}
+			}()
+		}
+	}
+
 	go func() {
 		<-ctx.Done()
 		gs.GracefulStop()
@@ -305,6 +346,21 @@ func (s *Server) DestroySession(ctx context.Context, req *pb.DestroySessionReque
 		return nil, status.Errorf(codes.Internal, "destroy session: %v", err)
 	}
 	return &pb.DestroySessionResponse{Ok: true}, nil
+}
+
+func (s *Server) ExposePort(ctx context.Context, req *pb.ExposePortRequest) (*pb.ExposePortResponse, error) {
+	url, expiresAt, err := s.orch.ExposePort(ctx, req.SessionId, req.Port, req.TtlSeconds)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.ExposePortResponse{Url: url, ExpiresAt: expiresAt}, nil
+}
+
+func (s *Server) UnexposePort(ctx context.Context, req *pb.UnexposePortRequest) (*pb.UnexposePortResponse, error) {
+	if err := s.orch.UnexposePort(ctx, req.SessionId, req.Port); err != nil {
+		return nil, err
+	}
+	return &pb.UnexposePortResponse{Ok: true}, nil
 }
 
 func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecResponse, error) {
@@ -417,7 +473,9 @@ func (s *Server) ReadFile(ctx context.Context, req *pb.ReadFileRequest) (*pb.Rea
 		return nil, status.Errorf(codes.Unavailable, "sandboxd read: %v", err)
 	}
 	defer resp.Body.Close()
-	var result struct{ Content string `json:"content"` }
+	var result struct {
+		Content string `json:"content"`
+	}
 	json.NewDecoder(resp.Body).Decode(&result)
 	return &pb.ReadFileResponse{Content: result.Content}, nil
 }

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package sandbox.v1;
-option go_package = "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb";
+option go_package = "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1";
 
 service SandboxService {
   rpc CreateSession(CreateSessionRequest)   returns (CreateSessionResponse);
@@ -20,6 +20,10 @@ service SandboxService {
   rpc Login(LoginRequest) returns (LoginResponse);
   // PollRun checks the status of a background execution.
   rpc PollRun(PollRunRequest)               returns (PollRunResponse);
+  // ExposePort publishes a session port through a signed, time-limited preview URL.
+  rpc ExposePort(ExposePortRequest)         returns (ExposePortResponse);
+  // UnexposePort revokes a preview route (Service + Ingress) immediately.
+  rpc UnexposePort(UnexposePortRequest)     returns (UnexposePortResponse);
 }
 
 message CreateSessionRequest {
@@ -117,3 +121,16 @@ message PollRunResponse {
   string stderr    = 4;
   int32  exit_code = 5;
 }
+
+message ExposePortRequest {
+  string session_id   = 1;
+  int32  port         = 2;
+  int32  ttl_seconds  = 3;  // override the default (session TTL); 0 = session TTL
+}
+message ExposePortResponse {
+  string url        = 1;
+  int64  expires_at = 2;  // unix seconds
+}
+
+message UnexposePortRequest  { string session_id = 1; int32 port = 2; }
+message UnexposePortResponse { bool ok = 1; }

--- a/skills/k8e-sandbox/SKILL.md
+++ b/skills/k8e-sandbox/SKILL.md
@@ -102,6 +102,8 @@ chmod +x k8e-sandbox-cli-linux-amd64
 | `k8e-sandbox-cli snapshot restore <name>` | Create session from saved snapshot | `--runtime`, `--tenant` |
 | `k8e-sandbox-cli snapshot list` | List saved snapshots | — |
 | `k8e-sandbox-cli snapshot delete <name>` | Delete a snapshot | — |
+| `k8e-sandbox-cli expose <sid> <port>` | Publish a session port as a signed preview URL | `--ttl <seconds>` (default: session TTL) |
+| `k8e-sandbox-cli unexpose <sid> <port>` | Revoke a preview route immediately | — |
 | `k8e-sandbox-cli install-skill [claude\|codex\|pi\|all]` | Install this skill into agent config | — |
 
 ```
@@ -140,6 +142,29 @@ Default allowed hosts (kernel-level Cilium eBPF enforcement):
 `pypi.org`, `files.pythonhosted.org`, `registry.npmjs.org`, `github.com`, `raw.githubusercontent.com`
 
 Override with `--allowed-hosts` on `create`. Everything else blocked.
+
+## Preview URLs (expose / unexpose)
+
+Serve a process listening inside a sandbox through a signed, time-limited URL:
+
+```
+k8e-sandbox-cli expose <session-id> <port> [--ttl <seconds>]
+# → {"url":"https://preview.<domain>/p/<sid>/<port>/<token>/","expires_at":...}
+```
+
+- Default TTL follows the session TTL; `--ttl` overrides it (expiry enforced at the
+gateway `/preview/verify` — the URL 403s after it passes).
+- Revoke explicitly: `k8e-sandbox-cli unexpose <sid> <port>` removes the Service +
+Ingress immediately; the URL stops serving (routes 404 once the Ingress is gone,
+and any token still reaching verify gets 403).
+- Re-exposing the same `(sid, port)` reuses the route and mints a fresh token.
+- `destroy` and session GC revoke every outstanding preview route/token for the
+session automatically.
+- The preview host, ingress class and verify endpoint are operator knobs on the
+server: `--sandbox-preview-domain`, `--sandbox-ingress-class`,
+`--sandbox-preview-verify-url`, `--sandbox-preview-port`. The Ingress controller
+must be deployed and reach the gateway's `/preview/verify` endpoint, and TLS for
+the preview host must terminate before the Ingress (operator's choice).
 
 ## Typical Scenarios
 
@@ -217,6 +242,17 @@ k8e-sandbox-cli snapshot save $SID my-analysis
 SID=$(k8e-sandbox-cli snapshot restore my-analysis | jq -r .session_id)
 k8e-sandbox-cli read $SID /workspace/result.json --raw
 ```
+
+### Scenario 8: Expose a service preview
+
+```
+1. k8e-sandbox-cli run "python3 -m http.server 8080 --bind 0.0.0.0" --session-id $SID --background
+2. URL=$(k8e-sandbox-cli expose $SID 8080 --ttl 3600 | jq -r .url)
+   # share the URL — the token in the path is the credential
+3. k8e-sandbox-cli unexpose $SID 8080   # revoke immediately
+```
+
+Destroying the session (or session GC) revokes all outstanding preview routes.
 
 ## Error reference
 


### PR DESCRIPTION
## Summary

Implements **KIP-12 Part A** — the sandbox Ports/Preview feature. `k8e-sandbox-cli expose <sid> <port>` publishes a session port through a K8s Service + Ingress and mints a **signed, time-limited, revocable** preview URL; `unexpose` tears the route down immediately; `--ttl` overrides the default expiry; session destroy/GC revokes all outstanding preview routes and tokens.

Resolves **#487** (unexpose, `--ttl`, preview revocation lifecycle), which was blocked by **#486** (expose with signed preview URL) — the #486 foundation is included in this PR.

## What changed

**Proto / API**
- `proto/sandbox/v1/sandbox.proto`: new `ExposePort` / `UnexposePort` RPCs + messages (also fixes the stale `go_package`); regenerated pb code
- `SandboxSessionStatus` gains `exposedPorts` (published preview routes tracked per session)

**Gateway (`pkg/sandboxmatrix/grpc`)**
- `preview.go` (new): HMAC-SHA256 token mint/verify with a persisted key (`<tlsDir>/sandbox-preview.key`) and a per-mint nonce; `/p/<sid>/<port>/<token>` path parsing; in-memory revocation registry (per-port + per-session)
- `/preview/verify` HTTP endpoint (default `:50052`) consumed by the Ingress `external-auth` annotation — enforces signature, expiry, revocation, session Active, port still published, live pod
- Orchestrator: `ExposePort` (idempotent Service+Ingress per `(sid, port)`, Service selector pins the session pod by `sandbox.k8e.io/session-id`, CNP host-ingress rule added for exposed ports, session status upsert) / `UnexposePort` (delete Service+Ingress, revoke, prune status) / `DestroySession` + `ReconcilePreviewOrphans` revoke by label (session GC path included)

**CLI**
- `k8e-sandbox-cli expose <sid> <port> [--ttl <seconds>]`, `k8e-sandbox-cli unexpose <sid> <port>`; `SKILL.md` preview docs + scenario

**Config** (the knobs #484 asked for)
- `--sandbox-preview-domain`, `--sandbox-ingress-class`, `--sandbox-preview-verify-url`, `--sandbox-preview-port`

## Acceptance criteria (#487)

- [x] `unexpose <sid> 8080` removes the Service + Ingress immediately; URL stops serving (routes 404 once the Ingress is gone; revoked tokens reaching verify get 403)
- [x] `expose --ttl 60` → URL returns 403 after 60s (expiry enforced at `/preview/verify`)
- [x] session GC revokes outstanding preview routes/tokens (label-based teardown + revocation markers + orphan sweep)
- [x] re-`expose` of the same `(sid, port)` reuses the route and issues a fresh token
- [x] test coverage for expiry + GC revocation (and sign/verify, unexpose, re-expose, verify handler)

## Tests

`go test ./pkg/sandboxmatrix/... ./pkg/sandboxcli/...` — all passing. New `pkg/sandboxmatrix/grpc/preview_test.go` covers token round-trip/expiry/tamper, path parsing, Service selector pinning, expose/re-expose/TTL, unexpose, destroy-GC revocation, and the verify HTTP handler.

## Notes

- The gateway runs in-process in `k8e-server` (the old gateway Deployment was removed in `18850a69`), so Service/Ingress RBAC comes from the server's admin kubeconfig — no separate SA grant needed
- Preview host TLS termination is the operator's decision (see #484); documented in `skills/k8e-sandbox/SKILL.md`
