### PR TITLE
feat(sandbox): autosquash manifests past threshold (KIP-16 M2, #511)

### DIFF
--- a/pkg/sandboxlayer/layerstore.go
+++ b/pkg/sandboxlayer/layerstore.go
@@ -103,9 +103,23 @@ type Manifest struct {
 // ManifestVersion is the current manifest schema.
 const ManifestVersion = 1
 
+// SquashThreshold is the max layers a manifest may hold before SaveManifest
+// squashes it into a single consolidated layer (mirrors ephemeral-sandbox's
+// squash_at_n_layers). Bounds manifest size and restore cost.
+const SquashThreshold = 32
+
 // SaveManifest writes a manifest under manifests/<name>.json (atomic: tmp +
 // rename). Layers referenced by any saved manifest are protected from GC.
+// When the layer count exceeds SquashThreshold, the layers are squashed into
+// one consolidated layer first (KIP-16 M2 autosquash).
 func (s *Store) SaveManifest(name string, layers []string) error {
+	if len(layers) > SquashThreshold {
+		consolidated, err := s.squash(layers)
+		if err != nil {
+			return err
+		}
+		layers = []string{consolidated}
+	}
 	m := Manifest{SchemaVersion: ManifestVersion, Layers: layers}
 	b, err := json.Marshal(m)
 	if err != nil {
@@ -260,6 +274,25 @@ func (s *Store) manifestDir() string {
 }
 func (s *Store) layerPath(digest string) string {
 	return filepath.Join(s.layerDir(), digest)
+}
+
+// squash consolidates layers into a single layer containing their
+// concatenated (decompressed) content. Used by autosquash to bound manifest
+// growth; the original layers become unreferenced and are reclaimed by GC.
+func (s *Store) squash(layers []string) (string, error) {
+	var out []byte
+	for _, d := range layers {
+		b, err := s.Get(d)
+		if err != nil {
+			return "", fmt.Errorf("layerstore squash get %s: %w", d, err)
+		}
+		out = append(out, b...)
+	}
+	digest, err := s.Put(out)
+	if err != nil {
+		return "", fmt.Errorf("layerstore squash put: %w", err)
+	}
+	return digest, nil
 }
 
 func trimExt(name string) string {

--- a/pkg/sandboxlayer/layerstore_test.go
+++ b/pkg/sandboxlayer/layerstore_test.go
@@ -222,3 +222,83 @@ func TestStore_LargeContentRoundTrip(t *testing.T) {
 		t.Fatalf("size mismatch: %d vs %d", len(got), len(content))
 	}
 }
+
+// TestStore_Autosquash verifies SaveManifest squashes over-threshold layer
+// counts into a single consolidated layer (KIP-16 M2 autosquash, mirroring
+// ephemeral-sandbox squash_at_n_layers).
+func TestStore_Autosquash(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	// Exactly at threshold: no squash.
+	atThreshold := make([]string, SquashThreshold)
+	for i := range atThreshold {
+		d, _ := s.Put([]byte{byte(i)})
+		atThreshold[i] = d
+	}
+	if err := s.SaveManifest("snap-at", atThreshold); err != nil {
+		t.Fatalf("save at threshold: %v", err)
+	}
+	mAt, _ := s.LoadManifest("snap-at")
+	if len(mAt.Layers) != SquashThreshold {
+		t.Fatalf("at threshold must not squash: %d layers", len(mAt.Layers))
+	}
+
+	// One over threshold: squashed to a single consolidated layer.
+	over := make([]string, SquashThreshold+1)
+	for i := range over {
+		d, _ := s.Put([]byte{byte(200 + i)})
+		over[i] = d
+	}
+	if err := s.SaveManifest("snap-over", over); err != nil {
+		t.Fatalf("save over threshold: %v", err)
+	}
+	mOver, _ := s.LoadManifest("snap-over")
+	if len(mOver.Layers) != 1 {
+		t.Fatalf("over threshold must squash to 1 layer, got %d", len(mOver.Layers))
+	}
+	// Consolidated content must reconstruct the concatenation.
+	got, err := s.Get(mOver.Layers[0])
+	if err != nil {
+		t.Fatalf("get consolidated: %v", err)
+	}
+	var want []byte
+	for i := range over {
+		want = append(want, byte(200+i))
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("squashed layer content mismatch")
+	}
+}
+
+// TestStore_Autosquash_ReleasesOriginals verifies the original over-threshold
+// layers become unreferenced and are reclaimed by GC.
+func TestStore_Autosquash_ReleasesOriginals(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	layers := make([]string, SquashThreshold+1)
+	for i := range layers {
+		d, _ := s.Put([]byte{byte(100 + i)})
+		layers[i] = d
+	}
+	if err := s.SaveManifest("snap-sq", layers); err != nil {
+		t.Fatal(err)
+	}
+	// GC should reclaim the squashed-away originals (only the consolidated
+	// layer is referenced now).
+	if _, err := s.GC(); err != nil {
+		t.Fatalf("gc: %v", err)
+	}
+	for _, d := range layers {
+		if s.Has(d) {
+			t.Fatalf("squashed-original layer %s must be reclaimed", d)
+		}
+	}
+	m, _ := s.LoadManifest("snap-sq")
+	if !s.Has(m.Layers[0]) {
+		t.Fatal("consolidated layer must survive GC")
+	}
+}


### PR DESCRIPTION
## Summary

KIP-16 M2 slice 6 (issue #511): **autosquash** — the final layerstack mechanism from ephemeral-sandbox (`squash_at_n_layers`).

## What
- `SaveManifest` squashes layer lists exceeding `SquashThreshold` (32) into a **single consolidated layer** (concatenated content, re-stored content-addressed)
- Bounds manifest size and restore cost — a long chain of incremental snapshots never grows unbounded
- Squashed-away original layers become unreferenced → reclaimed by lease-driven GC

## Tests
- `TestStore_Autosquash`: at-threshold preserved (32 layers), over-threshold squashed to 1 layer with intact content
- `TestStore_Autosquash_ReleasesOriginals`: GC reclaims originals, consolidated survives
- sandboxlayer/sandboxcli/sandboxmatrix all green

## M2 status
All layerstack mechanisms now present: CAS layers (#516), zstd (#521), chunked+delta (#522), server registry (#523), autosquash (this PR).