### PR TITLE
feat(sandbox): GetSession, exec observability, secret_refs (#503/#504/#505)

### DIFF
--- a/cmd/sandboxcli/main.go
+++ b/cmd/sandboxcli/main.go
@@ -30,6 +30,8 @@ func main() {
 		sandboxcli.RunCommand(),
 		sandboxcli.StatusCommand(),
 		sandboxcli.CreateCommand(),
+		sandboxcli.GetCommand(),
+		sandboxcli.SessionsCommand(),
 		sandboxcli.DestroyCommand(),
 		sandboxcli.WriteCommand(),
 		sandboxcli.ReadCommand(),

--- a/manifests/sandbox-matrix/crds.yaml
+++ b/manifests/sandbox-matrix/crds.yaml
@@ -102,6 +102,14 @@ spec:
               env:
                 type: object
                 additionalProperties: {type: string}
+              secretRefs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    secretName: {type: string}
+                    key: {type: string}
+                    envVar: {type: string}
           status:
             type: object
             properties:

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -251,7 +251,9 @@ func runAction(ctx *cli.Context) error {
 	}
 
 	cmd := buildCommand(lang, code)
-	req := &pb.ExecRequest{SessionId: sid, Command: cmd, Timeout: int32(ctx.Int("timeout")), Workdir: "/workspace"}
+	req := &pb.ExecRequest{
+		SessionId: sid, Command: cmd, Timeout: int32(ctx.Int("timeout")), Workdir: "/workspace", Language: lang,
+	}
 	return runExec(cli, ctx, req, sid, needsFinalize, raw)
 }
 
@@ -322,7 +324,16 @@ func runJSON(client *client.Client, req *pb.ExecRequest, sid string, needsFinali
 	if needsFinalize {
 		_ = finalizeState(tenant, sid)
 	}
-	printJSON(map[string]any{"stdout": resp.Stdout, "stderr": resp.Stderr, "exit_code": resp.ExitCode, "session_id": sid})
+	printJSON(map[string]any{
+		"stdout":      resp.Stdout,
+		"stderr":      resp.Stderr,
+		"exit_code":   resp.ExitCode,
+		"session_id":  sid,
+		"status":      resp.Status,
+		"duration_ms": resp.DurationMs,
+		"truncated":   resp.Truncated,
+		"language":    resp.Language,
+	})
 	return nil
 }
 
@@ -378,6 +389,7 @@ func CreateCommand() cli.Command {
 			cli.StringFlag{Name: "allowed-hosts", Usage: "Comma-separated FQDN egress allowlist"},
 			cli.StringFlag{Name: "session-id", Usage: "Custom session ID"},
 			cli.StringSliceFlag{Name: "env", Usage: "Non-sensitive env KEY=VAL (repeatable); applied at exec time"},
+			cli.StringSliceFlag{Name: "secret", Usage: "Secret ref ENV_VAR=secretName:key (repeatable); resolved at exec time"},
 			cli.StringFlag{Name: "manifest", Usage: "Path to workspace manifest YAML file"},
 			cli.StringFlag{Name: "git-repo", Usage: "Git repository URL to clone (shortcut)"},
 			cli.StringFlag{Name: "git-ref", Value: "main", Usage: "Git ref for --git-repo"},
@@ -399,6 +411,10 @@ func CreateCommand() cli.Command {
 			if envErr != nil {
 				return printErrorExit(envErr.Error(), 1)
 			}
+			secretRefs, secErr := parseSecretFlags(ctx.StringSlice("secret"))
+			if secErr != nil {
+				return printErrorExit(secErr.Error(), 1)
+			}
 
 			resp, err := client.SandboxServiceClient.CreateSession(context.Background(), &pb.CreateSessionRequest{
 				SessionId:    ctx.String("session-id"),
@@ -406,6 +422,7 @@ func CreateCommand() cli.Command {
 				RuntimeClass: ctx.String("runtime"),
 				AllowedHosts: hosts,
 				Env:          env,
+				SecretRefs:   secretRefs,
 			})
 			if err != nil {
 				return printErrorExit("create session: "+err.Error(), 2)
@@ -456,6 +473,96 @@ func parseEnvFlags(items []string) (map[string]string, error) {
 		out[k] = v
 	}
 	return out, nil
+}
+
+// parseSecretFlags converts --secret ENV_VAR=secretName:key into SecretRef messages.
+func parseSecretFlags(items []string) ([]*pb.SecretRef, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+	out := make([]*pb.SecretRef, 0, len(items))
+	for _, item := range items {
+		envVar, rest, ok := strings.Cut(item, "=")
+		if !ok || envVar == "" {
+			return nil, fmt.Errorf("invalid --secret %q, expected ENV_VAR=secretName:key", item)
+		}
+		secretName, key, ok := strings.Cut(rest, ":")
+		if !ok || secretName == "" || key == "" {
+			return nil, fmt.Errorf("invalid --secret %q, expected ENV_VAR=secretName:key", item)
+		}
+		out = append(out, &pb.SecretRef{EnvVar: envVar, SecretName: secretName, Key: key})
+	}
+	return out, nil
+}
+
+// GetCommand fetches a single session from the gateway.
+func GetCommand() cli.Command {
+	return cli.Command{
+		Name:      "get",
+		Usage:     "Get sandbox session details (phase, runtime, env keys — never secret values)",
+		ArgsUsage: "<session-id>",
+		Action: func(ctx *cli.Context) error {
+			sid := ctx.Args().First()
+			if sid == "" {
+				return printErrorExit("session-id required", 1)
+			}
+			client, exitErr := newClientFromCtx(ctx)
+			if exitErr != nil {
+				return exitErr
+			}
+			defer client.Close()
+			resp, err := client.SandboxServiceClient.GetSession(context.Background(), &pb.GetSessionRequest{SessionId: sid})
+			if err != nil {
+				return printErrorExit("get session: "+err.Error(), 2)
+			}
+			printJSON(sessionViewJSON(resp))
+			return nil
+		},
+	}
+}
+
+// SessionsCommand lists sessions visible to the gateway.
+func SessionsCommand() cli.Command {
+	return cli.Command{
+		Name:  "sessions",
+		Usage: "List sandbox sessions (default: Active only)",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "phase", Value: "Active", Usage: "Filter phase, or 'all'"},
+		},
+		Action: func(ctx *cli.Context) error {
+			client, exitErr := newClientFromCtx(ctx)
+			if exitErr != nil {
+				return exitErr
+			}
+			defer client.Close()
+			resp, err := client.SandboxServiceClient.ListSessions(context.Background(), &pb.ListSessionsRequest{
+				Phase: ctx.String("phase"),
+			})
+			if err != nil {
+				return printErrorExit("list sessions: "+err.Error(), 2)
+			}
+			list := make([]any, 0, len(resp.Sessions))
+			for _, s := range resp.Sessions {
+				list = append(list, sessionViewJSON(s))
+			}
+			printJSON(map[string]any{"sessions": list})
+			return nil
+		},
+	}
+}
+
+func sessionViewJSON(s *pb.GetSessionResponse) map[string]any {
+	return map[string]any{
+		"session_id":       s.SessionId,
+		"phase":            s.Phase,
+		"runtime_class":    s.RuntimeClass,
+		"pod_ip":           s.PodIp,
+		"tenant_id":        s.TenantId,
+		"expires_at":       s.ExpiresAt,
+		"env_keys":         s.EnvKeys,
+		"secret_env_vars":  s.SecretEnvVars,
+		"background_runs":  s.BackgroundRuns,
+	}
 }
 
 // resolveManifest builds a Manifest from --manifest, --git-repo flags, or returns nil.
@@ -999,11 +1106,13 @@ func PollCommand() cli.Command {
 				return printErrorExit("poll: "+err.Error(), 1)
 			}
 			printJSON(map[string]any{
-				"run_id":    resp.RunId,
-				"status":    resp.Status,
-				"stdout":    resp.Stdout,
-				"stderr":    resp.Stderr,
-				"exit_code": resp.ExitCode,
+				"run_id":      resp.RunId,
+				"status":      resp.Status,
+				"stdout":      resp.Stdout,
+				"stderr":      resp.Stderr,
+				"exit_code":   resp.ExitCode,
+				"duration_ms": resp.DurationMs,
+				"truncated":   resp.Truncated,
 			})
 			return nil
 		},

--- a/pkg/sandboxcli/commands_test.go
+++ b/pkg/sandboxcli/commands_test.go
@@ -28,6 +28,22 @@ func TestParseEnvFlags(t *testing.T) {
 	}
 }
 
+func TestParseSecretFlags(t *testing.T) {
+	got, err := parseSecretFlags([]string{"API_KEY=llm-secret:token", "DB=db-sec:password"})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if len(got) != 2 || got[0].EnvVar != "API_KEY" || got[0].SecretName != "llm-secret" || got[0].Key != "token" {
+		t.Fatalf("got %+v", got)
+	}
+	if _, err := parseSecretFlags([]string{"BAD"}); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := parseSecretFlags([]string{"X=noseparator"}); err == nil {
+		t.Fatal("expected error for missing colon")
+	}
+}
+
 func TestIsSessionExpired_grpcNotFound(t *testing.T) {
 	err := status.Error(codes.NotFound, "session sess-abc not found")
 	if !isSessionExpired(err) {

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -90,7 +90,9 @@ export K8E_SANDBOX_APIKEY=k8e-abc123...
 |---------|---------|-----------|
 | `k8e-sandbox-cli run <code>` | Execute code or shell command | `--lang python\|bash\|node\|ts`, `--session-id`, `--tenant`, `--timeout 30`, `--raw` |
 | `k8e-sandbox-cli status` | Check service + current session | — |
-| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--env KEY=VAL` (repeatable, non-sensitive), `--manifest`, `--git-repo` |
+| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime`, `--allowed-hosts`, `--env KEY=VAL`, `--secret ENV=secret:key`, `--manifest`, `--git-repo` |
+| `k8e-sandbox-cli get <sid>` | Session introspection | phase, runtime, env keys / secret env names |
+| `k8e-sandbox-cli sessions` | List sessions | `--phase Active\|all` |
 | `k8e-sandbox-cli destroy <sid>` | Destroy session | — |
 | `k8e-sandbox-cli write <sid> <path>` | Write file to /workspace | content via stdin, `--mode w\|a` |
 | `k8e-sandbox-cli read <sid> <path>` | Read file from /workspace | `--raw` (plain text output) |

--- a/pkg/sandboxmatrix/api/v1alpha1/types.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/types.go
@@ -59,6 +59,14 @@ type SandboxSession struct {
 	Status SandboxSessionStatus `json:"status,omitempty"`
 }
 
+// SecretRef references a key in a same-namespace K8s Secret. Only the reference
+// is stored on the CRD; values are resolved at exec time (#505 / KIP-12 B).
+type SecretRef struct {
+	SecretName string `json:"secretName,omitempty"`
+	Key        string `json:"key,omitempty"`
+	EnvVar     string `json:"envVar,omitempty"`
+}
+
 type SandboxSessionSpec struct {
 	TenantID        string            `json:"tenantID,omitempty"`
 	AllowedHosts    []string          `json:"allowedHosts,omitempty"`
@@ -68,6 +76,8 @@ type SandboxSessionSpec struct {
 	// Env is a non-sensitive map of environment variables applied at exec time
 	// (not baked into the pod spec) so warm-pool pods remain reusable.
 	Env map[string]string `json:"env,omitempty"`
+	// SecretRefs are resolved from K8s Secrets at exec time; values are never stored here.
+	SecretRefs []SecretRef `json:"secretRefs,omitempty"`
 }
 
 type SandboxSessionStatus struct {

--- a/pkg/sandboxmatrix/api/v1alpha1/zz_generated_deepcopy.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/zz_generated_deepcopy.go
@@ -95,6 +95,18 @@ func (in *SandboxSession) DeepCopyInto(out *SandboxSession) {
 	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 }
+func (in *SecretRef) DeepCopyInto(out *SecretRef) {
+	*out = *in
+}
+func (in *SecretRef) DeepCopy() *SecretRef {
+	if in == nil {
+		return nil
+	}
+	out := new(SecretRef)
+	in.DeepCopyInto(out)
+	return out
+}
+
 func (in *SandboxSessionSpec) DeepCopyInto(out *SandboxSessionSpec) {
 	*out = *in
 	if in.AllowedHosts != nil {
@@ -105,6 +117,10 @@ func (in *SandboxSessionSpec) DeepCopyInto(out *SandboxSessionSpec) {
 		for k, v := range in.Env {
 			out.Env[k] = v
 		}
+	}
+	if in.SecretRefs != nil {
+		out.SecretRefs = make([]SecretRef, len(in.SecretRefs))
+		copy(out.SecretRefs, in.SecretRefs)
 	}
 }
 func (in *SandboxSessionStatus) DeepCopyInto(out *SandboxSessionStatus) {

--- a/pkg/sandboxmatrix/grpc/env.go
+++ b/pkg/sandboxmatrix/grpc/env.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
 )
 
 // Session env limits (KIP-12 / #483 hardening). Applied at CreateSession so
@@ -13,6 +16,9 @@ const (
 	maxSessionEnvKeyBytes   = 256
 	maxSessionEnvValueBytes = 4 * 1024  // 4 KiB per value
 	maxSessionEnvTotalBytes = 32 * 1024 // 32 KiB keys+values combined
+	maxSessionSecretRefs    = 32
+	// maxExecOutputBytes is the per-stream capture cap for agent-facing truncation (~1 MiB).
+	maxExecOutputBytes = 1 * 1024 * 1024
 )
 
 // validateSessionEnv checks a CreateSession env map against size and key rules.
@@ -83,4 +89,105 @@ func sandboxdRequestBody(command, runID string, timeout int32, workdir string, e
 		body["env"] = env
 	}
 	return body
+}
+
+func validateSecretRefs(refs []*pb.SecretRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	if len(refs) > maxSessionSecretRefs {
+		return fmt.Errorf("too many secret_refs: %d (max %d)", len(refs), maxSessionSecretRefs)
+	}
+	seen := make(map[string]struct{}, len(refs))
+	for _, r := range refs {
+		if r == nil {
+			return fmt.Errorf("nil secret_ref")
+		}
+		if r.SecretName == "" || r.Key == "" || r.EnvVar == "" {
+			return fmt.Errorf("secret_name, key, and env_var are required")
+		}
+		if err := validateSessionEnvEntry(r.EnvVar, "x"); err != nil {
+			// reuse key rules for env_var name (value placeholder)
+			return fmt.Errorf("env_var %q: %w", r.EnvVar, err)
+		}
+		if _, ok := seen[r.EnvVar]; ok {
+			return fmt.Errorf("duplicate env_var %q", r.EnvVar)
+		}
+		seen[r.EnvVar] = struct{}{}
+	}
+	return nil
+}
+
+func pbSecretRefsToAPI(refs []*pb.SecretRef) []sandboxv1.SecretRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]sandboxv1.SecretRef, 0, len(refs))
+	for _, r := range refs {
+		if r == nil {
+			continue
+		}
+		out = append(out, sandboxv1.SecretRef{
+			SecretName: r.SecretName,
+			Key:        r.Key,
+			EnvVar:     r.EnvVar,
+		})
+	}
+	return out
+}
+
+// execStatusCompleted is returned when the process finished (any exit code).
+const (
+	execStatusStarted   = "started"
+	execStatusRunning   = "running"
+	execStatusCompleted = "completed"
+	execStatusTimedOut  = "timed_out"
+	execStatusFailed    = "failed"
+)
+
+// classifyExecStatus maps a finished execution to a neutral status string.
+// Non-zero exit_code remains completed (runtime error); only timeout is timed_out.
+func classifyExecStatus(timedOut bool, hadTransportError bool) string {
+	if hadTransportError {
+		return execStatusFailed
+	}
+	if timedOut {
+		return execStatusTimedOut
+	}
+	return execStatusCompleted
+}
+
+// sessionToProtoView builds a public-safe GetSessionResponse (no secret values).
+func sessionToProtoView(s *sandboxv1.SandboxSession, bgRuns int32) *pb.GetSessionResponse {
+	if s == nil {
+		return nil
+	}
+	view := &pb.GetSessionResponse{
+		SessionId:       s.Name,
+		Phase:           string(s.Status.Phase),
+		RuntimeClass:    s.Spec.RuntimeClass,
+		PodIp:           s.Status.PodIP,
+		TenantId:        s.Spec.TenantID,
+		BackgroundRuns:  bgRuns,
+	}
+	if s.Status.ExpiresAt != nil {
+		view.ExpiresAt = s.Status.ExpiresAt.Unix()
+	}
+	if len(s.Spec.Env) > 0 {
+		keys := make([]string, 0, len(s.Spec.Env))
+		for k := range s.Spec.Env {
+			keys = append(keys, k)
+		}
+		view.EnvKeys = keys
+	}
+	if len(s.Spec.SecretRefs) > 0 {
+		vars := make([]string, 0, len(s.Spec.SecretRefs))
+		for _, r := range s.Spec.SecretRefs {
+			if r.EnvVar != "" {
+				vars = append(vars, r.EnvVar)
+			}
+		}
+		view.SecretEnvVars = vars
+	}
+	return view
 }

--- a/pkg/sandboxmatrix/grpc/env_test.go
+++ b/pkg/sandboxmatrix/grpc/env_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -160,4 +161,128 @@ func TestGetSessionEnv_UnreadableEnvField(t *testing.T) {
 func newTestServer() *Server {
 	o := newTestOrchestrator()
 	return &Server{k8s: o.k8s, dyn: o.dynamic, orch: o}
+}
+
+func TestClassifyExecStatus(t *testing.T) {
+	if got := classifyExecStatus(false, false); got != execStatusCompleted {
+		t.Fatalf("got %s", got)
+	}
+	if got := classifyExecStatus(true, false); got != execStatusTimedOut {
+		t.Fatalf("got %s", got)
+	}
+	if got := classifyExecStatus(false, true); got != execStatusFailed {
+		t.Fatalf("got %s", got)
+	}
+}
+
+func TestValidateSecretRefs(t *testing.T) {
+	if err := validateSecretRefs(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSecretRefs([]*pb.SecretRef{{SecretName: "s", Key: "k", EnvVar: "API_KEY"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSecretRefs([]*pb.SecretRef{{SecretName: "s", Key: "k"}}); err == nil {
+		t.Fatal("expected missing env_var error")
+	}
+	if err := validateSecretRefs([]*pb.SecretRef{
+		{SecretName: "s", Key: "k", EnvVar: "A"},
+		{SecretName: "s", Key: "k2", EnvVar: "A"},
+	}); err == nil {
+		t.Fatal("expected duplicate env_var")
+	}
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	s := newTestServer()
+	_, err := s.GetSession(context.Background(), &pb.GetSessionRequest{SessionId: "missing"})
+	if err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestGetSession_AndListSessions(t *testing.T) {
+	s := newTestServer()
+	sess, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "get-1",
+		TenantId:  "t1",
+		Env:       map[string]string{"FOO": "bar"},
+		SecretRefs: []*pb.SecretRef{
+			{SecretName: "llm", Key: "token", EnvVar: "API_KEY"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	view, err := s.GetSession(context.Background(), &pb.GetSessionRequest{SessionId: sess.Name})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if view.Phase == "" || view.RuntimeClass == "" {
+		t.Fatalf("view incomplete: %+v", view)
+	}
+	if len(view.EnvKeys) != 1 || view.EnvKeys[0] != "FOO" {
+		t.Fatalf("env_keys: %v", view.EnvKeys)
+	}
+	if len(view.SecretEnvVars) != 1 || view.SecretEnvVars[0] != "API_KEY" {
+		t.Fatalf("secret_env_vars: %v", view.SecretEnvVars)
+	}
+	// Ensure secret values never appear in the view payload shape.
+	if strings.Contains(view.String(), "bar") {
+		t.Fatal("env value leaked into proto String()")
+	}
+
+	list, err := s.ListSessions(context.Background(), &pb.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Sessions) < 1 {
+		t.Fatalf("expected sessions, got %d", len(list.Sessions))
+	}
+}
+
+func TestResolveSessionEnv_WithSecret(t *testing.T) {
+	s := newTestServer()
+	// Seed K8s secret.
+	_, err := s.k8s.CoreV1().Secrets(sandboxNS).Create(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: sandboxNS},
+		Data:       map[string][]byte{"token": []byte("super-secret")},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("secret: %v", err)
+	}
+	_, err = s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "sec-1",
+		Env:       map[string]string{"LOG": "1"},
+		SecretRefs: []*pb.SecretRef{
+			{SecretName: "llm", Key: "token", EnvVar: "API_KEY"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	env, err := s.resolveSessionEnv(context.Background(), "sec-1")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if env["LOG"] != "1" || env["API_KEY"] != "super-secret" {
+		t.Fatalf("merged env: %v", env)
+	}
+}
+
+func TestResolveSessionEnv_MissingSecretFails(t *testing.T) {
+	s := newTestServer()
+	_, err := s.orch.CreateSession(context.Background(), &pb.CreateSessionRequest{
+		SessionId: "sec-miss",
+		SecretRefs: []*pb.SecretRef{
+			{SecretName: "nope", Key: "k", EnvVar: "X"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	_, err = s.resolveSessionEnv(context.Background(), "sec-miss")
+	if err == nil {
+		t.Fatal("expected secret resolution error")
+	}
 }

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -287,6 +287,9 @@ func (o *Orchestrator) createSessionWithTTL(ctx context.Context, req *pb.CreateS
 	if len(allowedHosts) == 0 && len(matrixDefaultHosts) > 0 {
 		allowedHosts = matrixDefaultHosts
 	}
+	if err := validateSecretRefs(req.SecretRefs); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "secret_refs: %v", err)
+	}
 	session := &sandboxv1.SandboxSession{
 		TypeMeta:   metav1.TypeMeta{APIVersion: sandboxAPIVersion, Kind: "SandboxSession"},
 		ObjectMeta: metav1.ObjectMeta{Name: sessionID, Namespace: sandboxNS},
@@ -296,6 +299,7 @@ func (o *Orchestrator) createSessionWithTTL(ctx context.Context, req *pb.CreateS
 			RuntimeClass: runtimeClass,
 			Depth:        0,
 			Env:          req.Env,
+			SecretRefs:   pbSecretRefsToAPI(req.SecretRefs),
 		},
 	}
 	if err := o.createSession(ctx, session); err != nil {
@@ -413,18 +417,44 @@ func (o *Orchestrator) releasePod(ctx context.Context, podName string) {
 
 // ListActiveSessions returns all Active SandboxSessions in the given namespace.
 func (o *Orchestrator) ListActiveSessions(ctx context.Context, namespace string) ([]*sandboxv1.SandboxSession, error) {
+	return o.listSessions(ctx, namespace, string(sandboxv1.SandboxPhaseActive))
+}
+
+// listSessions returns sessions in namespace filtered by phase.
+// phase empty or "Active" → Active only; "all" → every phase.
+func (o *Orchestrator) listSessions(ctx context.Context, namespace, phase string) ([]*sandboxv1.SandboxSession, error) {
 	list, err := o.dynamic.Resource(sessionGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
+	wantAll := phase == "all"
+	if phase == "" {
+		phase = string(sandboxv1.SandboxPhaseActive)
+	}
 	var result []*sandboxv1.SandboxSession
 	for i := range list.Items {
 		s, err := unstructuredToSession(&list.Items[i])
-		if err == nil && s.Status.Phase == sandboxv1.SandboxPhaseActive {
+		if err != nil {
+			continue
+		}
+		if wantAll || string(s.Status.Phase) == phase {
 			result = append(result, s)
 		}
 	}
 	return result, nil
+}
+
+// countBackgroundRuns returns how many run_registry entries point at sessionID.
+func (o *Orchestrator) countBackgroundRuns(sessionID string) int32 {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var n int32
+	for _, sid := range o.runRegistry {
+		if sid == sessionID {
+			n++
+		}
+	}
+	return n
 }
 
 func (o *Orchestrator) RunSubAgent(ctx context.Context, req *pb.RunSubAgentRequest) (*pb.RunSubAgentResponse, error) {
@@ -457,6 +487,7 @@ func (o *Orchestrator) RunSubAgent(ctx context.Context, req *pb.RunSubAgentReque
 			ParentSessionID: req.ParentSessionId,
 			Depth:           parent.Spec.Depth + 1,
 			Env:             parent.Spec.Env,
+			SecretRefs:      append([]sandboxv1.SecretRef(nil), parent.Spec.SecretRefs...),
 		},
 	}
 	if err := o.createSession(ctx, child); err != nil {

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -21,6 +21,68 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// SecretRef references a key in a same-namespace K8s Secret. Values are resolved
+// at exec time only and never stored on the SandboxSession CRD (#505 / KIP-12 B).
+type SecretRef struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SecretName    string                 `protobuf:"bytes,1,opt,name=secret_name,json=secretName,proto3" json:"secret_name,omitempty"` // K8s Secret name
+	Key           string                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`                                 // key within Secret.data
+	EnvVar        string                 `protobuf:"bytes,3,opt,name=env_var,json=envVar,proto3" json:"env_var,omitempty"`             // environment variable name injected into the process
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SecretRef) Reset() {
+	*x = SecretRef{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SecretRef) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SecretRef) ProtoMessage() {}
+
+func (x *SecretRef) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SecretRef.ProtoReflect.Descriptor instead.
+func (*SecretRef) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *SecretRef) GetSecretName() string {
+	if x != nil {
+		return x.SecretName
+	}
+	return ""
+}
+
+func (x *SecretRef) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *SecretRef) GetEnvVar() string {
+	if x != nil {
+		return x.EnvVar
+	}
+	return ""
+}
+
 type CreateSessionRequest struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
 	SessionId    string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -30,13 +92,14 @@ type CreateSessionRequest struct {
 	// Non-sensitive environment variables persisted on the SandboxSession and
 	// applied at exec time so warm-pool pods stay reusable (KIP-12 Part B / #483).
 	Env           map[string]string `protobuf:"bytes,5,rep,name=env,proto3" json:"env,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	SecretRefs    []*SecretRef      `protobuf:"bytes,6,rep,name=secret_refs,json=secretRefs,proto3" json:"secret_refs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateSessionRequest) Reset() {
 	*x = CreateSessionRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[0]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -48,7 +111,7 @@ func (x *CreateSessionRequest) String() string {
 func (*CreateSessionRequest) ProtoMessage() {}
 
 func (x *CreateSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[0]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61,7 +124,7 @@ func (x *CreateSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSessionRequest.ProtoReflect.Descriptor instead.
 func (*CreateSessionRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{0}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *CreateSessionRequest) GetSessionId() string {
@@ -99,6 +162,13 @@ func (x *CreateSessionRequest) GetEnv() map[string]string {
 	return nil
 }
 
+func (x *CreateSessionRequest) GetSecretRefs() []*SecretRef {
+	if x != nil {
+		return x.SecretRefs
+	}
+	return nil
+}
+
 type CreateSessionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -109,7 +179,7 @@ type CreateSessionResponse struct {
 
 func (x *CreateSessionResponse) Reset() {
 	*x = CreateSessionResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[1]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -121,7 +191,7 @@ func (x *CreateSessionResponse) String() string {
 func (*CreateSessionResponse) ProtoMessage() {}
 
 func (x *CreateSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[1]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -134,7 +204,7 @@ func (x *CreateSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateSessionResponse.ProtoReflect.Descriptor instead.
 func (*CreateSessionResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{1}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *CreateSessionResponse) GetSessionId() string {
@@ -151,6 +221,246 @@ func (x *CreateSessionResponse) GetPodIp() string {
 	return ""
 }
 
+type GetSessionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSessionRequest) Reset() {
+	*x = GetSessionRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSessionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSessionRequest) ProtoMessage() {}
+
+func (x *GetSessionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSessionRequest.ProtoReflect.Descriptor instead.
+func (*GetSessionRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *GetSessionRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type GetSessionResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	SessionId      string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Phase          string                 `protobuf:"bytes,2,opt,name=phase,proto3" json:"phase,omitempty"`
+	RuntimeClass   string                 `protobuf:"bytes,3,opt,name=runtime_class,json=runtimeClass,proto3" json:"runtime_class,omitempty"`
+	PodIp          string                 `protobuf:"bytes,4,opt,name=pod_ip,json=podIp,proto3" json:"pod_ip,omitempty"`
+	TenantId       string                 `protobuf:"bytes,5,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	ExpiresAt      int64                  `protobuf:"varint,6,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`                // unix seconds; 0 if none
+	EnvKeys        []string               `protobuf:"bytes,7,rep,name=env_keys,json=envKeys,proto3" json:"env_keys,omitempty"`                       // keys only, never values
+	SecretEnvVars  []string               `protobuf:"bytes,8,rep,name=secret_env_vars,json=secretEnvVars,proto3" json:"secret_env_vars,omitempty"`   // env_var names from secret_refs only
+	BackgroundRuns int32                  `protobuf:"varint,9,opt,name=background_runs,json=backgroundRuns,proto3" json:"background_runs,omitempty"` // active entries known to gateway registry
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GetSessionResponse) Reset() {
+	*x = GetSessionResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSessionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSessionResponse) ProtoMessage() {}
+
+func (x *GetSessionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSessionResponse.ProtoReflect.Descriptor instead.
+func (*GetSessionResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *GetSessionResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *GetSessionResponse) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+func (x *GetSessionResponse) GetRuntimeClass() string {
+	if x != nil {
+		return x.RuntimeClass
+	}
+	return ""
+}
+
+func (x *GetSessionResponse) GetPodIp() string {
+	if x != nil {
+		return x.PodIp
+	}
+	return ""
+}
+
+func (x *GetSessionResponse) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *GetSessionResponse) GetExpiresAt() int64 {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return 0
+}
+
+func (x *GetSessionResponse) GetEnvKeys() []string {
+	if x != nil {
+		return x.EnvKeys
+	}
+	return nil
+}
+
+func (x *GetSessionResponse) GetSecretEnvVars() []string {
+	if x != nil {
+		return x.SecretEnvVars
+	}
+	return nil
+}
+
+func (x *GetSessionResponse) GetBackgroundRuns() int32 {
+	if x != nil {
+		return x.BackgroundRuns
+	}
+	return 0
+}
+
+type ListSessionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Phase         string                 `protobuf:"bytes,1,opt,name=phase,proto3" json:"phase,omitempty"` // empty = Active only; "all" = every phase
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSessionsRequest) Reset() {
+	*x = ListSessionsRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSessionsRequest) ProtoMessage() {}
+
+func (x *ListSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSessionsRequest.ProtoReflect.Descriptor instead.
+func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ListSessionsRequest) GetPhase() string {
+	if x != nil {
+		return x.Phase
+	}
+	return ""
+}
+
+type ListSessionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sessions      []*GetSessionResponse  `protobuf:"bytes,1,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSessionsResponse) Reset() {
+	*x = ListSessionsResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSessionsResponse) ProtoMessage() {}
+
+func (x *ListSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSessionsResponse.ProtoReflect.Descriptor instead.
+func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListSessionsResponse) GetSessions() []*GetSessionResponse {
+	if x != nil {
+		return x.Sessions
+	}
+	return nil
+}
+
 type DestroySessionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -160,7 +470,7 @@ type DestroySessionRequest struct {
 
 func (x *DestroySessionRequest) Reset() {
 	*x = DestroySessionRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[2]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -172,7 +482,7 @@ func (x *DestroySessionRequest) String() string {
 func (*DestroySessionRequest) ProtoMessage() {}
 
 func (x *DestroySessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[2]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -185,7 +495,7 @@ func (x *DestroySessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroySessionRequest.ProtoReflect.Descriptor instead.
 func (*DestroySessionRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{2}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DestroySessionRequest) GetSessionId() string {
@@ -204,7 +514,7 @@ type DestroySessionResponse struct {
 
 func (x *DestroySessionResponse) Reset() {
 	*x = DestroySessionResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[3]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -216,7 +526,7 @@ func (x *DestroySessionResponse) String() string {
 func (*DestroySessionResponse) ProtoMessage() {}
 
 func (x *DestroySessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[3]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -229,7 +539,7 @@ func (x *DestroySessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DestroySessionResponse.ProtoReflect.Descriptor instead.
 func (*DestroySessionResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{3}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *DestroySessionResponse) GetOk() bool {
@@ -246,13 +556,14 @@ type ExecRequest struct {
 	Timeout       int32                  `protobuf:"varint,3,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	Workdir       string                 `protobuf:"bytes,4,opt,name=workdir,proto3" json:"workdir,omitempty"`
 	Background    bool                   `protobuf:"varint,5,opt,name=background,proto3" json:"background,omitempty"` // submit asynchronously, return run_id immediately
+	Language      string                 `protobuf:"bytes,6,opt,name=language,proto3" json:"language,omitempty"`      // optional hint: python|bash|node|ts (observability)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecRequest) Reset() {
 	*x = ExecRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[4]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -264,7 +575,7 @@ func (x *ExecRequest) String() string {
 func (*ExecRequest) ProtoMessage() {}
 
 func (x *ExecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[4]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -277,7 +588,7 @@ func (x *ExecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecRequest.ProtoReflect.Descriptor instead.
 func (*ExecRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{4}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ExecRequest) GetSessionId() string {
@@ -315,21 +626,32 @@ func (x *ExecRequest) GetBackground() bool {
 	return false
 }
 
+func (x *ExecRequest) GetLanguage() string {
+	if x != nil {
+		return x.Language
+	}
+	return ""
+}
+
 type ExecResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Stdout        string                 `protobuf:"bytes,1,opt,name=stdout,proto3" json:"stdout,omitempty"`
-	Stderr        string                 `protobuf:"bytes,2,opt,name=stderr,proto3" json:"stderr,omitempty"`
-	ExitCode      int32                  `protobuf:"varint,3,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
-	SessionId     string                 `protobuf:"bytes,4,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	RunId         string                 `protobuf:"bytes,5,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"` // set when background=true
-	Status        string                 `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`            // "started" when background=true
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Stdout    string                 `protobuf:"bytes,1,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr    string                 `protobuf:"bytes,2,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	ExitCode  int32                  `protobuf:"varint,3,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	SessionId string                 `protobuf:"bytes,4,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	RunId     string                 `protobuf:"bytes,5,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"` // set when background=true
+	// started|running|completed|timed_out|failed
+	Status        string `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	DurationMs    int64  `protobuf:"varint,7,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"` // wall-clock ms for this execution (0 if unknown/started)
+	Truncated     bool   `protobuf:"varint,8,opt,name=truncated,proto3" json:"truncated,omitempty"`                     // stdout and/or stderr hit size cap
+	Language      string `protobuf:"bytes,9,opt,name=language,proto3" json:"language,omitempty"`                        // echoed from request when set
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecResponse) Reset() {
 	*x = ExecResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[5]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -341,7 +663,7 @@ func (x *ExecResponse) String() string {
 func (*ExecResponse) ProtoMessage() {}
 
 func (x *ExecResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[5]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -354,7 +676,7 @@ func (x *ExecResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecResponse.ProtoReflect.Descriptor instead.
 func (*ExecResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{5}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ExecResponse) GetStdout() string {
@@ -399,6 +721,27 @@ func (x *ExecResponse) GetStatus() string {
 	return ""
 }
 
+func (x *ExecResponse) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *ExecResponse) GetTruncated() bool {
+	if x != nil {
+		return x.Truncated
+	}
+	return false
+}
+
+func (x *ExecResponse) GetLanguage() string {
+	if x != nil {
+		return x.Language
+	}
+	return ""
+}
+
 type ExecStreamResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Chunk         string                 `protobuf:"bytes,1,opt,name=chunk,proto3" json:"chunk,omitempty"`
@@ -408,7 +751,7 @@ type ExecStreamResponse struct {
 
 func (x *ExecStreamResponse) Reset() {
 	*x = ExecStreamResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[6]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -420,7 +763,7 @@ func (x *ExecStreamResponse) String() string {
 func (*ExecStreamResponse) ProtoMessage() {}
 
 func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[6]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -433,7 +776,7 @@ func (x *ExecStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecStreamResponse.ProtoReflect.Descriptor instead.
 func (*ExecStreamResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{6}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ExecStreamResponse) GetChunk() string {
@@ -455,7 +798,7 @@ type WriteFileRequest struct {
 
 func (x *WriteFileRequest) Reset() {
 	*x = WriteFileRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[7]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -467,7 +810,7 @@ func (x *WriteFileRequest) String() string {
 func (*WriteFileRequest) ProtoMessage() {}
 
 func (x *WriteFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[7]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -480,7 +823,7 @@ func (x *WriteFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteFileRequest.ProtoReflect.Descriptor instead.
 func (*WriteFileRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{7}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *WriteFileRequest) GetSessionId() string {
@@ -520,7 +863,7 @@ type WriteFileResponse struct {
 
 func (x *WriteFileResponse) Reset() {
 	*x = WriteFileResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[8]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -532,7 +875,7 @@ func (x *WriteFileResponse) String() string {
 func (*WriteFileResponse) ProtoMessage() {}
 
 func (x *WriteFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[8]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -545,7 +888,7 @@ func (x *WriteFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteFileResponse.ProtoReflect.Descriptor instead.
 func (*WriteFileResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{8}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *WriteFileResponse) GetOk() bool {
@@ -565,7 +908,7 @@ type ReadFileRequest struct {
 
 func (x *ReadFileRequest) Reset() {
 	*x = ReadFileRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[9]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -577,7 +920,7 @@ func (x *ReadFileRequest) String() string {
 func (*ReadFileRequest) ProtoMessage() {}
 
 func (x *ReadFileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[9]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +933,7 @@ func (x *ReadFileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFileRequest.ProtoReflect.Descriptor instead.
 func (*ReadFileRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{9}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ReadFileRequest) GetSessionId() string {
@@ -616,7 +959,7 @@ type ReadFileResponse struct {
 
 func (x *ReadFileResponse) Reset() {
 	*x = ReadFileResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[10]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -628,7 +971,7 @@ func (x *ReadFileResponse) String() string {
 func (*ReadFileResponse) ProtoMessage() {}
 
 func (x *ReadFileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[10]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -641,7 +984,7 @@ func (x *ReadFileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadFileResponse.ProtoReflect.Descriptor instead.
 func (*ReadFileResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{10}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ReadFileResponse) GetContent() string {
@@ -660,7 +1003,7 @@ type ListFilesRequest struct {
 
 func (x *ListFilesRequest) Reset() {
 	*x = ListFilesRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[11]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -672,7 +1015,7 @@ func (x *ListFilesRequest) String() string {
 func (*ListFilesRequest) ProtoMessage() {}
 
 func (x *ListFilesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[11]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -685,7 +1028,7 @@ func (x *ListFilesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFilesRequest.ProtoReflect.Descriptor instead.
 func (*ListFilesRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{11}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ListFilesRequest) GetSessionId() string {
@@ -704,7 +1047,7 @@ type ListFilesResponse struct {
 
 func (x *ListFilesResponse) Reset() {
 	*x = ListFilesResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[12]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -716,7 +1059,7 @@ func (x *ListFilesResponse) String() string {
 func (*ListFilesResponse) ProtoMessage() {}
 
 func (x *ListFilesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[12]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -729,7 +1072,7 @@ func (x *ListFilesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFilesResponse.ProtoReflect.Descriptor instead.
 func (*ListFilesResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{12}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListFilesResponse) GetFiles() []*FileEntry {
@@ -749,7 +1092,7 @@ type FileEntry struct {
 
 func (x *FileEntry) Reset() {
 	*x = FileEntry{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[13]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -761,7 +1104,7 @@ func (x *FileEntry) String() string {
 func (*FileEntry) ProtoMessage() {}
 
 func (x *FileEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[13]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -774,7 +1117,7 @@ func (x *FileEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileEntry.ProtoReflect.Descriptor instead.
 func (*FileEntry) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{13}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *FileEntry) GetPath() string {
@@ -801,7 +1144,7 @@ type PipInstallRequest struct {
 
 func (x *PipInstallRequest) Reset() {
 	*x = PipInstallRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[14]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -813,7 +1156,7 @@ func (x *PipInstallRequest) String() string {
 func (*PipInstallRequest) ProtoMessage() {}
 
 func (x *PipInstallRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[14]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -826,7 +1169,7 @@ func (x *PipInstallRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipInstallRequest.ProtoReflect.Descriptor instead.
 func (*PipInstallRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{14}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PipInstallRequest) GetSessionId() string {
@@ -853,7 +1196,7 @@ type PipInstallResponse struct {
 
 func (x *PipInstallResponse) Reset() {
 	*x = PipInstallResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[15]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -865,7 +1208,7 @@ func (x *PipInstallResponse) String() string {
 func (*PipInstallResponse) ProtoMessage() {}
 
 func (x *PipInstallResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[15]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -878,7 +1221,7 @@ func (x *PipInstallResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipInstallResponse.ProtoReflect.Descriptor instead.
 func (*PipInstallResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{15}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *PipInstallResponse) GetOutput() string {
@@ -906,7 +1249,7 @@ type RunSubAgentRequest struct {
 
 func (x *RunSubAgentRequest) Reset() {
 	*x = RunSubAgentRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[16]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -918,7 +1261,7 @@ func (x *RunSubAgentRequest) String() string {
 func (*RunSubAgentRequest) ProtoMessage() {}
 
 func (x *RunSubAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[16]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -931,7 +1274,7 @@ func (x *RunSubAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSubAgentRequest.ProtoReflect.Descriptor instead.
 func (*RunSubAgentRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{16}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RunSubAgentRequest) GetParentSessionId() string {
@@ -964,7 +1307,7 @@ type RunSubAgentResponse struct {
 
 func (x *RunSubAgentResponse) Reset() {
 	*x = RunSubAgentResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[17]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -976,7 +1319,7 @@ func (x *RunSubAgentResponse) String() string {
 func (*RunSubAgentResponse) ProtoMessage() {}
 
 func (x *RunSubAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[17]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -989,7 +1332,7 @@ func (x *RunSubAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSubAgentResponse.ProtoReflect.Descriptor instead.
 func (*RunSubAgentResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{17}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RunSubAgentResponse) GetSessionId() string {
@@ -1010,7 +1353,7 @@ type ConfirmActionRequest struct {
 
 func (x *ConfirmActionRequest) Reset() {
 	*x = ConfirmActionRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[18]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1022,7 +1365,7 @@ func (x *ConfirmActionRequest) String() string {
 func (*ConfirmActionRequest) ProtoMessage() {}
 
 func (x *ConfirmActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[18]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1035,7 +1378,7 @@ func (x *ConfirmActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfirmActionRequest.ProtoReflect.Descriptor instead.
 func (*ConfirmActionRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{18}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ConfirmActionRequest) GetSessionId() string {
@@ -1069,7 +1412,7 @@ type ConfirmActionResponse struct {
 
 func (x *ConfirmActionResponse) Reset() {
 	*x = ConfirmActionResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[19]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1081,7 +1424,7 @@ func (x *ConfirmActionResponse) String() string {
 func (*ConfirmActionResponse) ProtoMessage() {}
 
 func (x *ConfirmActionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[19]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1094,7 +1437,7 @@ func (x *ConfirmActionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConfirmActionResponse.ProtoReflect.Descriptor instead.
 func (*ConfirmActionResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{19}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ConfirmActionResponse) GetApprovalId() string {
@@ -1122,7 +1465,7 @@ type ApproveActionRequest struct {
 
 func (x *ApproveActionRequest) Reset() {
 	*x = ApproveActionRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[20]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1134,7 +1477,7 @@ func (x *ApproveActionRequest) String() string {
 func (*ApproveActionRequest) ProtoMessage() {}
 
 func (x *ApproveActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[20]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1147,7 +1490,7 @@ func (x *ApproveActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveActionRequest.ProtoReflect.Descriptor instead.
 func (*ApproveActionRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{20}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ApproveActionRequest) GetApprovalId() string {
@@ -1180,7 +1523,7 @@ type ApproveActionResponse struct {
 
 func (x *ApproveActionResponse) Reset() {
 	*x = ApproveActionResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[21]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1192,7 +1535,7 @@ func (x *ApproveActionResponse) String() string {
 func (*ApproveActionResponse) ProtoMessage() {}
 
 func (x *ApproveActionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[21]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1205,7 +1548,7 @@ func (x *ApproveActionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApproveActionResponse.ProtoReflect.Descriptor instead.
 func (*ApproveActionResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{21}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ApproveActionResponse) GetOk() bool {
@@ -1226,7 +1569,7 @@ type LoginRequest struct {
 
 func (x *LoginRequest) Reset() {
 	*x = LoginRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[22]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1238,7 +1581,7 @@ func (x *LoginRequest) String() string {
 func (*LoginRequest) ProtoMessage() {}
 
 func (x *LoginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[22]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1251,7 +1594,7 @@ func (x *LoginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginRequest.ProtoReflect.Descriptor instead.
 func (*LoginRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{22}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *LoginRequest) GetCsr() string {
@@ -1286,7 +1629,7 @@ type LoginResponse struct {
 
 func (x *LoginResponse) Reset() {
 	*x = LoginResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[23]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1298,7 +1641,7 @@ func (x *LoginResponse) String() string {
 func (*LoginResponse) ProtoMessage() {}
 
 func (x *LoginResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[23]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1311,7 +1654,7 @@ func (x *LoginResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginResponse.ProtoReflect.Descriptor instead.
 func (*LoginResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{23}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LoginResponse) GetCert() string {
@@ -1344,7 +1687,7 @@ type PollRunRequest struct {
 
 func (x *PollRunRequest) Reset() {
 	*x = PollRunRequest{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[24]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1356,7 +1699,7 @@ func (x *PollRunRequest) String() string {
 func (*PollRunRequest) ProtoMessage() {}
 
 func (x *PollRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[24]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1369,7 +1712,7 @@ func (x *PollRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PollRunRequest.ProtoReflect.Descriptor instead.
 func (*PollRunRequest) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{24}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *PollRunRequest) GetRunId() string {
@@ -1380,19 +1723,22 @@ func (x *PollRunRequest) GetRunId() string {
 }
 
 type PollRunResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
-	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"` // started | running | completed | failed | timed_out
-	Stdout        string                 `protobuf:"bytes,3,opt,name=stdout,proto3" json:"stdout,omitempty"`
-	Stderr        string                 `protobuf:"bytes,4,opt,name=stderr,proto3" json:"stderr,omitempty"`
-	ExitCode      int32                  `protobuf:"varint,5,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	RunId string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	// started|running|completed|failed|timed_out|not_found
+	Status        string `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
+	Stdout        string `protobuf:"bytes,3,opt,name=stdout,proto3" json:"stdout,omitempty"`
+	Stderr        string `protobuf:"bytes,4,opt,name=stderr,proto3" json:"stderr,omitempty"`
+	ExitCode      int32  `protobuf:"varint,5,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	DurationMs    int64  `protobuf:"varint,6,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	Truncated     bool   `protobuf:"varint,7,opt,name=truncated,proto3" json:"truncated,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PollRunResponse) Reset() {
 	*x = PollRunResponse{}
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[25]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1404,7 +1750,7 @@ func (x *PollRunResponse) String() string {
 func (*PollRunResponse) ProtoMessage() {}
 
 func (x *PollRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_sandbox_v1_sandbox_proto_msgTypes[25]
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1417,7 +1763,7 @@ func (x *PollRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PollRunResponse.ProtoReflect.Descriptor instead.
 func (*PollRunResponse) Descriptor() ([]byte, []int) {
-	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{25}
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *PollRunResponse) GetRunId() string {
@@ -1455,31 +1801,71 @@ func (x *PollRunResponse) GetExitCode() int32 {
 	return 0
 }
 
+func (x *PollRunResponse) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *PollRunResponse) GetTruncated() bool {
+	if x != nil {
+		return x.Truncated
+	}
+	return false
+}
+
 var File_sandbox_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"\x18sandbox/v1/sandbox.proto\x12\n" +
-	"sandbox.v1\"\x91\x02\n" +
+	"sandbox.v1\"W\n" +
+	"\tSecretRef\x12\x1f\n" +
+	"\vsecret_name\x18\x01 \x01(\tR\n" +
+	"secretName\x12\x10\n" +
+	"\x03key\x18\x02 \x01(\tR\x03key\x12\x17\n" +
+	"\aenv_var\x18\x03 \x01(\tR\x06envVar\"\xc9\x02\n" +
 	"\x14CreateSessionRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12#\n" +
 	"\rallowed_hosts\x18\x03 \x03(\tR\fallowedHosts\x12#\n" +
 	"\rruntime_class\x18\x04 \x01(\tR\fruntimeClass\x12;\n" +
-	"\x03env\x18\x05 \x03(\v2).sandbox.v1.CreateSessionRequest.EnvEntryR\x03env\x1a6\n" +
+	"\x03env\x18\x05 \x03(\v2).sandbox.v1.CreateSessionRequest.EnvEntryR\x03env\x126\n" +
+	"\vsecret_refs\x18\x06 \x03(\v2\x15.sandbox.v1.SecretRefR\n" +
+	"secretRefs\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"M\n" +
 	"\x15CreateSessionResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x15\n" +
-	"\x06pod_ip\x18\x02 \x01(\tR\x05podIp\"6\n" +
+	"\x06pod_ip\x18\x02 \x01(\tR\x05podIp\"2\n" +
+	"\x11GetSessionRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"\xad\x02\n" +
+	"\x12GetSessionResponse\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +
+	"\x05phase\x18\x02 \x01(\tR\x05phase\x12#\n" +
+	"\rruntime_class\x18\x03 \x01(\tR\fruntimeClass\x12\x15\n" +
+	"\x06pod_ip\x18\x04 \x01(\tR\x05podIp\x12\x1b\n" +
+	"\ttenant_id\x18\x05 \x01(\tR\btenantId\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x06 \x01(\x03R\texpiresAt\x12\x19\n" +
+	"\benv_keys\x18\a \x03(\tR\aenvKeys\x12&\n" +
+	"\x0fsecret_env_vars\x18\b \x03(\tR\rsecretEnvVars\x12'\n" +
+	"\x0fbackground_runs\x18\t \x01(\x05R\x0ebackgroundRuns\"+\n" +
+	"\x13ListSessionsRequest\x12\x14\n" +
+	"\x05phase\x18\x01 \x01(\tR\x05phase\"R\n" +
+	"\x14ListSessionsResponse\x12:\n" +
+	"\bsessions\x18\x01 \x03(\v2\x1e.sandbox.v1.GetSessionResponseR\bsessions\"6\n" +
 	"\x15DestroySessionRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"(\n" +
 	"\x16DestroySessionResponse\x12\x0e\n" +
-	"\x02ok\x18\x01 \x01(\bR\x02ok\"\x9a\x01\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\"\xb6\x01\n" +
 	"\vExecRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x18\n" +
@@ -1488,7 +1874,8 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\aworkdir\x18\x04 \x01(\tR\aworkdir\x12\x1e\n" +
 	"\n" +
 	"background\x18\x05 \x01(\bR\n" +
-	"background\"\xa9\x01\n" +
+	"background\x12\x1a\n" +
+	"\blanguage\x18\x06 \x01(\tR\blanguage\"\x84\x02\n" +
 	"\fExecResponse\x12\x16\n" +
 	"\x06stdout\x18\x01 \x01(\tR\x06stdout\x12\x16\n" +
 	"\x06stderr\x18\x02 \x01(\tR\x06stderr\x12\x1b\n" +
@@ -1496,7 +1883,11 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"session_id\x18\x04 \x01(\tR\tsessionId\x12\x15\n" +
 	"\x06run_id\x18\x05 \x01(\tR\x05runId\x12\x16\n" +
-	"\x06status\x18\x06 \x01(\tR\x06status\"*\n" +
+	"\x06status\x18\x06 \x01(\tR\x06status\x12\x1f\n" +
+	"\vduration_ms\x18\a \x01(\x03R\n" +
+	"durationMs\x12\x1c\n" +
+	"\ttruncated\x18\b \x01(\bR\ttruncated\x12\x1a\n" +
+	"\blanguage\x18\t \x01(\tR\blanguage\"*\n" +
 	"\x12ExecStreamResponse\x12\x14\n" +
 	"\x05chunk\x18\x01 \x01(\tR\x05chunk\"s\n" +
 	"\x10WriteFileRequest\x12\x1d\n" +
@@ -1564,15 +1955,21 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\n" +
 	"valid_days\x18\x03 \x01(\x03R\tvalidDays\"'\n" +
 	"\x0ePollRunRequest\x12\x15\n" +
-	"\x06run_id\x18\x01 \x01(\tR\x05runId\"\x8d\x01\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\"\xcc\x01\n" +
 	"\x0fPollRunResponse\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x16\n" +
 	"\x06stdout\x18\x03 \x01(\tR\x06stdout\x12\x16\n" +
 	"\x06stderr\x18\x04 \x01(\tR\x06stderr\x12\x1b\n" +
-	"\texit_code\x18\x05 \x01(\x05R\bexitCode2\xe9\a\n" +
+	"\texit_code\x18\x05 \x01(\x05R\bexitCode\x12\x1f\n" +
+	"\vduration_ms\x18\x06 \x01(\x03R\n" +
+	"durationMs\x12\x1c\n" +
+	"\ttruncated\x18\a \x01(\bR\ttruncated2\x89\t\n" +
 	"\x0eSandboxService\x12T\n" +
-	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12W\n" +
+	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12K\n" +
+	"\n" +
+	"GetSession\x12\x1d.sandbox.v1.GetSessionRequest\x1a\x1e.sandbox.v1.GetSessionResponse\x12Q\n" +
+	"\fListSessions\x12\x1f.sandbox.v1.ListSessionsRequest\x1a .sandbox.v1.ListSessionsResponse\x12W\n" +
 	"\x0eDestroySession\x12!.sandbox.v1.DestroySessionRequest\x1a\".sandbox.v1.DestroySessionResponse\x129\n" +
 	"\x04Exec\x12\x17.sandbox.v1.ExecRequest\x1a\x18.sandbox.v1.ExecResponse\x12G\n" +
 	"\n" +
@@ -1600,70 +1997,81 @@ func file_sandbox_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_sandbox_v1_sandbox_proto_rawDescData
 }
 
-var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_sandbox_v1_sandbox_proto_goTypes = []any{
-	(*CreateSessionRequest)(nil),   // 0: sandbox.v1.CreateSessionRequest
-	(*CreateSessionResponse)(nil),  // 1: sandbox.v1.CreateSessionResponse
-	(*DestroySessionRequest)(nil),  // 2: sandbox.v1.DestroySessionRequest
-	(*DestroySessionResponse)(nil), // 3: sandbox.v1.DestroySessionResponse
-	(*ExecRequest)(nil),            // 4: sandbox.v1.ExecRequest
-	(*ExecResponse)(nil),           // 5: sandbox.v1.ExecResponse
-	(*ExecStreamResponse)(nil),     // 6: sandbox.v1.ExecStreamResponse
-	(*WriteFileRequest)(nil),       // 7: sandbox.v1.WriteFileRequest
-	(*WriteFileResponse)(nil),      // 8: sandbox.v1.WriteFileResponse
-	(*ReadFileRequest)(nil),        // 9: sandbox.v1.ReadFileRequest
-	(*ReadFileResponse)(nil),       // 10: sandbox.v1.ReadFileResponse
-	(*ListFilesRequest)(nil),       // 11: sandbox.v1.ListFilesRequest
-	(*ListFilesResponse)(nil),      // 12: sandbox.v1.ListFilesResponse
-	(*FileEntry)(nil),              // 13: sandbox.v1.FileEntry
-	(*PipInstallRequest)(nil),      // 14: sandbox.v1.PipInstallRequest
-	(*PipInstallResponse)(nil),     // 15: sandbox.v1.PipInstallResponse
-	(*RunSubAgentRequest)(nil),     // 16: sandbox.v1.RunSubAgentRequest
-	(*RunSubAgentResponse)(nil),    // 17: sandbox.v1.RunSubAgentResponse
-	(*ConfirmActionRequest)(nil),   // 18: sandbox.v1.ConfirmActionRequest
-	(*ConfirmActionResponse)(nil),  // 19: sandbox.v1.ConfirmActionResponse
-	(*ApproveActionRequest)(nil),   // 20: sandbox.v1.ApproveActionRequest
-	(*ApproveActionResponse)(nil),  // 21: sandbox.v1.ApproveActionResponse
-	(*LoginRequest)(nil),           // 22: sandbox.v1.LoginRequest
-	(*LoginResponse)(nil),          // 23: sandbox.v1.LoginResponse
-	(*PollRunRequest)(nil),         // 24: sandbox.v1.PollRunRequest
-	(*PollRunResponse)(nil),        // 25: sandbox.v1.PollRunResponse
-	nil,                            // 26: sandbox.v1.CreateSessionRequest.EnvEntry
+	(*SecretRef)(nil),              // 0: sandbox.v1.SecretRef
+	(*CreateSessionRequest)(nil),   // 1: sandbox.v1.CreateSessionRequest
+	(*CreateSessionResponse)(nil),  // 2: sandbox.v1.CreateSessionResponse
+	(*GetSessionRequest)(nil),      // 3: sandbox.v1.GetSessionRequest
+	(*GetSessionResponse)(nil),     // 4: sandbox.v1.GetSessionResponse
+	(*ListSessionsRequest)(nil),    // 5: sandbox.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),   // 6: sandbox.v1.ListSessionsResponse
+	(*DestroySessionRequest)(nil),  // 7: sandbox.v1.DestroySessionRequest
+	(*DestroySessionResponse)(nil), // 8: sandbox.v1.DestroySessionResponse
+	(*ExecRequest)(nil),            // 9: sandbox.v1.ExecRequest
+	(*ExecResponse)(nil),           // 10: sandbox.v1.ExecResponse
+	(*ExecStreamResponse)(nil),     // 11: sandbox.v1.ExecStreamResponse
+	(*WriteFileRequest)(nil),       // 12: sandbox.v1.WriteFileRequest
+	(*WriteFileResponse)(nil),      // 13: sandbox.v1.WriteFileResponse
+	(*ReadFileRequest)(nil),        // 14: sandbox.v1.ReadFileRequest
+	(*ReadFileResponse)(nil),       // 15: sandbox.v1.ReadFileResponse
+	(*ListFilesRequest)(nil),       // 16: sandbox.v1.ListFilesRequest
+	(*ListFilesResponse)(nil),      // 17: sandbox.v1.ListFilesResponse
+	(*FileEntry)(nil),              // 18: sandbox.v1.FileEntry
+	(*PipInstallRequest)(nil),      // 19: sandbox.v1.PipInstallRequest
+	(*PipInstallResponse)(nil),     // 20: sandbox.v1.PipInstallResponse
+	(*RunSubAgentRequest)(nil),     // 21: sandbox.v1.RunSubAgentRequest
+	(*RunSubAgentResponse)(nil),    // 22: sandbox.v1.RunSubAgentResponse
+	(*ConfirmActionRequest)(nil),   // 23: sandbox.v1.ConfirmActionRequest
+	(*ConfirmActionResponse)(nil),  // 24: sandbox.v1.ConfirmActionResponse
+	(*ApproveActionRequest)(nil),   // 25: sandbox.v1.ApproveActionRequest
+	(*ApproveActionResponse)(nil),  // 26: sandbox.v1.ApproveActionResponse
+	(*LoginRequest)(nil),           // 27: sandbox.v1.LoginRequest
+	(*LoginResponse)(nil),          // 28: sandbox.v1.LoginResponse
+	(*PollRunRequest)(nil),         // 29: sandbox.v1.PollRunRequest
+	(*PollRunResponse)(nil),        // 30: sandbox.v1.PollRunResponse
+	nil,                            // 31: sandbox.v1.CreateSessionRequest.EnvEntry
 }
 var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
-	26, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
-	13, // 1: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
-	0,  // 2: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
-	2,  // 3: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
-	4,  // 4: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
-	4,  // 5: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
-	7,  // 6: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
-	9,  // 7: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
-	11, // 8: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
-	14, // 9: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
-	16, // 10: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
-	18, // 11: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
-	20, // 12: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
-	22, // 13: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
-	24, // 14: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
-	1,  // 15: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
-	3,  // 16: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
-	5,  // 17: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
-	6,  // 18: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
-	8,  // 19: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
-	10, // 20: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
-	12, // 21: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
-	15, // 22: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
-	17, // 23: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
-	19, // 24: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
-	21, // 25: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	23, // 26: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
-	25, // 27: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
-	15, // [15:28] is the sub-list for method output_type
-	2,  // [2:15] is the sub-list for method input_type
-	2,  // [2:2] is the sub-list for extension type_name
-	2,  // [2:2] is the sub-list for extension extendee
-	0,  // [0:2] is the sub-list for field type_name
+	31, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
+	0,  // 1: sandbox.v1.CreateSessionRequest.secret_refs:type_name -> sandbox.v1.SecretRef
+	4,  // 2: sandbox.v1.ListSessionsResponse.sessions:type_name -> sandbox.v1.GetSessionResponse
+	18, // 3: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
+	1,  // 4: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
+	3,  // 5: sandbox.v1.SandboxService.GetSession:input_type -> sandbox.v1.GetSessionRequest
+	5,  // 6: sandbox.v1.SandboxService.ListSessions:input_type -> sandbox.v1.ListSessionsRequest
+	7,  // 7: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
+	9,  // 8: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
+	9,  // 9: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
+	12, // 10: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
+	14, // 11: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
+	16, // 12: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
+	19, // 13: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
+	21, // 14: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
+	23, // 15: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
+	25, // 16: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
+	27, // 17: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
+	29, // 18: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
+	2,  // 19: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
+	4,  // 20: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
+	6,  // 21: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
+	8,  // 22: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
+	10, // 23: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
+	11, // 24: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
+	13, // 25: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
+	15, // 26: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
+	17, // 27: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
+	20, // 28: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
+	22, // 29: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
+	24, // 30: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
+	26, // 31: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
+	28, // 32: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
+	30, // 33: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
+	19, // [19:34] is the sub-list for method output_type
+	4,  // [4:19] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_sandbox_v1_sandbox_proto_init() }
@@ -1677,7 +2085,7 @@ func file_sandbox_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_v1_sandbox_proto_rawDesc), len(file_sandbox_v1_sandbox_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   27,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
@@ -20,6 +20,8 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	SandboxService_CreateSession_FullMethodName  = "/sandbox.v1.SandboxService/CreateSession"
+	SandboxService_GetSession_FullMethodName     = "/sandbox.v1.SandboxService/GetSession"
+	SandboxService_ListSessions_FullMethodName   = "/sandbox.v1.SandboxService/ListSessions"
 	SandboxService_DestroySession_FullMethodName = "/sandbox.v1.SandboxService/DestroySession"
 	SandboxService_Exec_FullMethodName           = "/sandbox.v1.SandboxService/Exec"
 	SandboxService_ExecStream_FullMethodName     = "/sandbox.v1.SandboxService/ExecStream"
@@ -39,6 +41,8 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type SandboxServiceClient interface {
 	CreateSession(ctx context.Context, in *CreateSessionRequest, opts ...grpc.CallOption) (*CreateSessionResponse, error)
+	GetSession(ctx context.Context, in *GetSessionRequest, opts ...grpc.CallOption) (*GetSessionResponse, error)
+	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
 	DestroySession(ctx context.Context, in *DestroySessionRequest, opts ...grpc.CallOption) (*DestroySessionResponse, error)
 	Exec(ctx context.Context, in *ExecRequest, opts ...grpc.CallOption) (*ExecResponse, error)
 	ExecStream(ctx context.Context, in *ExecRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ExecStreamResponse], error)
@@ -69,6 +73,26 @@ func (c *sandboxServiceClient) CreateSession(ctx context.Context, in *CreateSess
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateSessionResponse)
 	err := c.cc.Invoke(ctx, SandboxService_CreateSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) GetSession(ctx context.Context, in *GetSessionRequest, opts ...grpc.CallOption) (*GetSessionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSessionResponse)
+	err := c.cc.Invoke(ctx, SandboxService_GetSession_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSessionsResponse)
+	err := c.cc.Invoke(ctx, SandboxService_ListSessions_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -209,6 +233,8 @@ func (c *sandboxServiceClient) PollRun(ctx context.Context, in *PollRunRequest, 
 // for forward compatibility.
 type SandboxServiceServer interface {
 	CreateSession(context.Context, *CreateSessionRequest) (*CreateSessionResponse, error)
+	GetSession(context.Context, *GetSessionRequest) (*GetSessionResponse, error)
+	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
 	DestroySession(context.Context, *DestroySessionRequest) (*DestroySessionResponse, error)
 	Exec(context.Context, *ExecRequest) (*ExecResponse, error)
 	ExecStream(*ExecRequest, grpc.ServerStreamingServer[ExecStreamResponse]) error
@@ -237,6 +263,12 @@ type UnimplementedSandboxServiceServer struct{}
 
 func (UnimplementedSandboxServiceServer) CreateSession(context.Context, *CreateSessionRequest) (*CreateSessionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateSession not implemented")
+}
+func (UnimplementedSandboxServiceServer) GetSession(context.Context, *GetSessionRequest) (*GetSessionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSession not implemented")
+}
+func (UnimplementedSandboxServiceServer) ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSessions not implemented")
 }
 func (UnimplementedSandboxServiceServer) DestroySession(context.Context, *DestroySessionRequest) (*DestroySessionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DestroySession not implemented")
@@ -309,6 +341,42 @@ func _SandboxService_CreateSession_Handler(srv interface{}, ctx context.Context,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(SandboxServiceServer).CreateSession(ctx, req.(*CreateSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_GetSession_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSessionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).GetSession(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_GetSession_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).GetSession(ctx, req.(*GetSessionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_ListSessions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSessionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).ListSessions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_ListSessions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).ListSessions(ctx, req.(*ListSessionsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -532,6 +600,14 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CreateSession",
 			Handler:    _SandboxService_CreateSession_Handler,
+		},
+		{
+			MethodName: "GetSession",
+			Handler:    _SandboxService_GetSession_Handler,
+		},
+		{
+			MethodName: "ListSessions",
+			Handler:    _SandboxService_ListSessions_Handler,
 		},
 		{
 			MethodName: "DestroySession",

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -293,6 +293,9 @@ func (s *Server) CreateSession(ctx context.Context, req *pb.CreateSessionRequest
 	if err := validateSessionEnv(req.Env); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "env: %v", err)
 	}
+	if err := validateSecretRefs(req.SecretRefs); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "secret_refs: %v", err)
+	}
 	if err := s.orch.CheckCapacity(ctx); err != nil {
 		return nil, err
 	}
@@ -301,6 +304,33 @@ func (s *Server) CreateSession(ctx context.Context, req *pb.CreateSessionRequest
 		return nil, status.Errorf(codes.Internal, "create session: %v", err)
 	}
 	return &pb.CreateSessionResponse{SessionId: session.Name, PodIp: session.Status.PodIP}, nil
+}
+
+func (s *Server) GetSession(ctx context.Context, req *pb.GetSessionRequest) (*pb.GetSessionResponse, error) {
+	if req.SessionId == "" {
+		return nil, status.Error(codes.InvalidArgument, "session_id required")
+	}
+	sess, err := s.orch.getSession(ctx, req.SessionId)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "session %s not found", req.SessionId)
+	}
+	return sessionToProtoView(sess, s.orch.countBackgroundRuns(req.SessionId)), nil
+}
+
+func (s *Server) ListSessions(ctx context.Context, req *pb.ListSessionsRequest) (*pb.ListSessionsResponse, error) {
+	phase := req.Phase
+	if phase == "" {
+		phase = string(sandboxv1.SandboxPhaseActive)
+	}
+	sessions, err := s.orch.listSessions(ctx, sandboxNS, phase)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list sessions: %v", err)
+	}
+	out := make([]*pb.GetSessionResponse, 0, len(sessions))
+	for _, sess := range sessions {
+		out = append(out, sessionToProtoView(sess, s.orch.countBackgroundRuns(sess.Name)))
+	}
+	return &pb.ListSessionsResponse{Sessions: out}, nil
 }
 
 func (s *Server) DestroySession(ctx context.Context, req *pb.DestroySessionRequest) (*pb.DestroySessionResponse, error) {
@@ -313,12 +343,17 @@ func (s *Server) DestroySession(ctx context.Context, req *pb.DestroySessionReque
 func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecResponse, error) {
 	// Background mode: submit async, return run_id immediately
 	if req.Background {
-		env := s.getSessionEnv(ctx, req.SessionId)
+		env, envErr := s.resolveSessionEnv(ctx, req.SessionId)
+		if envErr != nil {
+			return nil, envErr
+		}
 		runID, err := s.orch.ExecBackground(ctx, req.SessionId, req.Command, req.Timeout, req.Workdir, env)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "background submit: %v", err)
 		}
-		return &pb.ExecResponse{RunId: runID, Status: "started", SessionId: req.SessionId}, nil
+		return &pb.ExecResponse{
+			RunId: runID, Status: execStatusStarted, SessionId: req.SessionId, Language: req.Language,
+		}, nil
 	}
 
 	podIP, err := s.getPodIP(ctx, req.SessionId)
@@ -334,24 +369,48 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 		workdir = "/workspace"
 	}
 
-	env := s.getSessionEnv(ctx, req.SessionId)
+	env, envErr := s.resolveSessionEnv(ctx, req.SessionId)
+	if envErr != nil {
+		return nil, envErr
+	}
 	body := sandboxdExecBody(req.Command, timeout, workdir, env)
+	start := time.Now()
 	httpCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout+5)*time.Second)
 	defer cancel()
 
 	resp, err := sandboxdPost(httpCtx, podIP, "/exec", body)
+	elapsed := time.Since(start).Milliseconds()
 	if err != nil {
 		return nil, status.Errorf(codes.Unavailable, "sandboxd exec: %v", err)
 	}
 	defer resp.Body.Close()
 
 	var result struct {
-		Stdout   string `json:"stdout"`
-		Stderr   string `json:"stderr"`
-		ExitCode int32  `json:"exit_code"`
+		Stdout     string `json:"stdout"`
+		Stderr     string `json:"stderr"`
+		ExitCode   int32  `json:"exit_code"`
+		DurationMs int64  `json:"duration_ms"`
+		Truncated  bool   `json:"truncated"`
+		TimedOut   bool   `json:"timed_out"`
 	}
 	json.NewDecoder(resp.Body).Decode(&result)
-	return &pb.ExecResponse{Stdout: result.Stdout, Stderr: result.Stderr, ExitCode: result.ExitCode}, nil
+	duration := result.DurationMs
+	if duration <= 0 {
+		duration = elapsed
+	}
+	// Prefer sandboxd truncation flag; also mark if streams hit gateway-side cap observation.
+	truncated := result.Truncated || len(result.Stdout) >= maxExecOutputBytes || len(result.Stderr) >= maxExecOutputBytes
+	timedOut := result.TimedOut || (timeout > 0 && duration >= int64(timeout)*1000 && result.ExitCode != 0)
+	return &pb.ExecResponse{
+		Stdout:     result.Stdout,
+		Stderr:     result.Stderr,
+		ExitCode:   result.ExitCode,
+		SessionId:  req.SessionId,
+		Status:     classifyExecStatus(timedOut, false),
+		DurationMs: duration,
+		Truncated:  truncated,
+		Language:   req.Language,
+	}, nil
 }
 
 func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecStreamServer) error {
@@ -367,7 +426,10 @@ func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecSt
 	if workdir == "" {
 		workdir = "/workspace"
 	}
-	env := s.getSessionEnv(stream.Context(), req.SessionId)
+	env, envErr := s.resolveSessionEnv(stream.Context(), req.SessionId)
+	if envErr != nil {
+		return envErr
+	}
 	body := sandboxdExecBody(req.Command, timeout, workdir, env)
 	httpCtx, cancel := context.WithTimeout(stream.Context(), time.Duration(timeout+5)*time.Second)
 	defer cancel()
@@ -395,26 +457,58 @@ func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxService_ExecSt
 	}
 }
 
-// getSessionEnv returns the non-sensitive env map stored on the SandboxSession CR.
-// Returns nil when absent. On lookup failure it logs a warning and returns nil so
-// exec still proceeds with sandboxd defaults (P1-1: no longer a silent drop).
+// resolveSessionEnv loads non-sensitive env and resolves secret_refs from K8s Secrets.
+// Secret resolution failures return a gRPC error (fail closed for secrets).
+func (s *Server) resolveSessionEnv(ctx context.Context, sessionID string) (map[string]string, error) {
+	sess, err := s.orch.getSession(ctx, sessionID)
+	if err != nil {
+		logrus.WithError(err).WithField("session_id", sessionID).
+			Warn("sandbox gRPC: failed to load session for env; continuing with sandboxd defaults")
+		return nil, nil
+	}
+	var out map[string]string
+	if len(sess.Spec.Env) > 0 {
+		out = make(map[string]string, len(sess.Spec.Env)+len(sess.Spec.SecretRefs))
+		for k, v := range sess.Spec.Env {
+			out[k] = v
+		}
+	}
+	if len(sess.Spec.SecretRefs) == 0 {
+		return out, nil
+	}
+	if out == nil {
+		out = make(map[string]string, len(sess.Spec.SecretRefs))
+	}
+	for _, ref := range sess.Spec.SecretRefs {
+		val, rerr := s.readSecretKey(ctx, ref.SecretName, ref.Key)
+		if rerr != nil {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"secret_ref %s/%s for env %s: %v", ref.SecretName, ref.Key, ref.EnvVar, rerr)
+		}
+		out[ref.EnvVar] = val
+	}
+	return out, nil
+}
+
+// getSessionEnv is a best-effort non-secret env load (tests / legacy helpers).
 func (s *Server) getSessionEnv(ctx context.Context, sessionID string) map[string]string {
-	u, err := s.dyn.Resource(sessionGVR).Namespace(sandboxNS).Get(ctx, sessionID, metav1.GetOptions{})
+	env, err := s.resolveSessionEnv(ctx, sessionID)
 	if err != nil {
-		logrus.WithError(err).WithField("session_id", sessionID).
-			Warn("sandbox gRPC: failed to load session env; continuing with sandboxd defaults")
-		return nil
-	}
-	env, found, err := unstructured.NestedStringMap(u.Object, "spec", "env")
-	if err != nil {
-		logrus.WithError(err).WithField("session_id", sessionID).
-			Warn("sandbox gRPC: session env field unreadable; continuing with sandboxd defaults")
-		return nil
-	}
-	if !found || len(env) == 0 {
 		return nil
 	}
 	return env
+}
+
+func (s *Server) readSecretKey(ctx context.Context, secretName, key string) (string, error) {
+	sec, err := s.k8s.CoreV1().Secrets(sandboxNS).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	raw, ok := sec.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in secret %q", key, secretName)
+	}
+	return string(raw), nil
 }
 
 func (s *Server) WriteFile(ctx context.Context, req *pb.WriteFileRequest) (*pb.WriteFileResponse, error) {

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -4,6 +4,8 @@ option go_package = "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;
 
 service SandboxService {
   rpc CreateSession(CreateSessionRequest)   returns (CreateSessionResponse);
+  rpc GetSession(GetSessionRequest)         returns (GetSessionResponse);
+  rpc ListSessions(ListSessionsRequest)     returns (ListSessionsResponse);
   rpc DestroySession(DestroySessionRequest) returns (DestroySessionResponse);
   rpc Exec(ExecRequest)                     returns (ExecResponse);
   rpc ExecStream(ExecRequest)               returns (stream ExecStreamResponse);
@@ -22,6 +24,14 @@ service SandboxService {
   rpc PollRun(PollRunRequest)               returns (PollRunResponse);
 }
 
+// SecretRef references a key in a same-namespace K8s Secret. Values are resolved
+// at exec time only and never stored on the SandboxSession CRD (#505 / KIP-12 B).
+message SecretRef {
+  string secret_name = 1; // K8s Secret name
+  string key         = 2; // key within Secret.data
+  string env_var     = 3; // environment variable name injected into the process
+}
+
 message CreateSessionRequest {
   string          session_id     = 1;
   string          tenant_id      = 2;
@@ -30,10 +40,31 @@ message CreateSessionRequest {
   // Non-sensitive environment variables persisted on the SandboxSession and
   // applied at exec time so warm-pool pods stay reusable (KIP-12 Part B / #483).
   map<string, string> env        = 5;
+  repeated SecretRef  secret_refs = 6;
 }
 message CreateSessionResponse {
   string session_id = 1;
   string pod_ip     = 2;
+}
+
+message GetSessionRequest  { string session_id = 1; }
+message GetSessionResponse {
+  string          session_id     = 1;
+  string          phase          = 2;
+  string          runtime_class  = 3;
+  string          pod_ip         = 4;
+  string          tenant_id      = 5;
+  int64           expires_at     = 6; // unix seconds; 0 if none
+  repeated string env_keys       = 7; // keys only, never values
+  repeated string secret_env_vars = 8; // env_var names from secret_refs only
+  int32           background_runs = 9; // active entries known to gateway registry
+}
+
+message ListSessionsRequest {
+  string phase = 1; // empty = Active only; "all" = every phase
+}
+message ListSessionsResponse {
+  repeated GetSessionResponse sessions = 1;
 }
 
 message DestroySessionRequest  { string session_id = 1; }
@@ -45,14 +76,19 @@ message ExecRequest {
   int32  timeout    = 3;
   string workdir    = 4;
   bool   background = 5;  // submit asynchronously, return run_id immediately
+  string language   = 6;  // optional hint: python|bash|node|ts (observability)
 }
 message ExecResponse {
-  string stdout    = 1;
-  string stderr    = 2;
-  int32  exit_code = 3;
-  string session_id = 4;
-  string run_id    = 5;  // set when background=true
-  string status    = 6;  // "started" when background=true
+  string stdout      = 1;
+  string stderr      = 2;
+  int32  exit_code   = 3;
+  string session_id  = 4;
+  string run_id      = 5;  // set when background=true
+  // started|running|completed|timed_out|failed
+  string status      = 6;
+  int64  duration_ms = 7;  // wall-clock ms for this execution (0 if unknown/started)
+  bool   truncated   = 8;  // stdout and/or stderr hit size cap
+  string language    = 9;  // echoed from request when set
 }
 message ExecStreamResponse { string chunk = 1; }
 
@@ -114,9 +150,12 @@ message LoginResponse {
 
 message PollRunRequest  { string run_id = 1; }
 message PollRunResponse {
-  string run_id    = 1;
-  string status    = 2;  // started | running | completed | failed | timed_out
-  string stdout    = 3;
-  string stderr    = 4;
-  int32  exit_code = 5;
+  string run_id      = 1;
+  // started|running|completed|failed|timed_out|not_found
+  string status      = 2;
+  string stdout      = 3;
+  string stderr      = 4;
+  int32  exit_code   = 5;
+  int64  duration_ms = 6;
+  bool   truncated   = 7;
 }

--- a/sandboxd/src/exec.zig
+++ b/sandboxd/src/exec.zig
@@ -13,10 +13,16 @@ const ExecRequest = struct {
     env: std.json.Value = .{ .null = {} },
 };
 
+// max_stdout_bytes / max_stderr_bytes: capture caps (~1 MiB agent-facing policy).
+const max_stdout_bytes: usize = 1 * 1024 * 1024;
+const max_stderr_bytes: usize = 1 * 1024 * 1024;
+
 pub const ExecResult = struct {
     stdout: []u8,
     stderr: []u8,
     exit_code: i32,
+    duration_ms: i64 = 0,
+    truncated: bool = false,
 
     pub fn deinit(self: ExecResult, allocator: std.mem.Allocator) void {
         allocator.free(self.stdout);
@@ -124,6 +130,9 @@ pub fn runCommandWithEnv(allocator: std.mem.Allocator, command: []const u8, work
         return error.PipeFailed;
     }
 
+    var ts_start: std.os.linux.timespec = undefined;
+    _ = std.os.linux.clock_gettime(std.os.linux.CLOCK.MONOTONIC, &ts_start);
+
     const pid = std.os.linux.fork();
     if (pid == 0) {
         // Child process
@@ -156,9 +165,11 @@ pub fn runCommandWithEnv(allocator: std.mem.Allocator, command: []const u8, work
     _ = std.os.linux.close(stdout_pipe[1]); // close write end
     _ = std.os.linux.close(stderr_pipe[1]); // close write end
 
-    const stdout = readAllFromFd(allocator, stdout_pipe[0], 10 * 1024 * 1024) catch
+    var stdout_trunc = false;
+    var stderr_trunc = false;
+    const stdout = readAllFromFdTrunc(allocator, stdout_pipe[0], max_stdout_bytes, &stdout_trunc) catch
         allocator.dupe(u8, "") catch @panic("oom");
-    const stderr = readAllFromFd(allocator, stderr_pipe[0], 1 * 1024 * 1024) catch
+    const stderr = readAllFromFdTrunc(allocator, stderr_pipe[0], max_stderr_bytes, &stderr_trunc) catch
         allocator.dupe(u8, "") catch @panic("oom");
 
     _ = std.os.linux.close(stdout_pipe[0]);
@@ -180,10 +191,31 @@ pub fn runCommandWithEnv(allocator: std.mem.Allocator, command: []const u8, work
         break :blk 0;
     };
 
-    return ExecResult{ .stdout = stdout, .stderr = stderr, .exit_code = exit_code };
+    var ts_end: std.os.linux.timespec = undefined;
+    _ = std.os.linux.clock_gettime(std.os.linux.CLOCK.MONOTONIC, &ts_end);
+    const duration_ms: i64 = blk: {
+        const sec = ts_end.sec - ts_start.sec;
+        const nsec = ts_end.nsec - ts_start.nsec;
+        break :blk @as(i64, @intCast(sec)) * 1000 + @divTrunc(@as(i64, @intCast(nsec)), 1_000_000);
+    };
+
+    return ExecResult{
+        .stdout = stdout,
+        .stderr = stderr,
+        .exit_code = exit_code,
+        .duration_ms = if (duration_ms < 0) 0 else duration_ms,
+        .truncated = stdout_trunc or stderr_trunc,
+    };
 }
 
 pub fn readAllFromFd(allocator: std.mem.Allocator, fd: i32, max_bytes: usize) ![]u8 {
+    var trunc = false;
+    return readAllFromFdTrunc(allocator, fd, max_bytes, &trunc);
+}
+
+/// readAllFromFdTrunc reads up to max_bytes; sets *truncated when more data was available.
+pub fn readAllFromFdTrunc(allocator: std.mem.Allocator, fd: i32, max_bytes: usize, truncated: *bool) ![]u8 {
+    truncated.* = false;
     var buf = try allocator.alloc(u8, max_bytes);
     errdefer allocator.free(buf);
     var total: usize = 0;
@@ -197,6 +229,15 @@ pub fn readAllFromFd(allocator: std.mem.Allocator, fd: i32, max_bytes: usize) ![
         if (n == 0) break;
         @memcpy(buf[total..][0..@as(usize, @intCast(n))], tmp[0..@as(usize, @intCast(n))]);
         total += @as(usize, @intCast(n));
+    }
+    if (total >= max_bytes) {
+        // Drain remainder so the writer does not block; mark truncated.
+        var drain: [4096]u8 = undefined;
+        while (true) {
+            const n = std.os.linux.read(fd, &drain, drain.len);
+            if (n <= 0) break;
+            truncated.* = true;
+        }
     }
     // Shrink to exact size so DebugAllocator canary check passes
     if (allocator.resize(buf, total)) {
@@ -338,9 +379,10 @@ pub fn handleExec(allocator: std.mem.Allocator, client_fd: i32, body: []const u8
     const stderr_json = try jsonEscape(allocator, result.stderr);
     defer allocator.free(stderr_json);
 
+    const trunc_lit: []const u8 = if (result.truncated) "true" else "false";
     const resp = try std.fmt.allocPrint(allocator,
-        "{{\"stdout\":\"{s}\",\"stderr\":\"{s}\",\"exit_code\":{d}}}",
-        .{ stdout_json, stderr_json, result.exit_code });
+        "{{\"stdout\":\"{s}\",\"stderr\":\"{s}\",\"exit_code\":{d},\"duration_ms\":{d},\"truncated\":{s}}}",
+        .{ stdout_json, stderr_json, result.exit_code, result.duration_ms, trunc_lit });
     defer allocator.free(resp);
     try main.writeResponse(client_fd, "200 OK", "application/json", resp);
 }

--- a/skills/k8e-sandbox/SKILL.md
+++ b/skills/k8e-sandbox/SKILL.md
@@ -91,7 +91,9 @@ chmod +x k8e-sandbox-cli-linux-amd64
 | `k8e-sandbox-cli login` | Authenticate and obtain mTLS cert (remote access) | `--apikey`, `--endpoint`, `--device-name` |
 | `k8e-sandbox-cli run <code>` | Execute code or shell command | `--lang python\|bash\|node\|ts`, `--session-id`, `--tenant`, `--timeout 30`, `--raw` |
 | `k8e-sandbox-cli status` | Check service + current session | — |
-| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--env KEY=VAL` (repeatable, non-sensitive), `--manifest`, `--git-repo` |
+| `k8e-sandbox-cli create` | New session (manual lifecycle) | `--runtime gvisor\|kata\|firecracker`, `--allowed-hosts`, `--env KEY=VAL` (non-sensitive), `--secret ENV=secret:key` (exec-time resolve), `--manifest`, `--git-repo` |
+| `k8e-sandbox-cli get <sid>` | Session introspection | phase, runtime, env keys / secret env names (never values) |
+| `k8e-sandbox-cli sessions` | List sessions | `--phase Active\|all` |
 | `k8e-sandbox-cli destroy <sid>` | Destroy session | — |
 | `k8e-sandbox-cli write <sid> <path>` | Write file to /workspace | content via stdin, `--mode w\|a` |
 | `k8e-sandbox-cli read <sid> <path>` | Read file from /workspace | `--raw` (plain text output) |
@@ -123,7 +125,7 @@ Code source: argument > stdin. Language default: `bash`.
 
 | Mode | Behavior | Output | Exit code |
 |------|----------|--------|-----------|
-| Default (JSON) | Wait for completion | `{"stdout":"...","stderr":"...","exit_code":0,"session_id":"sess-xxx"}` | match command |
+| Default (JSON) | Wait for completion | `{"stdout","stderr","exit_code","session_id","status","duration_ms","truncated","language"}` | match command |
 | `--raw` | Stream in real-time | plain text to stdout | match command |
 
 ## Session lifecycle
@@ -197,7 +199,7 @@ Env is stored on the session and applied at **every exec** (warm-pool safe — n
 3. k8e-sandbox-cli destroy $SID
 ```
 
-⚠️ **Red line:** `--env` is for non-sensitive config only. Values are stored in plaintext on the SandboxSession CRD. Use secret-ref injection (issue #485) for API keys and tokens — never put secrets in `--env`.
+⚠️ **Red line:** `--env` is for non-sensitive config only. Values are stored in plaintext on the SandboxSession CRD. Use `--secret ENV_VAR=secretName:key` for API keys/tokens (resolved at exec time from K8s Secrets; never stored on the CRD).
 
 ### Scenario 5: Parallel sub-agents
 


### PR DESCRIPTION
## Summary

Implements three Wave issues for the **vendor-neutral sandbox tool service** (KIP-15):

| Issue | Delivery |
|-------|----------|
| **#503** | `ExecResponse` / `PollRunResponse`: `duration_ms`, `truncated`, status (`completed`/`timed_out`/`failed`/`started`), optional `language`; sandboxd JSON + CLI surface |
| **#504** | `GetSession` + `ListSessions` gRPC; CLI `get` / `sessions`; env keys + secret env var **names** only (never values) |
| **#505** | `CreateSession.secret_refs` → CRD refs only; resolve K8s Secret at **exec time** into sandboxd env; CLI `--secret ENV=secret:key` |

## Notes

- Secret resolution **fails closed** if Secret/key missing (`FailedPrecondition`).
- Inline `--env` remains for non-sensitive config only (red line in skill).
- Apply CRD: `kubectl apply -f manifests/sandbox-matrix/crds.yaml`

## Test plan

- [x] `go test ./pkg/sandboxmatrix/grpc/ ./pkg/sandboxcli/`
- [x] `go build ./pkg/sandboxmatrix/grpc/ ./pkg/sandboxcli/ ./cmd/sandboxcli/`
- [ ] Cluster e2e: create with secret → exec sees env; get/list sessions; run JSON has duration_ms

Closes #503
Closes #504
Closes #505