### PR TITLE
feat(sandbox): server-side snapshot layer registry (KIP-16 M2, #511)

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -157,6 +157,8 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		DefaultMemory:  cfg.SandboxDefaultMemory,
 		GRPCPort:       cfg.SandboxGRPCPort,
 		Namespace:      cfg.SandboxNamespace,
+		// Server-side snapshot layer registry lives under the data dir.
+		LayerStoreDir: filepath.Join(cfg.DataDir, "server", "sandbox-layers"),
 	}
 	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
 	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -196,6 +196,9 @@ type SandboxConfig struct {
 	DefaultMemory  string
 	GRPCPort       int
 	Namespace      string
+	// LayerStoreDir, when set, enables the server-side content-addressed
+	// snapshot layer registry (KIP-16 M2 / issue #511).
+	LayerStoreDir string
 }
 
 type Control struct {
@@ -255,8 +258,8 @@ type Control struct {
 	ServerNodeName           string
 	VLevel                   int
 	VModule                  string
-	DisableSandboxMatrix bool
-	SandboxConfig        SandboxConfig
+	DisableSandboxMatrix     bool
+	SandboxConfig            SandboxConfig
 	// CiliumDNSProxyEnabled opts into the Cilium L7 DNS proxy (FQDN network
 	// policies). Off by default — see KIP-16 M10 / issue #510.
 	CiliumDNSProxyEnabled bool

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -84,6 +84,7 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 		ServerCertFile: tlsDir + "/sandbox-server.crt",
 		ServerKeyFile:  tlsDir + "/sandbox-server.key",
 		GRPCPort:       cfg.GRPCPort,
+		LayerStoreDir:  cfg.LayerStoreDir,
 	})
 	go func() {
 		if err := srv.Start(ctx); err != nil {

--- a/pkg/sandboxmatrix/grpc/env_test.go
+++ b/pkg/sandboxmatrix/grpc/env_test.go
@@ -15,7 +15,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xiaods/k8e/pkg/metrics"
+	"github.com/xiaods/k8e/pkg/sandboxlayer"
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestValidateSessionEnv(t *testing.T) {
@@ -566,5 +569,52 @@ func TestGetEvents_NoEvents(t *testing.T) {
 	}
 	if len(resp.Events) != 0 || resp.Returned != 0 {
 		t.Fatalf("expected empty events, got %+v", resp)
+	}
+}
+
+// TestSnapshotRPCs_LayerRegistry verifies the server-side snapshot registry
+// (KIP-16 M2): put/list/get manifest round-trip.
+func TestSnapshotRPCs_LayerRegistry(t *testing.T) {
+	s := newTestServer()
+	ls, err := sandboxlayer.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("layerstore: %v", err)
+	}
+	s.layerStore = ls
+	ctx := context.Background()
+
+	// Publish a manifest referencing two layer digests.
+	put, err := s.SnapshotPut(ctx, &pb.SnapshotPutRequest{Name: "snap-rpc", Layers: []string{"abc", "def"}})
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if put.Layers != 2 {
+		t.Fatalf("expected 2 layers published, got %d", put.Layers)
+	}
+
+	list, err := s.SnapshotList(ctx, &pb.SnapshotListRequest{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Names) != 1 || list.Names[0] != "snap-rpc" {
+		t.Fatalf("unexpected manifests: %v", list.Names)
+	}
+
+	got, err := s.SnapshotGet(ctx, &pb.SnapshotGetRequest{Name: "snap-rpc"})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Layers) != 2 || got.Layers[0] != "abc" || got.Layers[1] != "def" {
+		t.Fatalf("unexpected layers: %v", got.Layers)
+	}
+}
+
+// TestSnapshotRPCs_DisabledRegistry verifies a clear error when the registry
+// is not enabled.
+func TestSnapshotRPCs_DisabledRegistry(t *testing.T) {
+	s := newTestServer() // layerStore nil
+	_, err := s.SnapshotList(context.Background(), &pb.SnapshotListRequest{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("expected FailedPrecondition, got %v", err)
 	}
 }

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -2086,6 +2086,288 @@ func (x *GetEventsResponse) GetReturned() int64 {
 	return 0
 }
 
+// SnapshotPutRequest stores one content-addressed layer (or a whole chunked
+// manifest) in the server-side registry.
+type SnapshotPutRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`     // snapshot name (manifest id)
+	Layers        []string               `protobuf:"bytes,2,rep,name=layers,proto3" json:"layers,omitempty"` // layer digests to publish as this snapshot's manifest
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotPutRequest) Reset() {
+	*x = SnapshotPutRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotPutRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotPutRequest) ProtoMessage() {}
+
+func (x *SnapshotPutRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotPutRequest.ProtoReflect.Descriptor instead.
+func (*SnapshotPutRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *SnapshotPutRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SnapshotPutRequest) GetLayers() []string {
+	if x != nil {
+		return x.Layers
+	}
+	return nil
+}
+
+type SnapshotPutResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Layers        int64                  `protobuf:"varint,2,opt,name=layers,proto3" json:"layers,omitempty"` // number of layers published
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotPutResponse) Reset() {
+	*x = SnapshotPutResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotPutResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotPutResponse) ProtoMessage() {}
+
+func (x *SnapshotPutResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotPutResponse.ProtoReflect.Descriptor instead.
+func (*SnapshotPutResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *SnapshotPutResponse) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SnapshotPutResponse) GetLayers() int64 {
+	if x != nil {
+		return x.Layers
+	}
+	return 0
+}
+
+type SnapshotGetRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"` // manifest name
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotGetRequest) Reset() {
+	*x = SnapshotGetRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotGetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotGetRequest) ProtoMessage() {}
+
+func (x *SnapshotGetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotGetRequest.ProtoReflect.Descriptor instead.
+func (*SnapshotGetRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *SnapshotGetRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type SnapshotGetResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Layers        []string               `protobuf:"bytes,2,rep,name=layers,proto3" json:"layers,omitempty"` // ordered layer digests of the manifest
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotGetResponse) Reset() {
+	*x = SnapshotGetResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotGetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotGetResponse) ProtoMessage() {}
+
+func (x *SnapshotGetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotGetResponse.ProtoReflect.Descriptor instead.
+func (*SnapshotGetResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *SnapshotGetResponse) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SnapshotGetResponse) GetLayers() []string {
+	if x != nil {
+		return x.Layers
+	}
+	return nil
+}
+
+type SnapshotListRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotListRequest) Reset() {
+	*x = SnapshotListRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotListRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotListRequest) ProtoMessage() {}
+
+func (x *SnapshotListRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotListRequest.ProtoReflect.Descriptor instead.
+func (*SnapshotListRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{39}
+}
+
+type SnapshotListResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Names         []string               `protobuf:"bytes,1,rep,name=names,proto3" json:"names,omitempty"` // manifest names
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotListResponse) Reset() {
+	*x = SnapshotListResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotListResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotListResponse) ProtoMessage() {}
+
+func (x *SnapshotListResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotListResponse.ProtoReflect.Descriptor instead.
+func (*SnapshotListResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *SnapshotListResponse) GetNames() []string {
+	if x != nil {
+		return x.Names
+	}
+	return nil
+}
+
 var File_sandbox_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_sandbox_v1_sandbox_proto_rawDesc = "" +
@@ -2258,8 +2540,21 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\x11GetEventsResponse\x12\x16\n" +
 	"\x06events\x18\x01 \x03(\tR\x06events\x12\x1c\n" +
 	"\ttruncated\x18\x02 \x01(\bR\ttruncated\x12\x1a\n" +
-	"\breturned\x18\x03 \x01(\x03R\breturned2\xa9\n" +
-	"\n" +
+	"\breturned\x18\x03 \x01(\x03R\breturned\"@\n" +
+	"\x12SnapshotPutRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06layers\x18\x02 \x03(\tR\x06layers\"A\n" +
+	"\x13SnapshotPutResponse\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06layers\x18\x02 \x01(\x03R\x06layers\"(\n" +
+	"\x12SnapshotGetRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"A\n" +
+	"\x13SnapshotGetResponse\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06layers\x18\x02 \x03(\tR\x06layers\"\x15\n" +
+	"\x13SnapshotListRequest\",\n" +
+	"\x14SnapshotListResponse\x12\x14\n" +
+	"\x05names\x18\x01 \x03(\tR\x05names2\x9c\f\n" +
 	"\x0eSandboxService\x12T\n" +
 	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12K\n" +
 	"\n" +
@@ -2280,7 +2575,10 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\x05Login\x12\x18.sandbox.v1.LoginRequest\x1a\x19.sandbox.v1.LoginResponse\x12B\n" +
 	"\aPollRun\x12\x1a.sandbox.v1.PollRunRequest\x1a\x1b.sandbox.v1.PollRunResponse\x12T\n" +
 	"\rGetTranscript\x12 .sandbox.v1.GetTranscriptRequest\x1a!.sandbox.v1.GetTranscriptResponse\x12H\n" +
-	"\tGetEvents\x12\x1c.sandbox.v1.GetEventsRequest\x1a\x1d.sandbox.v1.GetEventsResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
+	"\tGetEvents\x12\x1c.sandbox.v1.GetEventsRequest\x1a\x1d.sandbox.v1.GetEventsResponse\x12N\n" +
+	"\vSnapshotPut\x12\x1e.sandbox.v1.SnapshotPutRequest\x1a\x1f.sandbox.v1.SnapshotPutResponse\x12N\n" +
+	"\vSnapshotGet\x12\x1e.sandbox.v1.SnapshotGetRequest\x1a\x1f.sandbox.v1.SnapshotGetResponse\x12Q\n" +
+	"\fSnapshotList\x12\x1f.sandbox.v1.SnapshotListRequest\x1a .sandbox.v1.SnapshotListResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
 
 var (
 	file_sandbox_v1_sandbox_proto_rawDescOnce sync.Once
@@ -2294,7 +2592,7 @@ func file_sandbox_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_sandbox_v1_sandbox_proto_rawDescData
 }
 
-var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*SecretRef)(nil),              // 0: sandbox.v1.SecretRef
 	(*CreateSessionRequest)(nil),   // 1: sandbox.v1.CreateSessionRequest
@@ -2331,10 +2629,16 @@ var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*GetTranscriptResponse)(nil),  // 32: sandbox.v1.GetTranscriptResponse
 	(*GetEventsRequest)(nil),       // 33: sandbox.v1.GetEventsRequest
 	(*GetEventsResponse)(nil),      // 34: sandbox.v1.GetEventsResponse
-	nil,                            // 35: sandbox.v1.CreateSessionRequest.EnvEntry
+	(*SnapshotPutRequest)(nil),     // 35: sandbox.v1.SnapshotPutRequest
+	(*SnapshotPutResponse)(nil),    // 36: sandbox.v1.SnapshotPutResponse
+	(*SnapshotGetRequest)(nil),     // 37: sandbox.v1.SnapshotGetRequest
+	(*SnapshotGetResponse)(nil),    // 38: sandbox.v1.SnapshotGetResponse
+	(*SnapshotListRequest)(nil),    // 39: sandbox.v1.SnapshotListRequest
+	(*SnapshotListResponse)(nil),   // 40: sandbox.v1.SnapshotListResponse
+	nil,                            // 41: sandbox.v1.CreateSessionRequest.EnvEntry
 }
 var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
-	35, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
+	41, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
 	0,  // 1: sandbox.v1.CreateSessionRequest.secret_refs:type_name -> sandbox.v1.SecretRef
 	4,  // 2: sandbox.v1.ListSessionsResponse.sessions:type_name -> sandbox.v1.GetSessionResponse
 	18, // 3: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
@@ -2355,25 +2659,31 @@ var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
 	29, // 18: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
 	31, // 19: sandbox.v1.SandboxService.GetTranscript:input_type -> sandbox.v1.GetTranscriptRequest
 	33, // 20: sandbox.v1.SandboxService.GetEvents:input_type -> sandbox.v1.GetEventsRequest
-	2,  // 21: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
-	4,  // 22: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
-	6,  // 23: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
-	8,  // 24: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
-	10, // 25: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
-	11, // 26: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
-	13, // 27: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
-	15, // 28: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
-	17, // 29: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
-	20, // 30: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
-	22, // 31: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
-	24, // 32: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
-	26, // 33: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	28, // 34: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
-	30, // 35: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
-	32, // 36: sandbox.v1.SandboxService.GetTranscript:output_type -> sandbox.v1.GetTranscriptResponse
-	34, // 37: sandbox.v1.SandboxService.GetEvents:output_type -> sandbox.v1.GetEventsResponse
-	21, // [21:38] is the sub-list for method output_type
-	4,  // [4:21] is the sub-list for method input_type
+	35, // 21: sandbox.v1.SandboxService.SnapshotPut:input_type -> sandbox.v1.SnapshotPutRequest
+	37, // 22: sandbox.v1.SandboxService.SnapshotGet:input_type -> sandbox.v1.SnapshotGetRequest
+	39, // 23: sandbox.v1.SandboxService.SnapshotList:input_type -> sandbox.v1.SnapshotListRequest
+	2,  // 24: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
+	4,  // 25: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
+	6,  // 26: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
+	8,  // 27: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
+	10, // 28: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
+	11, // 29: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
+	13, // 30: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
+	15, // 31: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
+	17, // 32: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
+	20, // 33: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
+	22, // 34: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
+	24, // 35: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
+	26, // 36: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
+	28, // 37: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
+	30, // 38: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
+	32, // 39: sandbox.v1.SandboxService.GetTranscript:output_type -> sandbox.v1.GetTranscriptResponse
+	34, // 40: sandbox.v1.SandboxService.GetEvents:output_type -> sandbox.v1.GetEventsResponse
+	36, // 41: sandbox.v1.SandboxService.SnapshotPut:output_type -> sandbox.v1.SnapshotPutResponse
+	38, // 42: sandbox.v1.SandboxService.SnapshotGet:output_type -> sandbox.v1.SnapshotGetResponse
+	40, // 43: sandbox.v1.SandboxService.SnapshotList:output_type -> sandbox.v1.SnapshotListResponse
+	24, // [24:44] is the sub-list for method output_type
+	4,  // [4:24] is the sub-list for method input_type
 	4,  // [4:4] is the sub-list for extension type_name
 	4,  // [4:4] is the sub-list for extension extendee
 	0,  // [0:4] is the sub-list for field type_name
@@ -2390,7 +2700,7 @@ func file_sandbox_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_v1_sandbox_proto_rawDesc), len(file_sandbox_v1_sandbox_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   36,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
@@ -36,6 +36,9 @@ const (
 	SandboxService_PollRun_FullMethodName        = "/sandbox.v1.SandboxService/PollRun"
 	SandboxService_GetTranscript_FullMethodName  = "/sandbox.v1.SandboxService/GetTranscript"
 	SandboxService_GetEvents_FullMethodName      = "/sandbox.v1.SandboxService/GetEvents"
+	SandboxService_SnapshotPut_FullMethodName    = "/sandbox.v1.SandboxService/SnapshotPut"
+	SandboxService_SnapshotGet_FullMethodName    = "/sandbox.v1.SandboxService/SnapshotGet"
+	SandboxService_SnapshotList_FullMethodName   = "/sandbox.v1.SandboxService/SnapshotList"
 )
 
 // SandboxServiceClient is the client API for SandboxService service.
@@ -67,6 +70,11 @@ type SandboxServiceClient interface {
 	// GetEvents reads the daemon's NDJSON event stream (exec/files/bg events;
 	// KIP-16 M5 / issue #513).
 	GetEvents(ctx context.Context, in *GetEventsRequest, opts ...grpc.CallOption) (*GetEventsResponse, error)
+	// Snapshot layer registry (server-side, KIP-16 M2 / issue #511):
+	// content-addressed snapshot artifacts hosted by the gateway.
+	SnapshotPut(ctx context.Context, in *SnapshotPutRequest, opts ...grpc.CallOption) (*SnapshotPutResponse, error)
+	SnapshotGet(ctx context.Context, in *SnapshotGetRequest, opts ...grpc.CallOption) (*SnapshotGetResponse, error)
+	SnapshotList(ctx context.Context, in *SnapshotListRequest, opts ...grpc.CallOption) (*SnapshotListResponse, error)
 }
 
 type sandboxServiceClient struct {
@@ -256,6 +264,36 @@ func (c *sandboxServiceClient) GetEvents(ctx context.Context, in *GetEventsReque
 	return out, nil
 }
 
+func (c *sandboxServiceClient) SnapshotPut(ctx context.Context, in *SnapshotPutRequest, opts ...grpc.CallOption) (*SnapshotPutResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SnapshotPutResponse)
+	err := c.cc.Invoke(ctx, SandboxService_SnapshotPut_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) SnapshotGet(ctx context.Context, in *SnapshotGetRequest, opts ...grpc.CallOption) (*SnapshotGetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SnapshotGetResponse)
+	err := c.cc.Invoke(ctx, SandboxService_SnapshotGet_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) SnapshotList(ctx context.Context, in *SnapshotListRequest, opts ...grpc.CallOption) (*SnapshotListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SnapshotListResponse)
+	err := c.cc.Invoke(ctx, SandboxService_SnapshotList_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SandboxServiceServer is the server API for SandboxService service.
 // All implementations must embed UnimplementedSandboxServiceServer
 // for forward compatibility.
@@ -285,6 +323,11 @@ type SandboxServiceServer interface {
 	// GetEvents reads the daemon's NDJSON event stream (exec/files/bg events;
 	// KIP-16 M5 / issue #513).
 	GetEvents(context.Context, *GetEventsRequest) (*GetEventsResponse, error)
+	// Snapshot layer registry (server-side, KIP-16 M2 / issue #511):
+	// content-addressed snapshot artifacts hosted by the gateway.
+	SnapshotPut(context.Context, *SnapshotPutRequest) (*SnapshotPutResponse, error)
+	SnapshotGet(context.Context, *SnapshotGetRequest) (*SnapshotGetResponse, error)
+	SnapshotList(context.Context, *SnapshotListRequest) (*SnapshotListResponse, error)
 	mustEmbedUnimplementedSandboxServiceServer()
 }
 
@@ -345,6 +388,15 @@ func (UnimplementedSandboxServiceServer) GetTranscript(context.Context, *GetTran
 }
 func (UnimplementedSandboxServiceServer) GetEvents(context.Context, *GetEventsRequest) (*GetEventsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetEvents not implemented")
+}
+func (UnimplementedSandboxServiceServer) SnapshotPut(context.Context, *SnapshotPutRequest) (*SnapshotPutResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SnapshotPut not implemented")
+}
+func (UnimplementedSandboxServiceServer) SnapshotGet(context.Context, *SnapshotGetRequest) (*SnapshotGetResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SnapshotGet not implemented")
+}
+func (UnimplementedSandboxServiceServer) SnapshotList(context.Context, *SnapshotListRequest) (*SnapshotListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SnapshotList not implemented")
 }
 func (UnimplementedSandboxServiceServer) mustEmbedUnimplementedSandboxServiceServer() {}
 func (UnimplementedSandboxServiceServer) testEmbeddedByValue()                        {}
@@ -666,6 +718,60 @@ func _SandboxService_GetEvents_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SandboxService_SnapshotPut_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SnapshotPutRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).SnapshotPut(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_SnapshotPut_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).SnapshotPut(ctx, req.(*SnapshotPutRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_SnapshotGet_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SnapshotGetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).SnapshotGet(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_SnapshotGet_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).SnapshotGet(ctx, req.(*SnapshotGetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_SnapshotList_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SnapshotListRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).SnapshotList(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_SnapshotList_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).SnapshotList(ctx, req.(*SnapshotListRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SandboxService_ServiceDesc is the grpc.ServiceDesc for SandboxService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -736,6 +842,18 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetEvents",
 			Handler:    _SandboxService_GetEvents_Handler,
+		},
+		{
+			MethodName: "SnapshotPut",
+			Handler:    _SandboxService_SnapshotPut_Handler,
+		},
+		{
+			MethodName: "SnapshotGet",
+			Handler:    _SandboxService_SnapshotGet_Handler,
+		},
+		{
+			MethodName: "SnapshotList",
+			Handler:    _SandboxService_SnapshotList_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/xiaods/k8e/pkg/sandboxlayer"
 	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"github.com/xiaods/k8e/pkg/sandboxmatrix/ratelimit"
@@ -108,6 +109,9 @@ type ServerConfig struct {
 	ServerKeyFile  string
 	GRPCPort       int
 	LocalAuth      bool // allow loopback connections without client cert
+	// LayerStoreDir, when set, enables the server-side content-addressed
+	// snapshot layer registry (KIP-16 M2 / issue #511).
+	LayerStoreDir string
 }
 
 // Server implements the SandboxService gRPC interface.
@@ -128,6 +132,7 @@ type Server struct {
 	revocList      *RevocationList
 	localAuth      bool
 	rateLimiter    *ratelimit.Limiter
+	layerStore     *sandboxlayer.Store
 }
 
 func NewServer(cfg ServerConfig) *Server {
@@ -148,6 +153,11 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 	s.orch = NewOrchestrator(cfg.K8s, cfg.Dyn)
 	RegisterSandboxMetrics(s.orch)
+	if cfg.LayerStoreDir != "" {
+		if ls, err := sandboxlayer.New(cfg.LayerStoreDir); err == nil {
+			s.layerStore = ls
+		}
+	}
 	return s
 }
 
@@ -683,6 +693,58 @@ func (s *Server) GetEvents(ctx context.Context, req *pb.GetEventsRequest) (*pb.G
 		Returned:  int64(len(lines)),
 		Truncated: int64(len(lines)) == limit,
 	}, nil
+}
+
+// requireLayerStore returns an error when the server-side layer registry is
+// not enabled (ServerConfig.LayerStoreDir unset).
+func (s *Server) requireLayerStore() (*sandboxlayer.Store, error) {
+	if s.layerStore == nil {
+		return nil, status.Error(codes.FailedPrecondition,
+			"server-side snapshot registry disabled; set ServerConfig.LayerStoreDir")
+	}
+	return s.layerStore, nil
+}
+
+// SnapshotPut publishes a snapshot manifest (its layer list) to the server-side
+// registry (KIP-16 M2 / issue #511).
+func (s *Server) SnapshotPut(ctx context.Context, req *pb.SnapshotPutRequest) (*pb.SnapshotPutResponse, error) {
+	store, err := s.requireLayerStore()
+	if err != nil {
+		return nil, err
+	}
+	if req.Name == "" || len(req.Layers) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "name and layers required")
+	}
+	if err := store.SaveManifest(req.Name, req.Layers); err != nil {
+		return nil, status.Errorf(codes.Internal, "snapshot put: %v", err)
+	}
+	return &pb.SnapshotPutResponse{Name: req.Name, Layers: int64(len(req.Layers))}, nil
+}
+
+// SnapshotGet returns a snapshot manifest's ordered layer list.
+func (s *Server) SnapshotGet(ctx context.Context, req *pb.SnapshotGetRequest) (*pb.SnapshotGetResponse, error) {
+	store, err := s.requireLayerStore()
+	if err != nil {
+		return nil, err
+	}
+	m, err := store.LoadManifest(req.Name)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "snapshot %s: %v", req.Name, err)
+	}
+	return &pb.SnapshotGetResponse{Name: req.Name, Layers: m.Layers}, nil
+}
+
+// SnapshotList returns all snapshot manifest names in the registry.
+func (s *Server) SnapshotList(ctx context.Context, req *pb.SnapshotListRequest) (*pb.SnapshotListResponse, error) {
+	store, err := s.requireLayerStore()
+	if err != nil {
+		return nil, err
+	}
+	names, err := store.ListManifests()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "snapshot list: %v", err)
+	}
+	return &pb.SnapshotListResponse{Names: names}, nil
 }
 
 // PollRun checks the status of a background execution.

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -28,6 +28,11 @@ service SandboxService {
   // GetEvents reads the daemon's NDJSON event stream (exec/files/bg events;
   // KIP-16 M5 / issue #513).
   rpc GetEvents(GetEventsRequest)           returns (GetEventsResponse);
+  // Snapshot layer registry (server-side, KIP-16 M2 / issue #511):
+  // content-addressed snapshot artifacts hosted by the gateway.
+  rpc SnapshotPut(SnapshotPutRequest)       returns (SnapshotPutResponse);
+  rpc SnapshotGet(SnapshotGetRequest)       returns (SnapshotGetResponse);
+  rpc SnapshotList(SnapshotListRequest)     returns (SnapshotListResponse);
 }
 
 // SecretRef references a key in a same-namespace K8s Secret. Values are resolved
@@ -198,4 +203,28 @@ message GetEventsResponse {
   repeated string events = 1; // raw NDJSON lines
   bool   truncated       = 2; // more events exist beyond the returned window
   int64  returned        = 3; // number of lines returned
+}
+
+// SnapshotPutRequest stores one content-addressed layer (or a whole chunked
+// manifest) in the server-side registry.
+message SnapshotPutRequest {
+  string name    = 1; // snapshot name (manifest id)
+  repeated string layers = 2; // layer digests to publish as this snapshot's manifest
+}
+message SnapshotPutResponse {
+  string name = 1;
+  int64  layers = 2; // number of layers published
+}
+
+message SnapshotGetRequest {
+  string name = 1; // manifest name
+}
+message SnapshotGetResponse {
+  string name   = 1;
+  repeated string layers = 2; // ordered layer digests of the manifest
+}
+
+message SnapshotListRequest {}
+message SnapshotListResponse {
+  repeated string names = 1; // manifest names
 }


### PR DESCRIPTION
## Summary

KIP-16 M2 slice 5 (issue #511): the gateway hosts a **server-side content-addressed snapshot layer registry** — snapshots become server-side artifacts instead of living only in the CLI's local file store.

## What
- `ServerConfig.LayerStoreDir` / `SandboxConfig.LayerStoreDir` (default `<dataDir>/server/sandbox-layers`) enables the registry
- New gRPC RPCs:
  - `SnapshotPut(name, layers)` — publish a snapshot manifest
  - `SnapshotGet(name)` — fetch a manifest's ordered layer list
  - `SnapshotList()` — registry contents
- `requireLayerStore` → `FailedPrecondition` when disabled (no behavior change for existing deployments)

## Why
Enables shared registries (multi-host snapshot reuse), wire-level incremental restore (fetch only missing layers via gateway), and server-side GC of unreferenced layers.

## Tests
- `TestSnapshotRPCs_LayerRegistry`: put → list → get round-trip
- `TestSnapshotRPCs_DisabledRegistry`: FailedPrecondition
- All sandboxmatrix/sandboxcli/sandboxlayer/daemons-config green

## Follow-ups (#511)
- CLI publish/query via the gateway (replace local store)
- Autosquash at N layers