### PR TITLE
feat(sandbox): sub-agents reuse parent pod (KIP-16 M1, #514)

### DIFF
--- a/docs/kip-16-sandbox-architecture-lessons-ephemeral.md
+++ b/docs/kip-16-sandbox-architecture-lessons-ephemeral.md
@@ -129,7 +129,7 @@ KIP-16 acceptance criterion #1 (each P0/P1 matrix row gets a GitHub issue):
 | M2 layerstack snapshot layer (P1) | [#511](https://github.com/xiaods/k8e/issues/511) | **slice 1 shipped** — real mtimes + `ListFiles(since)` diff foundation; CAS layerstore + delta layers remain |
 | M4 PTY transcript + windowed replay (P1) | [#512](https://github.com/xiaods/k8e/issues/512) | **Wave 3: shipped** — file-backed transcript + GetTranscript RPC + `log` CLI (transcript window semantics; PTY master variant deferred) |
 | M5 observability (P1) | [#513](https://github.com/xiaods/k8e/issues/513) | **slice 1+2 shipped** — Prometheus collector (#517) + sandboxd NDJSON event stream (#518); query endpoint + process topology remain |
-| M1 workspace-session reuse (P1) | [#514](https://github.com/xiaods/k8e/issues/514) | open |
+| M1 workspace-session reuse (P1) | [#514](https://github.com/xiaods/k8e/issues/514) | **slice 1 shipped (#520)** — sub-agents share parent pod (no own PodName/CNP); per-session overlay remains |
 | M7 protocol limits | implemented in-tree (Wave 1 R4) | — |
 | M8 ready handshake | implemented in-tree (Wave 1 R3) | — |
 | M12 background caps | implemented in-tree (Wave 2 M12) | — |

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -92,6 +92,7 @@ k8e-sandbox-cli connect --endpoint <server-ip>:50051 --apikey k8e-...
 | `k8e-sandbox-cli log <sid>` | Replay exec transcript | `--offset`, `--limit`, `--follow` |
 | `k8e-sandbox-cli events <sid>` | Read daemon NDJSON event stream | `--limit` |
 | `k8e-sandbox-cli poll <run-id>` | Poll a background run | |
+| `k8e-sandbox-cli subagent <parent-sid>` | Spawn child session (shares parent's pod + workspace — no new pod) |
 | `k8e-sandbox-cli destroy <sid>` | Tear down session |
 
 Default run output is JSON: `stdout`, `stderr`, `exit_code`, `session_id`. Use `--raw` to stream text.

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -551,21 +551,17 @@ func (o *Orchestrator) RunSubAgent(ctx context.Context, req *pb.RunSubAgentReque
 		return nil, status.Errorf(codes.Internal, "create sub-agent: %v", err)
 	}
 
-	pod, err := o.claimOrCreatePod(ctx, childID, child.Spec.RuntimeClass, parentPVC, "", "")
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "pod: %v", err)
-	}
-
+	// M1 workspace-session reuse (KIP-16 L1 / issue #514): the sub-agent shares
+	// the parent's pod + sandboxd instead of provisioning a new pod. The child
+	// inherits the parent's PodIP for exec routing but deliberately has NO own
+	// PodName and NO own CNP — so DestroySession/GC only delete the child CRD
+	// and never reset the shared pod's workspace or release it back to the pool.
 	child.Status.Phase = sandboxv1.SandboxPhaseActive
-	child.Status.PodName = pod.Name
-	child.Status.PodIP = pod.Status.PodIP
+	child.Status.PodIP = parent.Status.PodIP
 	child.Status.WorkspacePVC = parentPVC
 	child.Status.CreatedAt = &metav1.Time{Time: time.Now()}
 	o.updateSessionStatus(ctx, child)
 
-	if err := o.applyCNP(ctx, child); err != nil {
-		return nil, status.Errorf(codes.Internal, "network policy: %v", err)
-	}
 	return &pb.RunSubAgentResponse{SessionId: childID}, nil
 }
 

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -569,7 +569,7 @@ func TestRunSubAgent_Success(t *testing.T) {
 		"kind":       "SandboxSession",
 		"metadata":   map[string]interface{}{"name": "parent-ok", "namespace": sandboxNS},
 		"spec":       map[string]interface{}{"depth": int64(0), "runtimeClass": "gvisor", "allowedHosts": []interface{}{"pypi.org"}},
-		"status":     map[string]interface{}{"workspacePVC": "workspace-parent-ok"},
+		"status":     map[string]interface{}{"workspacePVC": "workspace-parent-ok", "podIP": "10.0.0.5"},
 	}}
 	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).Create(ctx, parent, metav1.CreateOptions{}) //nolint:errcheck
 
@@ -591,6 +591,14 @@ func TestRunSubAgent_Success(t *testing.T) {
 	// child must share the parent's workspace PVC for file-based IPC
 	if child.Status.WorkspacePVC != "workspace-parent-ok" {
 		t.Fatalf("expected child to share parent PVC, got %q", child.Status.WorkspacePVC)
+	}
+	// M1 workspace-session reuse: child inherits parent PodIP (exec routing)
+	// but has NO own PodName (destroy must not touch the shared pod).
+	if child.Status.PodIP != "10.0.0.5" {
+		t.Fatalf("expected child to reuse parent PodIP, got %q", child.Status.PodIP)
+	}
+	if child.Status.PodName != "" {
+		t.Fatalf("expected child to have no own PodName (shares parent pod), got %q", child.Status.PodName)
 	}
 }
 
@@ -888,5 +896,55 @@ func TestBuildSessionCNP_NamespaceScoped(t *testing.T) {
 	}
 	if obj.GetName() != "sandbox-session-cnp-ns" {
 		t.Fatalf("unexpected CNP name: %s", obj.GetName())
+	}
+}
+
+// TestRunSubAgent_DestroyChildLeavesParentPod verifies the M1 workspace-session
+// model: destroying a child that shares the parent's pod deletes only the
+// child CRD — the parent's pod is not reset or released (no own PodName, so
+// DestroySession's pod-cleanup path is skipped).
+func TestRunSubAgent_DestroyChildLeavesParentPod(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+
+	parent := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": testAPIVer,
+		"kind":       "SandboxSession",
+		"metadata":   map[string]interface{}{"name": "parent-shared", "namespace": sandboxNS},
+		"spec":       map[string]interface{}{"depth": int64(0), "runtimeClass": "gvisor"},
+		"status":     map[string]interface{}{"workspacePVC": "workspace-parent-shared", "podName": "pod-parent", "podIP": "10.0.0.9"},
+	}}
+	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).Create(ctx, parent, metav1.CreateOptions{}) //nolint:errcheck
+
+	// Parent pod exists and is active.
+	parentPod := warmTestPod("pod-parent", "10.0.0.9")
+	parentPod.Labels[labelSessionID] = "parent-shared"
+	parentPod.Labels[labelState] = stateActive
+	o.k8s.CoreV1().Pods(sandboxNS).Create(ctx, parentPod, metav1.CreateOptions{}) //nolint:errcheck
+
+	resp, err := o.RunSubAgent(ctx, &pb.RunSubAgentRequest{ParentSessionId: "parent-shared"})
+	if err != nil {
+		t.Fatalf("run sub-agent: %v", err)
+	}
+
+	if err := o.DestroySession(ctx, resp.SessionId); err != nil {
+		t.Fatalf("destroy child: %v", err)
+	}
+
+	// Child CRD gone.
+	if _, err := o.getSession(ctx, resp.SessionId); err == nil {
+		t.Fatal("expected child session to be deleted")
+	}
+
+	// Parent pod untouched: still exists, still active, session label intact.
+	pod, err := o.k8s.CoreV1().Pods(sandboxNS).Get(ctx, "pod-parent", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("parent pod should survive child destroy: %v", err)
+	}
+	if pod.Labels[labelState] != stateActive {
+		t.Fatalf("parent pod must stay active, got %v", pod.Labels)
+	}
+	if pod.Labels[labelSessionID] != "parent-shared" {
+		t.Fatalf("parent pod session label must be intact, got %v", pod.Labels)
 	}
 }


### PR DESCRIPTION
## Summary

KIP-16 M1 slice 1 (issue #514): workspace-session reuse over a shared sandbox — the ephemeral-sandbox L1 mechanism (N workspace sessions over one sandbox base) applied to k8e's sub-agent path.

## What changed

`RunSubAgent` no longer provisions a new pod per sub-agent:
- Child session **inherits the parent's PodIP** for exec routing
- Child has **NO own PodName** and **NO own CNP**
- `DestroySession`/GC only delete the child CRD — the shared pod is never reset, relabeled, or released back to the warm pool

## Why (KIP-16 M1 evidence)

Current 1:1 session→pod means each sub-agent spawns a full pod (claim/create + CNP + readiness) — high latency and resource waste. Reuse collapses sub-agent spawn to a CRD write; N sub-agents share one warm pod. Trust boundary stays pod-level (per KIP-16 §4: reuse optimization, NOT a security boundary).

## Tests
- `TestRunSubAgent_Success`: child reuses parent PodIP, has no own PodName
- `TestRunSubAgent_DestroyChildLeavesParentPod`: destroy deletes child CRD only; parent pod stays active with labels intact
- All sandboxmatrix tests green

## Follow-ups (#514)
- Per-session overlay (upperdir) isolation inside the pod
- Warm-pool child reuse (ephemeral parents without PVC)