### PR TITLE
feat(sandbox): zstd-compressed layer storage (KIP-16 M2, #511)

### DIFF
--- a/docs/kip-16-sandbox-architecture-lessons-ephemeral.md
+++ b/docs/kip-16-sandbox-architecture-lessons-ephemeral.md
@@ -126,7 +126,7 @@ KIP-16 acceptance criterion #1 (each P0/P1 matrix row gets a GitHub issue):
 | Matrix row | Issue | Status |
 |---|---|---|
 | M10 allowed_hosts enforcement (P0) | [#510](https://github.com/xiaods/k8e/issues/510) | open — needs design decision (toFQDNs / egress proxy / API removal) |
-| M2 layerstack snapshot layer (P1) | [#511](https://github.com/xiaods/k8e/issues/511) | **slice 1 shipped** — real mtimes + `ListFiles(since)` diff foundation; CAS layerstore + delta layers remain |
+| M2 layerstack snapshot layer (P1) | [#511](https://github.com/xiaods/k8e/issues/511) | **slices 1–3 shipped** — mtimes + ListFiles(since) (#515); CAS layerstore (#516); zstd-compressed layers (#521); wire delta + autosquash remain |
 | M4 PTY transcript + windowed replay (P1) | [#512](https://github.com/xiaods/k8e/issues/512) | **Wave 3: shipped** — file-backed transcript + GetTranscript RPC + `log` CLI (transcript window semantics; PTY master variant deferred) |
 | M5 observability (P1) | [#513](https://github.com/xiaods/k8e/issues/513) | **slice 1+2 shipped** — Prometheus collector (#517) + sandboxd NDJSON event stream (#518); query endpoint + process topology remain |
 | M1 workspace-session reuse (P1) | [#514](https://github.com/xiaods/k8e/issues/514) | open |

--- a/pkg/sandboxcli/snapshot_test.go
+++ b/pkg/sandboxcli/snapshot_test.go
@@ -1,6 +1,7 @@
 package sandboxcli
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +43,7 @@ func TestSnapshotStore_ContentAddressedDedup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	if string(got) != string(payload) {
+	if !bytes.Equal(got, payload) {
 		t.Fatal("zstd round-trip mismatch")
 	}
 }

--- a/pkg/sandboxcli/snapshot_test.go
+++ b/pkg/sandboxcli/snapshot_test.go
@@ -29,9 +29,21 @@ func TestSnapshotStore_ContentAddressedDedup(t *testing.T) {
 	if d1 != d2 {
 		t.Fatalf("same content must dedup to same digest: %s vs %s", d1, d2)
 	}
-	size, _ := store.SizeBytes()
-	if size != int64(len(payload)) {
-		t.Fatalf("expected deduped storage %d bytes, got %d", len(payload), size)
+	// Dedup: exactly one on-disk layer file despite two Put calls.
+	entries, err := os.ReadDir(filepath.Join(dir, ".layers", "layers"))
+	if err != nil {
+		t.Fatalf("read layer dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 deduped layer file, got %d", len(entries))
+	}
+	// Round-trip intact (zstd stored, transparently decompressed).
+	got, err := store.Get(d1)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatal("zstd round-trip mismatch")
 	}
 }
 

--- a/pkg/sandboxlayer/layerstore.go
+++ b/pkg/sandboxlayer/layerstore.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 // Store is a content-addressed layer store rooted at dir.
@@ -45,8 +47,10 @@ func Digest(b []byte) string {
 }
 
 // Put stages content and publishes it atomically under its sha256. Idempotent:
-// publishing an existing digest is a no-op. The layer file is fsync'd before
-// rename so a crash never leaves a torn layer under the final name.
+// publishing an existing digest is a no-op. The layer is stored zstd-compressed
+// (content-addressed by the UNCOMPRESSED digest, like OCI registries) so
+// dedup works on content and disk usage stays compact. The file is fsync'd
+// before rename so a crash never leaves a torn layer under the final name.
 func (s *Store) Put(content []byte) (string, error) {
 	digest := Digest(content)
 	layerPath := s.layerPath(digest)
@@ -54,6 +58,7 @@ func (s *Store) Put(content []byte) (string, error) {
 		return digest, nil // already present
 	}
 
+	compressed := compress(content)
 	tmp, err := os.CreateTemp(s.stagingDir(), "layer-")
 	if err != nil {
 		return "", fmt.Errorf("layerstore stage: %w", err)
@@ -61,7 +66,7 @@ func (s *Store) Put(content []byte) (string, error) {
 	tmpName := tmp.Name()
 	defer os.Remove(tmpName) // no-op after successful rename
 
-	if _, err := tmp.Write(content); err != nil {
+	if _, err := tmp.Write(compressed); err != nil {
 		tmp.Close() //nolint:errcheck
 		return "", fmt.Errorf("layerstore write: %w", err)
 	}
@@ -84,13 +89,13 @@ func (s *Store) Has(digest string) bool {
 	return err == nil
 }
 
-// Get returns the layer content for digest.
+// Get returns the (decompressed) layer content for digest.
 func (s *Store) Get(digest string) ([]byte, error) {
 	b, err := os.ReadFile(s.layerPath(digest))
 	if err != nil {
 		return nil, fmt.Errorf("layerstore get %s: %w", digest, err)
 	}
-	return b, nil
+	return decompress(b)
 }
 
 // Manifest is a content-addressed snapshot: an ordered list of layer digests
@@ -302,4 +307,31 @@ func trimExt(name string) string {
 		}
 	}
 	return name
+}
+
+// compress zstd-compresses layer content. The digest stays the sha256 of the
+// UNCOMPRESSED bytes so dedup is content-based (OCI-style).
+func compress(content []byte) []byte {
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		return content // never fail a store on compression
+	}
+	defer enc.Close()
+	return enc.EncodeAll(content, nil)
+}
+
+// decompress restores a layer stored zstd-compressed. Falls back to raw bytes
+// for layers written by older (uncompressed) versions.
+func decompress(b []byte) ([]byte, error) {
+	dec, err := zstd.NewReader(nil)
+	if err != nil {
+		return b, nil
+	}
+	defer dec.Close()
+	out, err := dec.DecodeAll(b, nil)
+	if err != nil {
+		// Not a valid zstd frame — treat as legacy uncompressed layer.
+		return b, nil
+	}
+	return out, nil
 }

--- a/pkg/sandboxlayer/layerstore_test.go
+++ b/pkg/sandboxlayer/layerstore_test.go
@@ -2,6 +2,7 @@ package sandboxlayer
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -197,8 +198,20 @@ func TestStore_SizeBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if total != 15 {
-		t.Fatalf("expected 15 bytes, got %d", total)
+	// Layers are zstd-compressed on disk (KIP-16 M2); SizeBytes sums the
+	// on-disk files, so it matches the actual layer directory.
+	entries, err := os.ReadDir(s.layerDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want int64
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil {
+			want += info.Size()
+		}
+	}
+	if total != want {
+		t.Fatalf("SizeBytes %d != on-disk %d", total, want)
 	}
 }
 
@@ -300,5 +313,52 @@ func TestStore_Autosquash_ReleasesOriginals(t *testing.T) {
 	m, _ := s.LoadManifest("snap-sq")
 	if !s.Has(m.Layers[0]) {
 		t.Fatal("consolidated layer must survive GC")
+	}
+}
+func TestStore_ZstdCompressedOnDisk(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	// Highly compressible payload: repeated text.
+	content := []byte(strings.Repeat("k8e-sandbox-layer-content-", 5000)) // ~125KB
+	d, err := s.Put(content)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err := s.Get(d)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatal("zstd round-trip mismatch")
+	}
+	info, err := os.Stat(s.layerPath(d))
+	if err != nil {
+		t.Fatalf("stat layer: %v", err)
+	}
+	if info.Size() >= int64(len(content)) {
+		t.Fatalf("expected compressed layer smaller than raw (%d >= %d)", info.Size(), len(content))
+	}
+}
+
+// TestStore_GetLegacyUncompressedLayer verifies decompress falls back to raw
+// bytes for layers written before zstd storage (backward compatibility).
+func TestStore_GetLegacyUncompressedLayer(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	legacy := []byte("legacy uncompressed layer content")
+	d := Digest(legacy)
+	if err := os.WriteFile(s.layerPath(d), legacy, 0o600); err != nil {
+		t.Fatalf("write legacy layer: %v", err)
+	}
+	got, err := s.Get(d)
+	if err != nil {
+		t.Fatalf("get legacy: %v", err)
+	}
+	if !bytes.Equal(got, legacy) {
+		t.Fatal("legacy layer fallback mismatch")
 	}
 }


### PR DESCRIPTION
## Summary

KIP-16 M2 slice 3 (issue #511): layers stored **zstd-compressed** in the content-addressed layerstore.

## What
- `Put`: writes zstd-compressed bytes, content-addressed by the **uncompressed** sha256 (OCI-style — dedup stays content-based)
- `Get`: transparently decompresses; falls back to raw bytes for legacy uncompressed layers (backward compatible)
- Disk savings on compressible workspace payloads; ready substrate for delta transfer

## Tests
- `TestStore_ZstdCompressedOnDisk`: round-trip + on-disk file smaller than raw (125KB repeated text)
- `TestStore_GetLegacyUncompressedLayer`: raw-byte fallback
- Updated: `TestStore_SizeBytes` (matches on-disk), `TestSnapshotStore_ContentAddressedDedup` (exactly one layer file)
- sandboxlayer/sandboxcli/sandboxmatrix all green

## Follow-ups (#511)
- `Delta` transfer over the wire (only missing compressed layers)
- Autosquash at N layers