### PR TITLE
feat(sandbox): session env injection at exec time (#483)

### DIFF
--- a/manifests/sandbox-matrix/crds.yaml
+++ b/manifests/sandbox-matrix/crds.yaml
@@ -99,6 +99,9 @@ spec:
               runtimeClass: {type: string}
               parentSessionID: {type: string}
               depth: {type: integer}
+              env:
+                type: object
+                additionalProperties: {type: string}
           status:
             type: object
             properties:

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -377,6 +377,7 @@ func CreateCommand() cli.Command {
 			cli.StringFlag{Name: "tenant", EnvVar: "K8E_SANDBOX_TENANT", Usage: "Tenant identifier"},
 			cli.StringFlag{Name: "allowed-hosts", Usage: "Comma-separated FQDN egress allowlist"},
 			cli.StringFlag{Name: "session-id", Usage: "Custom session ID"},
+			cli.StringSliceFlag{Name: "env", Usage: "Non-sensitive env KEY=VAL (repeatable); applied at exec time"},
 			cli.StringFlag{Name: "manifest", Usage: "Path to workspace manifest YAML file"},
 			cli.StringFlag{Name: "git-repo", Usage: "Git repository URL to clone (shortcut)"},
 			cli.StringFlag{Name: "git-ref", Value: "main", Usage: "Git ref for --git-repo"},
@@ -394,11 +395,17 @@ func CreateCommand() cli.Command {
 				hosts = strings.Split(raw, ",")
 			}
 
+			env, envErr := parseEnvFlags(ctx.StringSlice("env"))
+			if envErr != nil {
+				return printErrorExit(envErr.Error(), 1)
+			}
+
 			resp, err := client.SandboxServiceClient.CreateSession(context.Background(), &pb.CreateSessionRequest{
 				SessionId:    ctx.String("session-id"),
 				TenantId:     ctx.String("tenant"),
 				RuntimeClass: ctx.String("runtime"),
 				AllowedHosts: hosts,
+				Env:          env,
 			})
 			if err != nil {
 				return printErrorExit("create session: "+err.Error(), 2)
@@ -432,6 +439,23 @@ func CreateCommand() cli.Command {
 			return nil
 		},
 	}
+}
+
+// parseEnvFlags converts repeatable --env KEY=VAL flags into a map.
+// Empty input returns nil (no env field on the CreateSession request).
+func parseEnvFlags(items []string) (map[string]string, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(items))
+	for _, item := range items {
+		k, v, ok := strings.Cut(item, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid --env %q, expected KEY=VAL", item)
+		}
+		out[k] = v
+	}
+	return out, nil
 }
 
 // resolveManifest builds a Manifest from --manifest, --git-repo flags, or returns nil.

--- a/pkg/sandboxcli/commands_test.go
+++ b/pkg/sandboxcli/commands_test.go
@@ -8,6 +8,26 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+func TestParseEnvFlags(t *testing.T) {
+	got, err := parseEnvFlags([]string{"FOO=bar", "BAZ=qux"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["FOO"] != "bar" || got["BAZ"] != "qux" {
+		t.Fatalf("unexpected map: %v", got)
+	}
+	if _, err := parseEnvFlags([]string{"NOEQUALS"}); err == nil {
+		t.Fatal("expected error for missing '='")
+	}
+	if _, err := parseEnvFlags([]string{"=novalue"}); err == nil {
+		t.Fatal("expected error for empty key")
+	}
+	nilMap, err := parseEnvFlags(nil)
+	if err != nil || nilMap != nil {
+		t.Fatalf("expected nil map for empty input, got %v err=%v", nilMap, err)
+	}
+}
+
 func TestIsSessionExpired_grpcNotFound(t *testing.T) {
 	err := status.Error(codes.NotFound, "session sess-abc not found")
 	if !isSessionExpired(err) {

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -88,7 +88,7 @@ export K8E_SANDBOX_APIKEY=k8e-abc123...
 |---------|---------|-----------|
 | `k8e-sandbox-cli run <code>` | Execute code or shell command | `--lang python\|bash\|node\|ts`, `--session-id`, `--tenant`, `--timeout 30`, `--raw` |
 | `k8e-sandbox-cli status` | Check service + current session | — |
-| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--manifest`, `--git-repo` |
+| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--env KEY=VAL` (repeatable, non-sensitive), `--manifest`, `--git-repo` |
 | `k8e-sandbox-cli destroy <sid>` | Destroy session | — |
 | `k8e-sandbox-cli write <sid> <path>` | Write file to /workspace | content via stdin, `--mode w\|a` |
 | `k8e-sandbox-cli read <sid> <path>` | Read file from /workspace | `--raw` (plain text output) |

--- a/pkg/sandboxmatrix/api/v1alpha1/types.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/types.go
@@ -60,11 +60,14 @@ type SandboxSession struct {
 }
 
 type SandboxSessionSpec struct {
-	TenantID        string   `json:"tenantID,omitempty"`
-	AllowedHosts    []string `json:"allowedHosts,omitempty"`
-	RuntimeClass    string   `json:"runtimeClass,omitempty"`
-	ParentSessionID string   `json:"parentSessionID,omitempty"`
-	Depth           int      `json:"depth,omitempty"`
+	TenantID        string            `json:"tenantID,omitempty"`
+	AllowedHosts    []string          `json:"allowedHosts,omitempty"`
+	RuntimeClass    string            `json:"runtimeClass,omitempty"`
+	ParentSessionID string            `json:"parentSessionID,omitempty"`
+	Depth           int               `json:"depth,omitempty"`
+	// Env is a non-sensitive map of environment variables applied at exec time
+	// (not baked into the pod spec) so warm-pool pods remain reusable.
+	Env map[string]string `json:"env,omitempty"`
 }
 
 type SandboxSessionStatus struct {

--- a/pkg/sandboxmatrix/api/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/zz_generated_deepcopy.go
@@ -100,6 +100,12 @@ func (in *SandboxSessionSpec) DeepCopyInto(out *SandboxSessionSpec) {
 	if in.AllowedHosts != nil {
 		out.AllowedHosts = append([]string{}, in.AllowedHosts...)
 	}
+	if in.Env != nil {
+		out.Env = make(map[string]string, len(in.Env))
+		for k, v := range in.Env {
+			out.Env[k] = v
+		}
+	}
 }
 func (in *SandboxSessionStatus) DeepCopyInto(out *SandboxSessionStatus) {
 	*out = *in

--- a/pkg/sandboxmatrix/grpc/env.go
+++ b/pkg/sandboxmatrix/grpc/env.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"fmt"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -25,27 +26,10 @@ func validateSessionEnv(env map[string]string) error {
 	}
 	total := 0
 	for k, v := range env {
-		if k == "" {
-			return fmt.Errorf("empty key")
+		if err := validateSessionEnvEntry(k, v); err != nil {
+			return err
 		}
-		if !utf8.ValidString(k) || !utf8.ValidString(v) {
-			return fmt.Errorf("key %q: non-utf8 key or value", k)
-		}
-		if containsNUL(k) || containsNUL(v) {
-			return fmt.Errorf("key %q: NUL byte not allowed in key or value", k)
-		}
-		if containsByte(k, '=') {
-			return fmt.Errorf("key %q: '=' not allowed in env key", k)
-		}
-		kb := len(k)
-		vb := len(v)
-		if kb > maxSessionEnvKeyBytes {
-			return fmt.Errorf("key %q: too long (%d bytes, max %d)", k, kb, maxSessionEnvKeyBytes)
-		}
-		if vb > maxSessionEnvValueBytes {
-			return fmt.Errorf("key %q: value too long (%d bytes, max %d)", k, vb, maxSessionEnvValueBytes)
-		}
-		total += kb + vb
+		total += len(k) + len(v)
 		if total > maxSessionEnvTotalBytes {
 			return fmt.Errorf("total size exceeds %d bytes", maxSessionEnvTotalBytes)
 		}
@@ -53,45 +37,47 @@ func validateSessionEnv(env map[string]string) error {
 	return nil
 }
 
-func containsNUL(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] == 0 {
-			return true
-		}
+func validateSessionEnvEntry(k, v string) error {
+	if k == "" {
+		return fmt.Errorf("empty key")
 	}
-	return false
-}
-
-func containsByte(s string, b byte) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] == b {
-			return true
-		}
+	if !utf8.ValidString(k) || !utf8.ValidString(v) {
+		return fmt.Errorf("key %q: non-utf8 key or value", k)
 	}
-	return false
+	if strings.IndexByte(k, 0) >= 0 || strings.IndexByte(v, 0) >= 0 {
+		return fmt.Errorf("key %q: NUL byte not allowed in key or value", k)
+	}
+	if strings.Contains(k, "=") {
+		return fmt.Errorf("key %q: '=' not allowed in env key", k)
+	}
+	if len(k) > maxSessionEnvKeyBytes {
+		return fmt.Errorf("key %q: too long (%d bytes, max %d)", k, len(k), maxSessionEnvKeyBytes)
+	}
+	if len(v) > maxSessionEnvValueBytes {
+		return fmt.Errorf("key %q: value too long (%d bytes, max %d)", k, len(v), maxSessionEnvValueBytes)
+	}
+	return nil
 }
 
 // sandboxdExecBody builds the JSON body for sandboxd /exec and /exec/stream.
 // env is omitted when empty so older sandboxd builds stay compatible.
 func sandboxdExecBody(command string, timeout int32, workdir string, env map[string]string) map[string]any {
-	body := map[string]any{
-		"command": command,
-		"timeout": timeout,
-		"workdir": workdir,
-	}
-	if len(env) > 0 {
-		body["env"] = env
-	}
-	return body
+	return sandboxdRequestBody(command, "", timeout, workdir, env)
 }
 
 // sandboxdBackgroundBody builds the JSON body for sandboxd /exec/background.
 func sandboxdBackgroundBody(command, runID string, timeout int32, workdir string, env map[string]string) map[string]any {
+	return sandboxdRequestBody(command, runID, timeout, workdir, env)
+}
+
+func sandboxdRequestBody(command, runID string, timeout int32, workdir string, env map[string]string) map[string]any {
 	body := map[string]any{
 		"command": command,
-		"run_id":  runID,
 		"timeout": timeout,
 		"workdir": workdir,
+	}
+	if runID != "" {
+		body["run_id"] = runID
 	}
 	if len(env) > 0 {
 		body["env"] = env

--- a/pkg/sandboxmatrix/grpc/env.go
+++ b/pkg/sandboxmatrix/grpc/env.go
@@ -1,0 +1,100 @@
+package grpc
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+// Session env limits (KIP-12 / #483 hardening). Applied at CreateSession so
+// oversized maps cannot fill etcd or explode per-exec sandboxd envp builds.
+const (
+	maxSessionEnvKeys       = 64
+	maxSessionEnvKeyBytes   = 256
+	maxSessionEnvValueBytes = 4 * 1024  // 4 KiB per value
+	maxSessionEnvTotalBytes = 32 * 1024 // 32 KiB keys+values combined
+)
+
+// validateSessionEnv checks a CreateSession env map against size and key rules.
+// nil/empty maps are valid (no env configured).
+func validateSessionEnv(env map[string]string) error {
+	if len(env) == 0 {
+		return nil
+	}
+	if len(env) > maxSessionEnvKeys {
+		return fmt.Errorf("too many entries: %d (max %d)", len(env), maxSessionEnvKeys)
+	}
+	total := 0
+	for k, v := range env {
+		if k == "" {
+			return fmt.Errorf("empty key")
+		}
+		if !utf8.ValidString(k) || !utf8.ValidString(v) {
+			return fmt.Errorf("key %q: non-utf8 key or value", k)
+		}
+		if containsNUL(k) || containsNUL(v) {
+			return fmt.Errorf("key %q: NUL byte not allowed in key or value", k)
+		}
+		if containsByte(k, '=') {
+			return fmt.Errorf("key %q: '=' not allowed in env key", k)
+		}
+		kb := len(k)
+		vb := len(v)
+		if kb > maxSessionEnvKeyBytes {
+			return fmt.Errorf("key %q: too long (%d bytes, max %d)", k, kb, maxSessionEnvKeyBytes)
+		}
+		if vb > maxSessionEnvValueBytes {
+			return fmt.Errorf("key %q: value too long (%d bytes, max %d)", k, vb, maxSessionEnvValueBytes)
+		}
+		total += kb + vb
+		if total > maxSessionEnvTotalBytes {
+			return fmt.Errorf("total size exceeds %d bytes", maxSessionEnvTotalBytes)
+		}
+	}
+	return nil
+}
+
+func containsNUL(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func containsByte(s string, b byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return true
+		}
+	}
+	return false
+}
+
+// sandboxdExecBody builds the JSON body for sandboxd /exec and /exec/stream.
+// env is omitted when empty so older sandboxd builds stay compatible.
+func sandboxdExecBody(command string, timeout int32, workdir string, env map[string]string) map[string]any {
+	body := map[string]any{
+		"command": command,
+		"timeout": timeout,
+		"workdir": workdir,
+	}
+	if len(env) > 0 {
+		body["env"] = env
+	}
+	return body
+}
+
+// sandboxdBackgroundBody builds the JSON body for sandboxd /exec/background.
+func sandboxdBackgroundBody(command, runID string, timeout int32, workdir string, env map[string]string) map[string]any {
+	body := map[string]any{
+		"command": command,
+		"run_id":  runID,
+		"timeout": timeout,
+		"workdir": workdir,
+	}
+	if len(env) > 0 {
+		body["env"] = env
+	}
+	return body
+}

--- a/pkg/sandboxmatrix/grpc/env_test.go
+++ b/pkg/sandboxmatrix/grpc/env_test.go
@@ -2,136 +2,91 @@ package grpc
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	dynfake "k8s.io/client-go/dynamic/fake"
-	kubefake "k8s.io/client-go/kubernetes/fake"
 
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 )
 
-func TestValidateSessionEnv_EmptyOK(t *testing.T) {
-	if err := validateSessionEnv(nil); err != nil {
-		t.Fatalf("nil env: %v", err)
-	}
-	if err := validateSessionEnv(map[string]string{}); err != nil {
-		t.Fatalf("empty env: %v", err)
-	}
-}
-
-func TestValidateSessionEnv_OK(t *testing.T) {
-	err := validateSessionEnv(map[string]string{
-		"FOO": "bar",
-		"BAZ": "qux=with=equals",
-	})
-	if err != nil {
-		t.Fatalf("unexpected: %v", err)
-	}
-}
-
-func TestValidateSessionEnv_TooManyKeys(t *testing.T) {
-	env := make(map[string]string, maxSessionEnvKeys+1)
+func TestValidateSessionEnv(t *testing.T) {
+	tooMany := make(map[string]string, maxSessionEnvKeys+1)
 	for i := 0; i < maxSessionEnvKeys+1; i++ {
-		env["k"+itoa(i)] = "v"
+		tooMany["k"+strconv.Itoa(i)] = "v"
 	}
-	if err := validateSessionEnv(env); err == nil {
-		t.Fatal("expected too many keys error")
-	}
-}
-
-func TestValidateSessionEnv_ValueTooLarge(t *testing.T) {
-	err := validateSessionEnv(map[string]string{
-		"BIG": strings.Repeat("a", maxSessionEnvValueBytes+1),
-	})
-	if err == nil {
-		t.Fatal("expected value too long")
-	}
-}
-
-func TestValidateSessionEnv_KeyTooLarge(t *testing.T) {
-	err := validateSessionEnv(map[string]string{
-		strings.Repeat("k", maxSessionEnvKeyBytes+1): "v",
-	})
-	if err == nil {
-		t.Fatal("expected key too long")
-	}
-}
-
-func TestValidateSessionEnv_TotalTooLarge(t *testing.T) {
-	// Each value max-sized; fewer than max keys but total over limit.
 	n := maxSessionEnvTotalBytes/maxSessionEnvValueBytes + 1
 	if n > maxSessionEnvKeys {
 		n = maxSessionEnvKeys
 	}
-	env := make(map[string]string, n)
+	tooBigTotal := make(map[string]string, n)
 	for i := 0; i < n; i++ {
-		env["k"+itoa(i)] = strings.Repeat("v", maxSessionEnvValueBytes)
+		tooBigTotal["k"+strconv.Itoa(i)] = strings.Repeat("v", maxSessionEnvValueBytes)
 	}
-	if err := validateSessionEnv(env); err == nil {
-		t.Fatal("expected total size error")
+
+	cases := []struct {
+		name    string
+		env     map[string]string
+		wantErr string
+	}{
+		{name: "nil", env: nil},
+		{name: "empty", env: map[string]string{}},
+		{name: "ok", env: map[string]string{"FOO": "bar", "BAZ": "qux=with=equals"}},
+		{name: "too many keys", env: tooMany, wantErr: "too many entries"},
+		{name: "value too large", env: map[string]string{"BIG": strings.Repeat("a", maxSessionEnvValueBytes+1)}, wantErr: "value too long"},
+		{name: "key too large", env: map[string]string{strings.Repeat("k", maxSessionEnvKeyBytes+1): "v"}, wantErr: "too long"},
+		{name: "total too large", env: tooBigTotal, wantErr: "total size exceeds"},
+		{name: "empty key", env: map[string]string{"": "x"}, wantErr: "empty key"},
+		{name: "key equals", env: map[string]string{"FOO=BAR": "x"}, wantErr: "'=' not allowed"},
+		{name: "nul value", env: map[string]string{"FOO": "a\x00b"}, wantErr: "NUL byte"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSessionEnv(tc.env)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 
-func TestValidateSessionEnv_EmptyKey(t *testing.T) {
-	if err := validateSessionEnv(map[string]string{"": "x"}); err == nil {
-		t.Fatal("expected empty key error")
-	}
-}
-
-func TestValidateSessionEnv_KeyContainsEquals(t *testing.T) {
-	if err := validateSessionEnv(map[string]string{"FOO=BAR": "x"}); err == nil {
-		t.Fatal("expected '=' in key error")
-	}
-}
-
-func TestValidateSessionEnv_NUL(t *testing.T) {
-	if err := validateSessionEnv(map[string]string{"FOO": "a\x00b"}); err == nil {
-		t.Fatal("expected NUL error")
-	}
-}
-
-func TestSandboxdExecBody_OmitsEmptyEnv(t *testing.T) {
-	body := sandboxdExecBody("echo hi", 30, "/workspace", nil)
-	if _, ok := body["env"]; ok {
-		t.Fatalf("env should be omitted when empty: %v", body)
-	}
-	if body["command"] != "echo hi" || body["timeout"] != int32(30) || body["workdir"] != "/workspace" {
-		t.Fatalf("unexpected body: %v", body)
-	}
-}
-
-func TestSandboxdExecBody_IncludesEnv(t *testing.T) {
+func TestSandboxdRequestBodies(t *testing.T) {
 	env := map[string]string{"FOO": "bar", "BAZ": "qux"}
-	body := sandboxdExecBody("true", 10, "/tmp", env)
-	got, ok := body["env"].(map[string]string)
-	if !ok {
-		t.Fatalf("env type: %T", body["env"])
-	}
-	if got["FOO"] != "bar" || got["BAZ"] != "qux" {
-		t.Fatalf("env payload: %v", got)
-	}
-}
 
-func TestSandboxdBackgroundBody_IncludesEnv(t *testing.T) {
-	env := map[string]string{"FOO": "bar"}
-	body := sandboxdBackgroundBody("sleep 1", "run-1", 60, "/workspace", env)
-	if body["run_id"] != "run-1" {
-		t.Fatalf("run_id: %v", body["run_id"])
+	empty := sandboxdExecBody("echo hi", 30, "/workspace", nil)
+	if _, ok := empty["env"]; ok {
+		t.Fatalf("env should be omitted when empty: %v", empty)
 	}
-	got, ok := body["env"].(map[string]string)
+	if empty["command"] != "echo hi" || empty["timeout"] != int32(30) || empty["workdir"] != "/workspace" {
+		t.Fatalf("unexpected exec body: %v", empty)
+	}
+
+	withEnv := sandboxdExecBody("true", 10, "/tmp", env)
+	got, ok := withEnv["env"].(map[string]string)
+	if !ok || got["FOO"] != "bar" || got["BAZ"] != "qux" {
+		t.Fatalf("exec env payload: %v", withEnv["env"])
+	}
+
+	bg := sandboxdBackgroundBody("sleep 1", "run-1", 60, "/workspace", map[string]string{"FOO": "bar"})
+	if bg["run_id"] != "run-1" {
+		t.Fatalf("run_id: %v", bg["run_id"])
+	}
+	got, ok = bg["env"].(map[string]string)
 	if !ok || got["FOO"] != "bar" {
-		t.Fatalf("env: %v", body["env"])
+		t.Fatalf("background env: %v", bg["env"])
 	}
 }
 
 func TestGetSessionEnv_ReturnsPersistedEnv(t *testing.T) {
 	s := newTestServer()
-	// Create via orchestrator (bypasses capacity) with env.
 	sess, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
 		SessionId: "env-get-test",
 		Env:       map[string]string{"FOO": "bar", "BAZ": "qux"},
@@ -147,53 +102,41 @@ func TestGetSessionEnv_ReturnsPersistedEnv(t *testing.T) {
 
 func TestGetSessionEnv_MissingSession(t *testing.T) {
 	s := newTestServer()
-	got := s.getSessionEnv(context.Background(), "does-not-exist")
-	if got != nil {
+	if got := s.getSessionEnv(context.Background(), "does-not-exist"); got != nil {
 		t.Fatalf("expected nil on missing session, got %v", got)
 	}
 }
 
 func TestGetSessionEnv_NoEnvField(t *testing.T) {
 	s := newTestServer()
-	sess, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
-		SessionId: "env-none",
-	})
+	sess, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{SessionId: "env-none"})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	got := s.getSessionEnv(context.Background(), sess.Name)
-	if got != nil {
+	if got := s.getSessionEnv(context.Background(), sess.Name); got != nil {
 		t.Fatalf("expected nil when no env, got %v", got)
 	}
 }
 
 func TestCreateSession_RejectsOversizedEnv(t *testing.T) {
-	o := newTestOrchestrator()
-	err := validateSessionEnv(map[string]string{
-		"BIG": strings.Repeat("x", maxSessionEnvValueBytes+1),
-	})
-	if err == nil {
+	big := map[string]string{"BIG": strings.Repeat("x", maxSessionEnvValueBytes+1)}
+	if err := validateSessionEnv(big); err == nil {
 		t.Fatal("precondition: validate should fail")
 	}
-	// Orchestrator path also enforces limits.
-	_, err = o.CreateSession(context.Background(), &pb.CreateSessionRequest{
+	_, err := newTestOrchestrator().CreateSession(context.Background(), &pb.CreateSessionRequest{
 		SessionId: "env-too-big",
-		Env:       map[string]string{"BIG": strings.Repeat("x", maxSessionEnvValueBytes+1)},
+		Env:       big,
 	})
 	if err == nil {
 		t.Fatal("expected CreateSession to reject oversized env")
 	}
-	if st, ok := statusFrom(err); !ok || st != "InvalidArgument" {
-		// Accept any error that mentions env; status code when available.
-		if !strings.Contains(err.Error(), "env") {
-			t.Fatalf("unexpected error: %v", err)
-		}
+	if !strings.Contains(err.Error(), "env") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
 func TestGetSessionEnv_UnreadableEnvField(t *testing.T) {
 	s := newTestServer()
-	// Seed a session object where spec.env is not a string map.
 	u := &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": testAPIVer,
 		"kind":       "SandboxSession",
@@ -204,61 +147,17 @@ func TestGetSessionEnv_UnreadableEnvField(t *testing.T) {
 		},
 		"status": map[string]interface{}{"phase": "Active", "podIP": "10.0.0.1"},
 	}}
-	_, err := s.dyn.Resource(sessionGVR).Namespace(sandboxNS).Create(context.Background(), u, metav1.CreateOptions{})
-	if err != nil {
+	if _, err := s.dyn.Resource(sessionGVR).Namespace(sandboxNS).Create(context.Background(), u, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	got := s.getSessionEnv(context.Background(), "env-bad")
-	if got != nil {
+	if got := s.getSessionEnv(context.Background(), "env-bad"); got != nil {
 		t.Fatalf("expected nil on unreadable env, got %v", got)
 	}
 }
 
+// newTestServer reuses the shared fake k8s/dynamic clients from newTestOrchestrator
+// (avoids duplicating the scheme/listKinds setup that Sonar flagged).
 func newTestServer() *Server {
-	scheme := runtime.NewScheme()
-	for _, gvk := range []schema.GroupVersionKind{
-		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxSession"},
-		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxMatrix"},
-		{Group: testGroupCilium, Version: "v2", Kind: "CiliumNetworkPolicy"},
-	} {
-		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
-	}
-	for _, gvk := range []schema.GroupVersionKind{
-		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxSessionList"},
-		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxMatrixList"},
-		{Group: testGroupCilium, Version: "v2", Kind: "CiliumNetworkPolicyList"},
-	} {
-		scheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
-	}
-	listKinds := map[schema.GroupVersionResource]string{
-		{Group: testGroupK8e, Version: "v1alpha1", Resource: "sandboxsessions"}:       "SandboxSessionList",
-		{Group: testGroupK8e, Version: "v1alpha1", Resource: "sandboxmatrices"}:       "SandboxMatrixList",
-		{Group: testGroupCilium, Version: "v2", Resource: "ciliumnetworkpolicies"}: "CiliumNetworkPolicyList",
-	}
-	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
-	k8s := kubefake.NewSimpleClientset()
-	return NewServer(ServerConfig{K8s: k8s, Dyn: dyn})
-}
-
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	var b [16]byte
-	pos := len(b)
-	for i > 0 {
-		pos--
-		b[pos] = byte('0' + i%10)
-		i /= 10
-	}
-	return string(b[pos:])
-}
-
-func statusFrom(err error) (string, bool) {
-	// Avoid importing status codes comparison noise; Error() from gRPC status embeds the code name.
-	msg := err.Error()
-	if strings.Contains(msg, "InvalidArgument") || strings.Contains(msg, "invalid argument") {
-		return "InvalidArgument", true
-	}
-	return "", false
+	o := newTestOrchestrator()
+	return &Server{k8s: o.k8s, dyn: o.dynamic, orch: o}
 }

--- a/pkg/sandboxmatrix/grpc/env_test.go
+++ b/pkg/sandboxmatrix/grpc/env_test.go
@@ -1,0 +1,264 @@
+package grpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+)
+
+func TestValidateSessionEnv_EmptyOK(t *testing.T) {
+	if err := validateSessionEnv(nil); err != nil {
+		t.Fatalf("nil env: %v", err)
+	}
+	if err := validateSessionEnv(map[string]string{}); err != nil {
+		t.Fatalf("empty env: %v", err)
+	}
+}
+
+func TestValidateSessionEnv_OK(t *testing.T) {
+	err := validateSessionEnv(map[string]string{
+		"FOO": "bar",
+		"BAZ": "qux=with=equals",
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+}
+
+func TestValidateSessionEnv_TooManyKeys(t *testing.T) {
+	env := make(map[string]string, maxSessionEnvKeys+1)
+	for i := 0; i < maxSessionEnvKeys+1; i++ {
+		env["k"+itoa(i)] = "v"
+	}
+	if err := validateSessionEnv(env); err == nil {
+		t.Fatal("expected too many keys error")
+	}
+}
+
+func TestValidateSessionEnv_ValueTooLarge(t *testing.T) {
+	err := validateSessionEnv(map[string]string{
+		"BIG": strings.Repeat("a", maxSessionEnvValueBytes+1),
+	})
+	if err == nil {
+		t.Fatal("expected value too long")
+	}
+}
+
+func TestValidateSessionEnv_KeyTooLarge(t *testing.T) {
+	err := validateSessionEnv(map[string]string{
+		strings.Repeat("k", maxSessionEnvKeyBytes+1): "v",
+	})
+	if err == nil {
+		t.Fatal("expected key too long")
+	}
+}
+
+func TestValidateSessionEnv_TotalTooLarge(t *testing.T) {
+	// Each value max-sized; fewer than max keys but total over limit.
+	n := maxSessionEnvTotalBytes/maxSessionEnvValueBytes + 1
+	if n > maxSessionEnvKeys {
+		n = maxSessionEnvKeys
+	}
+	env := make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		env["k"+itoa(i)] = strings.Repeat("v", maxSessionEnvValueBytes)
+	}
+	if err := validateSessionEnv(env); err == nil {
+		t.Fatal("expected total size error")
+	}
+}
+
+func TestValidateSessionEnv_EmptyKey(t *testing.T) {
+	if err := validateSessionEnv(map[string]string{"": "x"}); err == nil {
+		t.Fatal("expected empty key error")
+	}
+}
+
+func TestValidateSessionEnv_KeyContainsEquals(t *testing.T) {
+	if err := validateSessionEnv(map[string]string{"FOO=BAR": "x"}); err == nil {
+		t.Fatal("expected '=' in key error")
+	}
+}
+
+func TestValidateSessionEnv_NUL(t *testing.T) {
+	if err := validateSessionEnv(map[string]string{"FOO": "a\x00b"}); err == nil {
+		t.Fatal("expected NUL error")
+	}
+}
+
+func TestSandboxdExecBody_OmitsEmptyEnv(t *testing.T) {
+	body := sandboxdExecBody("echo hi", 30, "/workspace", nil)
+	if _, ok := body["env"]; ok {
+		t.Fatalf("env should be omitted when empty: %v", body)
+	}
+	if body["command"] != "echo hi" || body["timeout"] != int32(30) || body["workdir"] != "/workspace" {
+		t.Fatalf("unexpected body: %v", body)
+	}
+}
+
+func TestSandboxdExecBody_IncludesEnv(t *testing.T) {
+	env := map[string]string{"FOO": "bar", "BAZ": "qux"}
+	body := sandboxdExecBody("true", 10, "/tmp", env)
+	got, ok := body["env"].(map[string]string)
+	if !ok {
+		t.Fatalf("env type: %T", body["env"])
+	}
+	if got["FOO"] != "bar" || got["BAZ"] != "qux" {
+		t.Fatalf("env payload: %v", got)
+	}
+}
+
+func TestSandboxdBackgroundBody_IncludesEnv(t *testing.T) {
+	env := map[string]string{"FOO": "bar"}
+	body := sandboxdBackgroundBody("sleep 1", "run-1", 60, "/workspace", env)
+	if body["run_id"] != "run-1" {
+		t.Fatalf("run_id: %v", body["run_id"])
+	}
+	got, ok := body["env"].(map[string]string)
+	if !ok || got["FOO"] != "bar" {
+		t.Fatalf("env: %v", body["env"])
+	}
+}
+
+func TestGetSessionEnv_ReturnsPersistedEnv(t *testing.T) {
+	s := newTestServer()
+	// Create via orchestrator (bypasses capacity) with env.
+	sess, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "env-get-test",
+		Env:       map[string]string{"FOO": "bar", "BAZ": "qux"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got := s.getSessionEnv(context.Background(), sess.Name)
+	if got["FOO"] != "bar" || got["BAZ"] != "qux" {
+		t.Fatalf("getSessionEnv: %v", got)
+	}
+}
+
+func TestGetSessionEnv_MissingSession(t *testing.T) {
+	s := newTestServer()
+	got := s.getSessionEnv(context.Background(), "does-not-exist")
+	if got != nil {
+		t.Fatalf("expected nil on missing session, got %v", got)
+	}
+}
+
+func TestGetSessionEnv_NoEnvField(t *testing.T) {
+	s := newTestServer()
+	sess, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "env-none",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got := s.getSessionEnv(context.Background(), sess.Name)
+	if got != nil {
+		t.Fatalf("expected nil when no env, got %v", got)
+	}
+}
+
+func TestCreateSession_RejectsOversizedEnv(t *testing.T) {
+	o := newTestOrchestrator()
+	err := validateSessionEnv(map[string]string{
+		"BIG": strings.Repeat("x", maxSessionEnvValueBytes+1),
+	})
+	if err == nil {
+		t.Fatal("precondition: validate should fail")
+	}
+	// Orchestrator path also enforces limits.
+	_, err = o.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "env-too-big",
+		Env:       map[string]string{"BIG": strings.Repeat("x", maxSessionEnvValueBytes+1)},
+	})
+	if err == nil {
+		t.Fatal("expected CreateSession to reject oversized env")
+	}
+	if st, ok := statusFrom(err); !ok || st != "InvalidArgument" {
+		// Accept any error that mentions env; status code when available.
+		if !strings.Contains(err.Error(), "env") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestGetSessionEnv_UnreadableEnvField(t *testing.T) {
+	s := newTestServer()
+	// Seed a session object where spec.env is not a string map.
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": testAPIVer,
+		"kind":       "SandboxSession",
+		"metadata":   map[string]interface{}{"name": "env-bad", "namespace": sandboxNS},
+		"spec": map[string]interface{}{
+			"runtimeClass": "gvisor",
+			"env":          "not-a-map",
+		},
+		"status": map[string]interface{}{"phase": "Active", "podIP": "10.0.0.1"},
+	}}
+	_, err := s.dyn.Resource(sessionGVR).Namespace(sandboxNS).Create(context.Background(), u, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got := s.getSessionEnv(context.Background(), "env-bad")
+	if got != nil {
+		t.Fatalf("expected nil on unreadable env, got %v", got)
+	}
+}
+
+func newTestServer() *Server {
+	scheme := runtime.NewScheme()
+	for _, gvk := range []schema.GroupVersionKind{
+		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxSession"},
+		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxMatrix"},
+		{Group: testGroupCilium, Version: "v2", Kind: "CiliumNetworkPolicy"},
+	} {
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+	for _, gvk := range []schema.GroupVersionKind{
+		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxSessionList"},
+		{Group: testGroupK8e, Version: "v1alpha1", Kind: "SandboxMatrixList"},
+		{Group: testGroupCilium, Version: "v2", Kind: "CiliumNetworkPolicyList"},
+	} {
+		scheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+	}
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: testGroupK8e, Version: "v1alpha1", Resource: "sandboxsessions"}:       "SandboxSessionList",
+		{Group: testGroupK8e, Version: "v1alpha1", Resource: "sandboxmatrices"}:       "SandboxMatrixList",
+		{Group: testGroupCilium, Version: "v2", Resource: "ciliumnetworkpolicies"}: "CiliumNetworkPolicyList",
+	}
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	k8s := kubefake.NewSimpleClientset()
+	return NewServer(ServerConfig{K8s: k8s, Dyn: dyn})
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [16]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}
+
+func statusFrom(err error) (string, bool) {
+	// Avoid importing status codes comparison noise; Error() from gRPC status embeds the code name.
+	msg := err.Error()
+	if strings.Contains(msg, "InvalidArgument") || strings.Contains(msg, "invalid argument") {
+		return "InvalidArgument", true
+	}
+	return "", false
+}

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -292,6 +292,7 @@ func (o *Orchestrator) createSessionWithTTL(ctx context.Context, req *pb.CreateS
 			AllowedHosts: allowedHosts,
 			RuntimeClass: runtimeClass,
 			Depth:        0,
+			Env:          req.Env,
 		},
 	}
 	if err := o.createSession(ctx, session); err != nil {
@@ -452,6 +453,7 @@ func (o *Orchestrator) RunSubAgent(ctx context.Context, req *pb.RunSubAgentReque
 			RuntimeClass:    parent.Spec.RuntimeClass,
 			ParentSessionID: req.ParentSessionId,
 			Depth:           parent.Spec.Depth + 1,
+			Env:             parent.Spec.Env,
 		},
 	}
 	if err := o.createSession(ctx, child); err != nil {
@@ -552,16 +554,21 @@ func (o *Orchestrator) StartApprovalGC(ctx context.Context) {
 }
 
 // ExecBackground submits a background command to the sandboxd and registers the run_id.
-func (o *Orchestrator) ExecBackground(ctx context.Context, sessionID, command string, timeout int32, workdir string) (string, error) {
+// env is the session's non-sensitive environment map (applied at exec time).
+func (o *Orchestrator) ExecBackground(ctx context.Context, sessionID, command string, timeout int32, workdir string, env map[string]string) (string, error) {
 	podIP, err := o.getPodIPBySession(ctx, sessionID)
 	if err != nil {
 		return "", err
 	}
 
 	runID := fmt.Sprintf("%s-bg-%d", sessionID, time.Now().UnixNano())
-	body, _ := json.Marshal(map[string]any{
+	bodyMap := map[string]any{
 		"command": command, "run_id": runID, "timeout": timeout, "workdir": workdir,
-	})
+	}
+	if len(env) > 0 {
+		bodyMap["env"] = env
+	}
+	body, _ := json.Marshal(bodyMap)
 
 	url := fmt.Sprintf("http://%s:%d/exec/background", podIP, 2024)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -269,6 +269,9 @@ func (o *Orchestrator) getMatrixConfig(ctx context.Context) (allowedHosts []stri
 }
 
 func (o *Orchestrator) createSessionWithTTL(ctx context.Context, req *pb.CreateSessionRequest, ttl int, matrixDefaultHosts []string, matrixCPU, matrixMemory string) (*sandboxv1.SandboxSession, error) {
+	if err := validateSessionEnv(req.Env); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "env: %v", err)
+	}
 	sessionID := req.SessionId
 	if sessionID == "" {
 		sessionID = fmt.Sprintf("sess-%d", time.Now().UnixNano())
@@ -562,13 +565,7 @@ func (o *Orchestrator) ExecBackground(ctx context.Context, sessionID, command st
 	}
 
 	runID := fmt.Sprintf("%s-bg-%d", sessionID, time.Now().UnixNano())
-	bodyMap := map[string]any{
-		"command": command, "run_id": runID, "timeout": timeout, "workdir": workdir,
-	}
-	if len(env) > 0 {
-		bodyMap["env"] = env
-	}
-	body, _ := json.Marshal(bodyMap)
+	body, _ := json.Marshal(sandboxdBackgroundBody(command, runID, timeout, workdir, env))
 
 	url := fmt.Sprintf("http://%s:%d/exec/background", podIP, 2024)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -355,6 +355,28 @@ func TestCreateSession_AllowedHosts(t *testing.T) {
 	}
 }
 
+func TestCreateSession_Env(t *testing.T) {
+	o := newTestOrchestrator()
+	sess, err := o.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "env-test",
+		Env:       map[string]string{"FOO": "bar", "BAZ": "qux"},
+	})
+	if err != nil {
+		t.Fatalf(msgUnexpected, err)
+	}
+	if sess.Spec.Env["FOO"] != "bar" || sess.Spec.Env["BAZ"] != "qux" {
+		t.Fatalf("unexpected env: %v", sess.Spec.Env)
+	}
+	// Round-trip through getSession (unstructured conversion) must preserve env.
+	got, err := o.getSession(context.Background(), "env-test")
+	if err != nil {
+		t.Fatalf("getSession: %v", err)
+	}
+	if got.Spec.Env["FOO"] != "bar" || got.Spec.Env["BAZ"] != "qux" {
+		t.Fatalf("env lost on getSession round-trip: %v", got.Spec.Env)
+	}
+}
+
 func TestCreateSession_ExpiresAt_WithTTL(t *testing.T) {
 	o := newTestOrchestrator()
 	// seed a SandboxMatrix with sessionTTL=3600

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -22,11 +22,14 @@ const (
 )
 
 type CreateSessionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	TenantId      string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	AllowedHosts  []string               `protobuf:"bytes,3,rep,name=allowed_hosts,json=allowedHosts,proto3" json:"allowed_hosts,omitempty"`
-	RuntimeClass  string                 `protobuf:"bytes,4,opt,name=runtime_class,json=runtimeClass,proto3" json:"runtime_class,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	SessionId    string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	TenantId     string                 `protobuf:"bytes,2,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	AllowedHosts []string               `protobuf:"bytes,3,rep,name=allowed_hosts,json=allowedHosts,proto3" json:"allowed_hosts,omitempty"`
+	RuntimeClass string                 `protobuf:"bytes,4,opt,name=runtime_class,json=runtimeClass,proto3" json:"runtime_class,omitempty"`
+	// Non-sensitive environment variables persisted on the SandboxSession and
+	// applied at exec time so warm-pool pods stay reusable (KIP-12 Part B / #483).
+	Env           map[string]string `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -87,6 +90,13 @@ func (x *CreateSessionRequest) GetRuntimeClass() string {
 		return x.RuntimeClass
 	}
 	return ""
+}
+
+func (x *CreateSessionRequest) GetEnv() map[string]string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
 }
 
 type CreateSessionResponse struct {
@@ -1450,13 +1460,17 @@ var File_sandbox_v1_sandbox_proto protoreflect.FileDescriptor
 const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"\x18sandbox/v1/sandbox.proto\x12\n" +
-	"sandbox.v1\"\x9c\x01\n" +
+	"sandbox.v1\"\x91\x02\n" +
 	"\x14CreateSessionRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12#\n" +
 	"\rallowed_hosts\x18\x03 \x03(\tR\fallowedHosts\x12#\n" +
-	"\rruntime_class\x18\x04 \x01(\tR\fruntimeClass\"M\n" +
+	"\rruntime_class\x18\x04 \x01(\tR\fruntimeClass\x12;\n" +
+	"\x03env\x18\x05 \x03(\v2).sandbox.v1.CreateSessionRequest.EnvEntryR\x03env\x1a6\n" +
+	"\bEnvEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"M\n" +
 	"\x15CreateSessionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x15\n" +
@@ -1572,7 +1586,7 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\rConfirmAction\x12 .sandbox.v1.ConfirmActionRequest\x1a!.sandbox.v1.ConfirmActionResponse\x12T\n" +
 	"\rApproveAction\x12 .sandbox.v1.ApproveActionRequest\x1a!.sandbox.v1.ApproveActionResponse\x12<\n" +
 	"\x05Login\x12\x18.sandbox.v1.LoginRequest\x1a\x19.sandbox.v1.LoginResponse\x12B\n" +
-	"\aPollRun\x12\x1a.sandbox.v1.PollRunRequest\x1a\x1b.sandbox.v1.PollRunResponseB1Z/github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pbb\x06proto3"
+	"\aPollRun\x12\x1a.sandbox.v1.PollRunRequest\x1a\x1b.sandbox.v1.PollRunResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
 
 var (
 	file_sandbox_v1_sandbox_proto_rawDescOnce sync.Once
@@ -1586,7 +1600,7 @@ func file_sandbox_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_sandbox_v1_sandbox_proto_rawDescData
 }
 
-var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*CreateSessionRequest)(nil),   // 0: sandbox.v1.CreateSessionRequest
 	(*CreateSessionResponse)(nil),  // 1: sandbox.v1.CreateSessionResponse
@@ -1614,40 +1628,42 @@ var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*LoginResponse)(nil),          // 23: sandbox.v1.LoginResponse
 	(*PollRunRequest)(nil),         // 24: sandbox.v1.PollRunRequest
 	(*PollRunResponse)(nil),        // 25: sandbox.v1.PollRunResponse
+	nil,                            // 26: sandbox.v1.CreateSessionRequest.EnvEntry
 }
 var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
-	13, // 0: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
-	0,  // 1: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
-	2,  // 2: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
-	4,  // 3: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
-	4,  // 4: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
-	7,  // 5: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
-	9,  // 6: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
-	11, // 7: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
-	14, // 8: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
-	16, // 9: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
-	18, // 10: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
-	20, // 11: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
-	22, // 12: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
-	24, // 13: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
-	1,  // 14: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
-	3,  // 15: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
-	5,  // 16: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
-	6,  // 17: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
-	8,  // 18: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
-	10, // 19: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
-	12, // 20: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
-	15, // 21: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
-	17, // 22: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
-	19, // 23: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
-	21, // 24: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	23, // 25: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
-	25, // 26: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
-	14, // [14:27] is the sub-list for method output_type
-	1,  // [1:14] is the sub-list for method input_type
-	1,  // [1:1] is the sub-list for extension type_name
-	1,  // [1:1] is the sub-list for extension extendee
-	0,  // [0:1] is the sub-list for field type_name
+	26, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
+	13, // 1: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
+	0,  // 2: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
+	2,  // 3: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
+	4,  // 4: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
+	4,  // 5: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
+	7,  // 6: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
+	9,  // 7: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
+	11, // 8: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
+	14, // 9: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
+	16, // 10: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
+	18, // 11: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
+	20, // 12: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
+	22, // 13: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
+	24, // 14: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
+	1,  // 15: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
+	3,  // 16: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
+	5,  // 17: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
+	6,  // 18: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
+	8,  // 19: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
+	10, // 20: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
+	12, // 21: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
+	15, // 22: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
+	17, // 23: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
+	19, // 24: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
+	21, // 25: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
+	23, // 26: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
+	25, // 27: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
+	15, // [15:28] is the sub-list for method output_type
+	2,  // [2:15] is the sub-list for method input_type
+	2,  // [2:2] is the sub-list for extension type_name
+	2,  // [2:2] is the sub-list for extension extendee
+	0,  // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_sandbox_v1_sandbox_proto_init() }
@@ -1661,7 +1677,7 @@ func file_sandbox_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_v1_sandbox_proto_rawDesc), len(file_sandbox_v1_sandbox_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   26,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -290,6 +290,9 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) CreateSession(ctx context.Context, req *pb.CreateSessionRequest) (*pb.CreateSessionResponse, error) {
+	if err := validateSessionEnv(req.Env); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "env: %v", err)
+	}
 	if err := s.orch.CheckCapacity(ctx); err != nil {
 		return nil, err
 	}
@@ -331,10 +334,8 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 		workdir = "/workspace"
 	}
 
-	body := map[string]any{"command": req.Command, "timeout": timeout, "workdir": workdir}
-	if env := s.getSessionEnv(ctx, req.SessionId); len(env) > 0 {
-		body["env"] = env
-	}
+	env := s.getSessionEnv(ctx, req.SessionId)
+	body := sandboxdExecBody(req.Command, timeout, workdir, env)
 	httpCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout+5)*time.Second)
 	defer cancel()
 
@@ -366,10 +367,8 @@ func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecSt
 	if workdir == "" {
 		workdir = "/workspace"
 	}
-	body := map[string]any{"command": req.Command, "timeout": timeout, "workdir": workdir}
-	if env := s.getSessionEnv(stream.Context(), req.SessionId); len(env) > 0 {
-		body["env"] = env
-	}
+	env := s.getSessionEnv(stream.Context(), req.SessionId)
+	body := sandboxdExecBody(req.Command, timeout, workdir, env)
 	httpCtx, cancel := context.WithTimeout(stream.Context(), time.Duration(timeout+5)*time.Second)
 	defer cancel()
 
@@ -397,14 +396,22 @@ func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecSt
 }
 
 // getSessionEnv returns the non-sensitive env map stored on the SandboxSession CR.
-// Returns nil when absent or on lookup failure (exec proceeds with sandboxd defaults).
+// Returns nil when absent. On lookup failure it logs a warning and returns nil so
+// exec still proceeds with sandboxd defaults (P1-1: no longer a silent drop).
 func (s *Server) getSessionEnv(ctx context.Context, sessionID string) map[string]string {
 	u, err := s.dyn.Resource(sessionGVR).Namespace(sandboxNS).Get(ctx, sessionID, metav1.GetOptions{})
 	if err != nil {
+		logrus.WithError(err).WithField("session_id", sessionID).
+			Warn("sandbox gRPC: failed to load session env; continuing with sandboxd defaults")
 		return nil
 	}
-	env, _, _ := unstructured.NestedStringMap(u.Object, "spec", "env")
-	if len(env) == 0 {
+	env, found, err := unstructured.NestedStringMap(u.Object, "spec", "env")
+	if err != nil {
+		logrus.WithError(err).WithField("session_id", sessionID).
+			Warn("sandbox gRPC: session env field unreadable; continuing with sandboxd defaults")
+		return nil
+	}
+	if !found || len(env) == 0 {
 		return nil
 	}
 	return env

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -310,7 +310,8 @@ func (s *Server) DestroySession(ctx context.Context, req *pb.DestroySessionReque
 func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecResponse, error) {
 	// Background mode: submit async, return run_id immediately
 	if req.Background {
-		runID, err := s.orch.ExecBackground(ctx, req.SessionId, req.Command, req.Timeout, req.Workdir)
+		env := s.getSessionEnv(ctx, req.SessionId)
+		runID, err := s.orch.ExecBackground(ctx, req.SessionId, req.Command, req.Timeout, req.Workdir, env)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "background submit: %v", err)
 		}
@@ -331,6 +332,9 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 	}
 
 	body := map[string]any{"command": req.Command, "timeout": timeout, "workdir": workdir}
+	if env := s.getSessionEnv(ctx, req.SessionId); len(env) > 0 {
+		body["env"] = env
+	}
 	httpCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout+5)*time.Second)
 	defer cancel()
 
@@ -363,6 +367,9 @@ func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecSt
 		workdir = "/workspace"
 	}
 	body := map[string]any{"command": req.Command, "timeout": timeout, "workdir": workdir}
+	if env := s.getSessionEnv(stream.Context(), req.SessionId); len(env) > 0 {
+		body["env"] = env
+	}
 	httpCtx, cancel := context.WithTimeout(stream.Context(), time.Duration(timeout+5)*time.Second)
 	defer cancel()
 
@@ -387,6 +394,20 @@ func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecSt
 			return status.Errorf(codes.Internal, "stream read: %v", err)
 		}
 	}
+}
+
+// getSessionEnv returns the non-sensitive env map stored on the SandboxSession CR.
+// Returns nil when absent or on lookup failure (exec proceeds with sandboxd defaults).
+func (s *Server) getSessionEnv(ctx context.Context, sessionID string) map[string]string {
+	u, err := s.dyn.Resource(sessionGVR).Namespace(sandboxNS).Get(ctx, sessionID, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	env, _, _ := unstructured.NestedStringMap(u.Object, "spec", "env")
+	if len(env) == 0 {
+		return nil
+	}
+	return env
 }
 
 func (s *Server) WriteFile(ctx context.Context, req *pb.WriteFileRequest) (*pb.WriteFileResponse, error) {

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package sandbox.v1;
-option go_package = "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb";
+option go_package = "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pb";
 
 service SandboxService {
   rpc CreateSession(CreateSessionRequest)   returns (CreateSessionResponse);
@@ -27,6 +27,9 @@ message CreateSessionRequest {
   string          tenant_id      = 2;
   repeated string allowed_hosts  = 3;
   string          runtime_class  = 4;
+  // Non-sensitive environment variables persisted on the SandboxSession and
+  // applied at exec time so warm-pool pods stay reusable (KIP-12 Part B / #483).
+  map<string, string> env        = 5;
 }
 message CreateSessionResponse {
   string session_id = 1;

--- a/sandboxd/src/background.zig
+++ b/sandboxd/src/background.zig
@@ -17,7 +17,7 @@ const BG_WRAPPER = "trap 'rc=$?; printf %s \"$rc\" > \"$K8E_BG_DIR/exit_code\"' 
 /// POST /exec/background
 /// Body: {"command": "...", "run_id": "...", "timeout": 300, "workdir": "/workspace"}
 pub fn handleBgSubmit(allocator: std.mem.Allocator, client_fd: i32, body: []const u8) !void {
-    const parsed = std.json.parseFromSlice(BgSubmitRequest, allocator, body, .{ .ignore_unknown_fields = true }) catch {
+    const parsed = std.json.parseFromSlice(BgSubmitRequest, allocator, body, .{ .ignore_unknown_fields = true, .allocate = .alloc_always }) catch {
         try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
         return;
     };
@@ -48,17 +48,13 @@ pub fn handleBgSubmit(allocator: std.mem.Allocator, client_fd: i32, body: []cons
         }
     }
 
-    // Build argv/envp in the parent so the post-fork child can execve without allocating.
-    const dir_env = try std.fmt.allocPrintSentinel(allocator, "K8E_BG_DIR={s}", .{run_dir}, 0);
-    defer allocator.free(dir_env);
-    const cmd_env = try std.fmt.allocPrintSentinel(allocator, "K8E_BG_CMD={s}", .{req.command}, 0);
-    defer allocator.free(cmd_env);
-
-    // Explicit env: a sane PATH (covers python:/usr/local/bin and node) plus the
-    // run dir and command the wrapper reads. K8E_BG_CMD/K8E_BG_DIR carry the user
-    // command and target dir so they need no shell quoting in BG_WRAPPER.
-    const path_env: [*:0]const u8 = "PATH=/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-    const envp = [3:null]?[*:0]const u8{ path_env, dir_env.ptr, cmd_env.ptr };
+    // Build envp in the parent so the post-fork child can execve without allocating.
+    // Defaults (PATH/VIRTUAL_ENV) + session env + K8E_BG_* for the wrapper.
+    var env_build = try exec.buildEnvp(allocator, req.env, &.{
+        .{ "K8E_BG_DIR", run_dir },
+        .{ "K8E_BG_CMD", req.command },
+    });
+    defer env_build.deinit();
 
     const wrapper_z: [*:0]const u8 = BG_WRAPPER;
     const argv = [3:null]?[*:0]const u8{ "/bin/sh".ptr, "-c".ptr, wrapper_z };
@@ -93,7 +89,7 @@ pub fn handleBgSubmit(allocator: std.mem.Allocator, client_fd: i32, body: []cons
             _ = std.os.linux.close(@intCast(pid_fd));
         }
 
-        _ = std.os.linux.execve("/bin/sh", &argv, &envp);
+        _ = std.os.linux.execve("/bin/sh", &argv, env_build.envpPtr());
         std.os.linux.exit(1);
     }
 
@@ -168,6 +164,8 @@ const BgSubmitRequest = struct {
     run_id: []const u8 = "",
     timeout: u32 = 0,
     workdir: []const u8 = "/workspace",
+    // Optional object of string->string; applied at exec time with K8E_BG_* extras.
+    env: std.json.Value = .{ .null = {} },
 };
 
 // readFileZ reads up to max bytes from a null-terminated path via raw syscalls,

--- a/sandboxd/src/exec.zig
+++ b/sandboxd/src/exec.zig
@@ -2,10 +2,15 @@ const std = @import("std");
 const main = @import("main.zig");
 const venv = @import("venv.zig");
 
+const default_path_value = "/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const default_venv_value = "/workspace/.venv";
+
 const ExecRequest = struct {
     command: []const u8 = "",
     timeout: u32 = 30,
     workdir: []const u8 = "/workspace",
+    // Optional object of string->string; absent/null means defaults only.
+    env: std.json.Value = .{ .null = {} },
 };
 
 pub const ExecResult = struct {
@@ -19,15 +24,95 @@ pub const ExecResult = struct {
     }
 };
 
+/// Owned envp for execve: null-terminated pointer list + owned KEY=VAL strings.
+pub const EnvBuild = struct {
+    allocator: std.mem.Allocator,
+    /// Pointers for execve; last entry is null. Length is entry_count+1.
+    ptrs: []?[*:0]const u8,
+    entries: [][:0]u8,
+
+    pub fn deinit(self: *EnvBuild) void {
+        for (self.entries) |e| self.allocator.free(e);
+        self.allocator.free(self.entries);
+        self.allocator.free(self.ptrs);
+        self.* = undefined;
+    }
+
+    pub fn envpPtr(self: *const EnvBuild) [*:null]?[*:0]const u8 {
+        return @ptrCast(self.ptrs.ptr);
+    }
+};
+
+/// buildEnvp merges sandbox defaults (PATH, VIRTUAL_ENV) with optional user env.
+/// User keys override defaults. extra_pairs are forced last (e.g. K8E_BG_* for background).
+pub fn buildEnvp(
+    allocator: std.mem.Allocator,
+    user_env: std.json.Value,
+    extra_pairs: []const struct { []const u8, []const u8 },
+) !EnvBuild {
+    var map = std.StringHashMap([]const u8).init(allocator);
+    defer map.deinit();
+
+    try map.put("PATH", default_path_value);
+    try map.put("VIRTUAL_ENV", default_venv_value);
+
+    if (user_env == .object) {
+        var it = user_env.object.iterator();
+        while (it.next()) |entry| {
+            if (entry.key_ptr.*.len == 0) continue;
+            if (entry.value_ptr.* != .string) continue;
+            try map.put(entry.key_ptr.*, entry.value_ptr.*.string);
+        }
+    }
+
+    for (extra_pairs) |pair| {
+        try map.put(pair[0], pair[1]);
+    }
+
+    const n = map.count();
+    var entries = try allocator.alloc([:0]u8, n);
+    var filled: usize = 0;
+    errdefer {
+        for (entries[0..filled]) |e| allocator.free(e);
+        allocator.free(entries);
+    }
+    var ptrs = try allocator.alloc(?[*:0]const u8, n + 1);
+    errdefer allocator.free(ptrs);
+
+    var i: usize = 0;
+    var mit = map.iterator();
+    while (mit.next()) |e| : (i += 1) {
+        const kv = try std.fmt.allocPrintSentinel(allocator, "{s}={s}", .{ e.key_ptr.*, e.value_ptr.* }, 0);
+        entries[i] = kv;
+        ptrs[i] = kv.ptr;
+        filled = i + 1;
+    }
+    ptrs[n] = null;
+
+    return EnvBuild{
+        .allocator = allocator,
+        .ptrs = ptrs,
+        .entries = entries,
+    };
+}
+
 /// runCommand spawns /bin/sh -c <command> in workdir and returns stdout/stderr.
-/// Uses raw fork/exec with pipe-based I/O.
+/// Uses raw fork/exec with pipe-based I/O. user_env is a JSON value (object or null).
 pub fn runCommand(allocator: std.mem.Allocator, command: []const u8, workdir: []const u8) !ExecResult {
+    return runCommandWithEnv(allocator, command, workdir, .{ .null = {} });
+}
+
+pub fn runCommandWithEnv(allocator: std.mem.Allocator, command: []const u8, workdir: []const u8, user_env: std.json.Value) !ExecResult {
     // Null-terminate command for execve (child has no allocator)
     var cmd_buf: [65536]u8 = undefined;
     if (command.len >= cmd_buf.len) return error.CommandTooLong;
     @memcpy(cmd_buf[0..command.len], command);
     cmd_buf[command.len] = 0;
     const cmd_z: [*:0]const u8 = @ptrCast(&cmd_buf);
+
+    var env_build = try buildEnvp(allocator, user_env, &.{});
+    defer env_build.deinit();
+
     var stdout_pipe: [2]i32 = undefined;
     var stderr_pipe: [2]i32 = undefined;
     if (std.os.linux.pipe2(&stdout_pipe, std.os.linux.O{ .CLOEXEC = true }) < 0) {
@@ -56,17 +141,13 @@ pub fn runCommand(allocator: std.mem.Allocator, command: []const u8, workdir: []
         const cwd_z = std.fmt.bufPrintZ(&cwd_buf, "{s}", .{workdir}) catch return error.PathTooLong;
         _ = std.os.linux.chdir(cwd_z);
 
-        // Exec /bin/sh with venv in PATH so pip installs go to /workspace/.venv
+        // Exec /bin/sh with merged env (defaults + session env)
         const argv: [3:null]?[*:0]const u8 = .{
             "/bin/sh".ptr,
             "-c".ptr,
             cmd_z,
         };
-        const envp = [2:null]?[*:0]const u8{
-            "PATH=/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-            "VIRTUAL_ENV=/workspace/.venv",
-        };
-        _ = std.os.linux.execve("/bin/sh", &argv, &envp);
+        _ = std.os.linux.execve("/bin/sh", &argv, env_build.envpPtr());
         // If execve returns, it's an error
         std.os.linux.exit(1);
     }
@@ -144,7 +225,7 @@ fn spawnTimeoutKiller(pid: std.os.linux.pid_t, timeout_sec: u32) void {
 }
 
 pub fn handleExec(allocator: std.mem.Allocator, client_fd: i32, body: []const u8, streaming: bool) !void {
-    const parsed = std.json.parseFromSlice(ExecRequest, allocator, body, .{ .ignore_unknown_fields = true }) catch {
+    const parsed = std.json.parseFromSlice(ExecRequest, allocator, body, .{ .ignore_unknown_fields = true, .allocate = .alloc_always }) catch {
         try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
         return;
     };
@@ -170,6 +251,12 @@ pub fn handleExec(allocator: std.mem.Allocator, client_fd: i32, body: []const u8
         cmd_buf[req.command.len] = 0;
         const cmd_z: [*:0]const u8 = @ptrCast(&cmd_buf);
 
+        var env_build = buildEnvp(allocator, req.env, &.{}) catch {
+            try main.writeResponse(client_fd, "500 Internal Server Error", "application/json", "{\"error\":\"env build failed\"}");
+            return;
+        };
+        defer env_build.deinit();
+
         // Fork /bin/sh -c <command> with stdout piped
         var stdout_pipe: [2]i32 = undefined;
         if (std.os.linux.pipe2(&stdout_pipe, std.os.linux.O{ .CLOEXEC = true }) < 0) {
@@ -190,11 +277,7 @@ pub fn handleExec(allocator: std.mem.Allocator, client_fd: i32, body: []const u8
             _ = std.os.linux.chdir(cwd_z);
 
             const argv: [3:null]?[*:0]const u8 = .{ "/bin/sh".ptr, "-c".ptr, cmd_z };
-            const envp = [2:null]?[*:0]const u8{
-                "PATH=/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-                "VIRTUAL_ENV=/workspace/.venv",
-            };
-            _ = std.os.linux.execve("/bin/sh", &argv, &envp);
+            _ = std.os.linux.execve("/bin/sh", &argv, env_build.envpPtr());
             std.os.linux.exit(1);
         }
 
@@ -242,7 +325,7 @@ pub fn handleExec(allocator: std.mem.Allocator, client_fd: i32, body: []const u8
         return;
     }
 
-    const result = runCommand(allocator, req.command, req.workdir) catch |err| {
+    const result = runCommandWithEnv(allocator, req.command, req.workdir, req.env) catch |err| {
         const msg = try std.fmt.allocPrint(allocator, "{{\"error\":\"{s}\"}}", .{@errorName(err)});
         defer allocator.free(msg);
         try main.writeResponse(client_fd, "500 Internal Server Error", "application/json", msg);

--- a/sandboxd/src/exec_test.zig
+++ b/sandboxd/src/exec_test.zig
@@ -38,6 +38,78 @@ test "jsonEscape: empty string" {
     try std.testing.expectEqualStrings("", out);
 }
 
+// --- buildEnvp tests ---
+
+test "buildEnvp: defaults only" {
+    const allocator = std.testing.allocator;
+    var env = try exec.buildEnvp(allocator, .{ .null = {} }, &.{});
+    defer env.deinit();
+    try std.testing.expect(env.entries.len >= 2);
+    var saw_path = false;
+    var saw_venv = false;
+    for (env.entries) |e| {
+        if (std.mem.startsWith(u8, e, "PATH=")) saw_path = true;
+        if (std.mem.startsWith(u8, e, "VIRTUAL_ENV=")) saw_venv = true;
+    }
+    try std.testing.expect(saw_path);
+    try std.testing.expect(saw_venv);
+}
+
+test "buildEnvp: user env merges and overrides" {
+    const allocator = std.testing.allocator;
+    var obj: std.json.ObjectMap = .empty;
+    defer obj.deinit(allocator);
+    try obj.put(allocator, "FOO", .{ .string = "bar" });
+    try obj.put(allocator, "PATH", .{ .string = "/custom/bin" });
+    var env = try exec.buildEnvp(allocator, .{ .object = obj }, &.{});
+    defer env.deinit();
+    var saw_foo = false;
+    var path_val: ?[]const u8 = null;
+    for (env.entries) |e| {
+        if (std.mem.eql(u8, e, "FOO=bar")) saw_foo = true;
+        if (std.mem.startsWith(u8, e, "PATH=")) path_val = e;
+    }
+    try std.testing.expect(saw_foo);
+    try std.testing.expectEqualStrings("PATH=/custom/bin", path_val.?);
+}
+
+test "buildEnvp: from parsed JSON body env field" {
+    const allocator = std.testing.allocator;
+    const body =
+        \\{"command":"true","env":{"FOO":"bar","BAZ":"qux"}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{ .allocate = .alloc_always });
+    defer parsed.deinit();
+    const env_val: std.json.Value = parsed.value.object.get("env") orelse .null;
+    var env = try exec.buildEnvp(allocator, env_val, &.{});
+    defer env.deinit();
+    var saw_foo = false;
+    var saw_baz = false;
+    for (env.entries) |e| {
+        if (std.mem.eql(u8, e, "FOO=bar")) saw_foo = true;
+        if (std.mem.eql(u8, e, "BAZ=qux")) saw_baz = true;
+    }
+    try std.testing.expect(saw_foo);
+    try std.testing.expect(saw_baz);
+}
+
+test "buildEnvp: extra pairs forced for background" {
+    const allocator = std.testing.allocator;
+    var env = try exec.buildEnvp(allocator, .{ .null = {} }, &.{
+        .{ "K8E_BG_DIR", "/workspace/.k8e_bg/r1" },
+        .{ "K8E_BG_CMD", "sleep 1" },
+    });
+    defer env.deinit();
+    var saw_dir = false;
+    var saw_cmd = false;
+    for (env.entries) |e| {
+        if (std.mem.eql(u8, e, "K8E_BG_DIR=/workspace/.k8e_bg/r1")) saw_dir = true;
+        if (std.mem.eql(u8, e, "K8E_BG_CMD=sleep 1")) saw_cmd = true;
+    }
+    try std.testing.expect(saw_dir);
+    try std.testing.expect(saw_cmd);
+}
+
 // --- runCommand tests (exercises posix.waitpid path) ---
 
 test "runCommand: echo stdout" {
@@ -46,6 +118,17 @@ test "runCommand: echo stdout" {
     defer result.deinit(allocator);
     try std.testing.expectEqualStrings("hello\n", result.stdout);
     try std.testing.expectEqualStrings("", result.stderr);
+    try std.testing.expectEqual(@as(i32, 0), result.exit_code);
+}
+
+test "runCommandWithEnv: injects FOO" {
+    const allocator = std.testing.allocator;
+    var obj: std.json.ObjectMap = .empty;
+    defer obj.deinit(allocator);
+    try obj.put(allocator, "FOO", .{ .string = "bar" });
+    const result = try exec.runCommandWithEnv(allocator, "echo -n \"$FOO\"", "/tmp", .{ .object = obj });
+    defer result.deinit(allocator);
+    try std.testing.expectEqualStrings("bar", result.stdout);
     try std.testing.expectEqual(@as(i32, 0), result.exit_code);
 }
 

--- a/skills/k8e-sandbox/SKILL.md
+++ b/skills/k8e-sandbox/SKILL.md
@@ -89,7 +89,7 @@ chmod +x k8e-sandbox-cli-linux-amd64
 | `k8e-sandbox-cli login` | Authenticate and obtain mTLS cert (remote access) | `--apikey`, `--endpoint`, `--device-name` |
 | `k8e-sandbox-cli run <code>` | Execute code or shell command | `--lang python\|bash\|node\|ts`, `--session-id`, `--tenant`, `--timeout 30`, `--raw` |
 | `k8e-sandbox-cli status` | Check service + current session | — |
-| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--manifest`, `--git-repo` |
+| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--env KEY=VAL` (repeatable, non-sensitive), `--manifest`, `--git-repo` |
 | `k8e-sandbox-cli destroy <sid>` | Destroy session | — |
 | `k8e-sandbox-cli write <sid> <path>` | Write file to /workspace | content via stdin, `--mode w\|a` |
 | `k8e-sandbox-cli read <sid> <path>` | Read file from /workspace | `--raw` (plain text output) |
@@ -184,6 +184,18 @@ Same auto-session reused across both calls.
 2. k8e-sandbox-cli run "curl -s https://api.example.com/data" --session-id $SID
 3. k8e-sandbox-cli destroy $SID
 ```
+
+### Scenario 4b: Session env (non-sensitive)
+
+Env is stored on the session and applied at **every exec** (warm-pool safe — not baked into the pod).
+
+```
+1. SID=$(k8e-sandbox-cli create --env LOG_LEVEL=debug --env PYTHONPATH=/workspace/lib | jq -r .session_id)
+2. k8e-sandbox-cli run 'echo $LOG_LEVEL' --session-id $SID   # → debug
+3. k8e-sandbox-cli destroy $SID
+```
+
+⚠️ **Red line:** `--env` is for non-sensitive config only. Values are stored in plaintext on the SandboxSession CRD. Use secret-ref injection (issue #485) for API keys and tokens — never put secrets in `--env`.
 
 ### Scenario 5: Parallel sub-agents
 


### PR DESCRIPTION
## Summary

Implements [KIP-12 Part B](docs/kip-12-sandbox-ports-env-secrets.md) / closes #483: non-sensitive environment variables on sandbox sessions, applied at **exec time** so warm-pool pods stay reusable.

- **Proto/CRD**: `CreateSessionRequest.env` and `SandboxSessionSpec.Env`
- **Gateway**: persist env on create; inject into sandboxd `/exec`, `/exec/stream`, and background submit
- **sandboxd**: shared `buildEnvp` merges defaults (`PATH`, `VIRTUAL_ENV`) with session env on all exec paths
- **CLI**: `create --env KEY=VAL` (repeatable)
- **Docs**: skill table + red line (secrets must not use `--env`; #485 will cover secret-refs)

## Test plan

- [x] `go test ./pkg/sandboxmatrix/grpc/ ./pkg/sandboxcli/`
- [x] Zig `buildEnvp` / JSON merge unit tests
- [ ] Linux cluster e2e: `create --env FOO=bar` → `run 'echo $FOO'` → background exec
- [ ] Apply updated CRD: `kubectl apply -f manifests/sandbox-matrix/crds.yaml`
- [ ] Roll gateway + sandbox image with new sandboxd

Closes #483