### PR TITLE
feat(sandbox): enforce allowed_hosts via Cilium toFQDNs (KIP-16 M10, #510)

### DIFF
--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -158,7 +158,8 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		GRPCPort:       cfg.SandboxGRPCPort,
 		Namespace:      cfg.SandboxNamespace,
 		// Server-side snapshot layer registry lives under the data dir.
-		LayerStoreDir: filepath.Join(cfg.DataDir, "server", "sandbox-layers"),
+		LayerStoreDir:         filepath.Join(cfg.DataDir, "server", "sandbox-layers"),
+		CiliumDNSProxyEnabled: cfg.CiliumDNSProxyEnabled,
 	}
 	serverConfig.ControlConfig.EtcdExposeMetrics = cfg.EtcdExposeMetrics
 	serverConfig.ControlConfig.EtcdDisableSnapshots = cfg.EtcdDisableSnapshots

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -199,6 +199,9 @@ type SandboxConfig struct {
 	// LayerStoreDir, when set, enables the server-side content-addressed
 	// snapshot layer registry (KIP-16 M2 / issue #511).
 	LayerStoreDir string
+	// CiliumDNSProxyEnabled opts into Cilium toFQDNs egress enforcement for
+	// sessions with allowedHosts (KIP-16 M10 / issue #510).
+	CiliumDNSProxyEnabled bool
 }
 
 type Control struct {

--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -85,6 +85,7 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 		ServerKeyFile:  tlsDir + "/sandbox-server.key",
 		GRPCPort:       cfg.GRPCPort,
 		LayerStoreDir:  cfg.LayerStoreDir,
+		FQDNEnabled:    cfg.CiliumDNSProxyEnabled,
 	})
 	go func() {
 		if err := srv.Start(ctx); err != nil {

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -105,6 +105,10 @@ type Orchestrator struct {
 	// session. Matches the KIP-16 M12 recommendation (capped, reaped
 	// background execution) and KIP-15 G9 Perplexity parity.
 	maxBackgroundRuns int
+
+	// fqdnEgressEnabled enables Cilium toFQDNs egress rules for sessions with
+	// allowedHosts (requires the Cilium DNS proxy; see KIP-16 M10 / #510).
+	fqdnEgressEnabled bool
 }
 
 func NewOrchestrator(k8s kubernetes.Interface, dyn dynamic.Interface) *Orchestrator {
@@ -186,6 +190,21 @@ func PodReadyCondition(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// SetFQDNEGressEnabled toggles Cilium toFQDNs enforcement for allowedHosts.
+// When false (default), egress stays blanket world:53/443 regardless of
+// allowedHosts (KIP-16 M10 / issue #510).
+func (o *Orchestrator) SetFQDNEGressEnabled(enabled bool) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.fqdnEgressEnabled = enabled
+}
+
+func (o *Orchestrator) fqdnEnabled() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.fqdnEgressEnabled
 }
 
 // defaultTTL is used when the session has no explicit TTL (0 = no expiry).
@@ -939,7 +958,7 @@ func (o *Orchestrator) ensureWorkspacePVC(ctx context.Context, sessionID string)
 }
 
 func (o *Orchestrator) applyCNP(ctx context.Context, session *sandboxv1.SandboxSession) error {
-	obj := buildSessionCNP(session)
+	obj := buildSessionCNP(session, o.fqdnEnabled())
 	name := fmt.Sprintf("sandbox-session-%s", session.Name)
 	_, err := o.dynamic.Resource(cnpGVR).Namespace(session.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
@@ -959,7 +978,44 @@ func (o *Orchestrator) applyCNP(ctx context.Context, session *sandboxv1.SandboxS
 // enabled in 9f5b7f41 and reverted in 2b3bfb0a because it broke DNS in gVisor
 // pods. Operators who re-enable the DNS proxy (see manifests/cilium.yaml
 // dnsProxy.enabled) can tighten egress further; see KIP-16 M10 / issue #510.
-func buildSessionCNP(session *sandboxv1.SandboxSession) *unstructured.Unstructured {
+func buildSessionCNP(session *sandboxv1.SandboxSession, fqdnEnabled bool) *unstructured.Unstructured {
+	// Egress: DNS (53) always to world. HTTPS (443) is either blanket world
+	// (default) or scoped toFQDNs when FQDN egress is enabled AND the session
+	// declares allowedHosts (KIP-16 M10 / issue #510).
+	egress := []interface{}{
+		map[string]interface{}{
+			"toEntities": []interface{}{"world"},
+			"toPorts": []interface{}{
+				map[string]interface{}{
+					"ports": []interface{}{map[string]interface{}{"port": "53", "protocol": "ANY"}},
+				},
+			},
+		},
+	}
+	if fqdnEnabled && len(session.Spec.AllowedHosts) > 0 {
+		// Scoped egress: only the declared hosts, via Cilium FQDN rules.
+		fqdns := make([]interface{}, 0, len(session.Spec.AllowedHosts))
+		for _, h := range session.Spec.AllowedHosts {
+			fqdns = append(fqdns, map[string]interface{}{"matchName": h})
+		}
+		egress = append(egress, map[string]interface{}{
+			"toFQDNs": fqdns,
+			"toPorts": []interface{}{
+				map[string]interface{}{
+					"ports": []interface{}{map[string]interface{}{"port": "443", "protocol": "TCP"}},
+				},
+			},
+		})
+	} else {
+		egress = append(egress, map[string]interface{}{
+			"toEntities": []interface{}{"world"},
+			"toPorts": []interface{}{
+				map[string]interface{}{
+					"ports": []interface{}{map[string]interface{}{"port": "443", "protocol": "TCP"}},
+				},
+			},
+		})
+	}
 	return &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "cilium.io/v2",
 		"kind":       "CiliumNetworkPolicy",
@@ -995,24 +1051,7 @@ func buildSessionCNP(session *sandboxv1.SandboxSession) *unstructured.Unstructur
 					},
 				},
 			},
-			"egress": []interface{}{
-				map[string]interface{}{
-					"toEntities": []interface{}{"world"},
-					"toPorts": []interface{}{
-						map[string]interface{}{
-							"ports": []interface{}{map[string]interface{}{"port": "53", "protocol": "ANY"}},
-						},
-					},
-				},
-				map[string]interface{}{
-					"toEntities": []interface{}{"world"},
-					"toPorts": []interface{}{
-						map[string]interface{}{
-							"ports": []interface{}{map[string]interface{}{"port": "443", "protocol": "TCP"}},
-						},
-					},
-				},
-			},
+			"egress": egress,
 		},
 	}}
 }

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -838,7 +838,7 @@ func TestBuildSessionCNP_PerSessionPolicy(t *testing.T) {
 	sess.Name = "cnp-test"
 	sess.Namespace = sandboxNS
 
-	obj := buildSessionCNP(sess)
+	obj := buildSessionCNP(sess, false)
 	if obj.GetAPIVersion() != "cilium.io/v2" || obj.GetKind() != "CiliumNetworkPolicy" {
 		t.Fatalf("unexpected GVK: %s/%s", obj.GetAPIVersion(), obj.GetKind())
 	}
@@ -890,7 +890,7 @@ func TestBuildSessionCNP_NamespaceScoped(t *testing.T) {
 	sess.Name = "cnp-ns"
 	sess.Namespace = "team-a"
 
-	obj := buildSessionCNP(sess)
+	obj := buildSessionCNP(sess, false)
 	if obj.GetNamespace() != "team-a" {
 		t.Fatalf("expected CNP in session namespace, got %s", obj.GetNamespace())
 	}
@@ -946,5 +946,60 @@ func TestRunSubAgent_DestroyChildLeavesParentPod(t *testing.T) {
 	}
 	if pod.Labels[labelSessionID] != "parent-shared" {
 		t.Fatalf("parent pod session label must be intact, got %v", pod.Labels)
+	}
+}
+
+// TestBuildSessionCNP_FQDNEnforced verifies that with FQDN egress enabled and
+// allowedHosts set, the HTTPS egress becomes scoped toFQDNs instead of blanket
+// world (KIP-16 M10 / issue #510).
+func TestBuildSessionCNP_FQDNEnforced(t *testing.T) {
+	sess := &sandboxv1.SandboxSession{}
+	sess.Name = "cnp-fqdn"
+	sess.Namespace = sandboxNS
+	sess.Spec.AllowedHosts = []string{"pypi.org", "github.com"}
+
+	obj := buildSessionCNP(sess, true)
+	spec := obj.Object["spec"].(map[string]interface{})
+	egress := spec["egress"].([]interface{})
+	if len(egress) != 2 {
+		t.Fatalf("expected 2 egress rules (dns + fqdn), got %d", len(egress))
+	}
+	// Second rule must be toFQDNs, not toEntities world.
+	rule := egress[1].(map[string]interface{})
+	if _, hasFQDNs := rule["toFQDNs"]; !hasFQDNs {
+		t.Fatalf("expected toFQDNs rule, got %v", rule)
+	}
+	if _, hasWorld := rule["toEntities"]; hasWorld {
+		t.Fatal("FQDN rule must not use toEntities")
+	}
+	fqdns := rule["toFQDNs"].([]interface{})
+	if len(fqdns) != 2 {
+		t.Fatalf("expected 2 FQDN matches, got %d", len(fqdns))
+	}
+	names := map[string]bool{}
+	for _, f := range fqdns {
+		names[f.(map[string]interface{})["matchName"].(string)] = true
+	}
+	if !names["pypi.org"] || !names["github.com"] {
+		t.Fatalf("unexpected FQDN matches: %v", names)
+	}
+}
+
+// TestBuildSessionCNP_FQDNNoHosts verifies FQDN mode with no allowedHosts keeps
+// blanket world egress (nothing to scope to).
+func TestBuildSessionCNP_FQDNNoHosts(t *testing.T) {
+	sess := &sandboxv1.SandboxSession{}
+	sess.Name = "cnp-fqdn-empty"
+	sess.Namespace = sandboxNS
+
+	obj := buildSessionCNP(sess, true)
+	spec := obj.Object["spec"].(map[string]interface{})
+	egress := spec["egress"].([]interface{})
+	rule := egress[1].(map[string]interface{})
+	if _, hasFQDNs := rule["toFQDNs"]; hasFQDNs {
+		t.Fatal("no allowedHosts -> no toFQDNs rule")
+	}
+	if _, hasWorld := rule["toEntities"]; !hasWorld {
+		t.Fatal("expected blanket world fallback")
 	}
 }

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -112,6 +112,9 @@ type ServerConfig struct {
 	// LayerStoreDir, when set, enables the server-side content-addressed
 	// snapshot layer registry (KIP-16 M2 / issue #511).
 	LayerStoreDir string
+	// FQDNEnabled enables Cilium toFQDNs egress for sessions with allowedHosts
+	// (requires Cilium DNS proxy; KIP-16 M10 / issue #510).
+	FQDNEnabled bool
 }
 
 // Server implements the SandboxService gRPC interface.
@@ -152,6 +155,9 @@ func NewServer(cfg ServerConfig) *Server {
 		rateLimiter:    ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
 	}
 	s.orch = NewOrchestrator(cfg.K8s, cfg.Dyn)
+	if cfg.FQDNEnabled {
+		s.orch.SetFQDNEGressEnabled(true)
+	}
 	RegisterSandboxMetrics(s.orch)
 	if cfg.LayerStoreDir != "" {
 		if ls, err := sandboxlayer.New(cfg.LayerStoreDir); err == nil {


### PR DESCRIPTION
## Summary

KIP-16 **M10 (P0 security)** slice 1 (issue #510):  was stored on sessions but **never enforced** — the CNP always used blanket `world:53/443` egress. This PR closes the gap when the operator opts into the Cilium DNS proxy.

## What
- When `--cilium-dns-proxy` is enabled **and** a session declares `allowedHosts`, the session CNP's :443 egress becomes scoped `toFQDNs` (one `matchName` per host) instead of blanket world
- Wiring: `ServerConfig.FQDNEnabled` ← `SandboxConfig.CiliumDNSProxyEnabled` ← `--cilium-dns-proxy`; `Orchestrator.SetFQDNEGressEnabled` gates it
- **Default unchanged**: DNS-proxy-off environments keep blanket world (no regression; the gVisor DNS history from 2b3bfb0a is respected)

## Design notes
- Chose toFQDNs over egress-proxy / API-removal (the other options in #510) because the DNS proxy is now an explicit opt-in flag (from #515), making enforcement safe and opt-in
- DNS (:53) stays world so name resolution always works; only :443 becomes scoped

## Tests
- `TestBuildSessionCNP_FQDNEnforced`: allowedHosts + FQDN enabled → scoped toFQDNs rule (2 matchNames)
- `TestBuildSessionCNP_FQDNNoHosts`: FQDN enabled but no allowedHosts → blanket world fallback
- All sandboxmatrix/sandboxcli/daemons-config green

## Follow-ups (#510)
- Egress-proxy option for DNS-proxy-off clusters
- Document the security posture in README/skill