### PR TITLE
feat(sandbox): per-session workspace isolation (KIP-16 M1 slice 2, #514)

### DIFF
--- a/pkg/sandboxmatrix/api/v1alpha1/types.go
+++ b/pkg/sandboxmatrix/api/v1alpha1/types.go
@@ -19,12 +19,12 @@ type SandboxMatrix struct {
 }
 
 type SandboxMatrixSpec struct {
-	WarmPoolSize        int                `json:"warmPoolSize,omitempty"`
-	RuntimeClass        string             `json:"runtimeClass,omitempty"`
-	SessionTTL          int                `json:"sessionTTL,omitempty"`
-	DefaultAllowedHosts []string           `json:"defaultAllowedHosts,omitempty"`
+	WarmPoolSize        int                 `json:"warmPoolSize,omitempty"`
+	RuntimeClass        string              `json:"runtimeClass,omitempty"`
+	SessionTTL          int                 `json:"sessionTTL,omitempty"`
+	DefaultAllowedHosts []string            `json:"defaultAllowedHosts,omitempty"`
 	ResourceLimits      corev1.ResourceList `json:"resourceLimits,omitempty"`
-	RateLimits          *RateLimitSpec     `json:"rateLimits,omitempty"`
+	RateLimits          *RateLimitSpec      `json:"rateLimits,omitempty"`
 }
 
 // RateLimitSpec configures per-tenant rate limiting.
@@ -68,11 +68,11 @@ type SecretRef struct {
 }
 
 type SandboxSessionSpec struct {
-	TenantID        string            `json:"tenantID,omitempty"`
-	AllowedHosts    []string          `json:"allowedHosts,omitempty"`
-	RuntimeClass    string            `json:"runtimeClass,omitempty"`
-	ParentSessionID string            `json:"parentSessionID,omitempty"`
-	Depth           int               `json:"depth,omitempty"`
+	TenantID        string   `json:"tenantID,omitempty"`
+	AllowedHosts    []string `json:"allowedHosts,omitempty"`
+	RuntimeClass    string   `json:"runtimeClass,omitempty"`
+	ParentSessionID string   `json:"parentSessionID,omitempty"`
+	Depth           int      `json:"depth,omitempty"`
 	// Env is a non-sensitive map of environment variables applied at exec time
 	// (not baked into the pod spec) so warm-pool pods remain reusable.
 	Env map[string]string `json:"env,omitempty"`
@@ -81,23 +81,27 @@ type SandboxSessionSpec struct {
 }
 
 type SandboxSessionStatus struct {
-	Phase        SandboxPhase  `json:"phase,omitempty"`
-	PodName      string        `json:"podName,omitempty"`
-	PodIP        string        `json:"podIP,omitempty"`
-	WorkspacePVC string        `json:"workspacePVC,omitempty"`
-	CreatedAt    *metav1.Time  `json:"createdAt,omitempty"`
-	ExpiresAt    *metav1.Time  `json:"expiresAt,omitempty"`
+	Phase        SandboxPhase `json:"phase,omitempty"`
+	PodName      string       `json:"podName,omitempty"`
+	PodIP        string       `json:"podIP,omitempty"`
+	WorkspacePVC string       `json:"workspacePVC,omitempty"`
+	// WorkspaceScope is the session's isolated workspace subdirectory under
+	// /workspace (M1 slice 2: sub-agents get `.sessions/<sid>` so their
+	// workspace resets independently of the parent).
+	WorkspaceScope string       `json:"workspaceScope,omitempty"`
+	CreatedAt      *metav1.Time `json:"createdAt,omitempty"`
+	ExpiresAt      *metav1.Time `json:"expiresAt,omitempty"`
 }
 
 type SandboxPhase string
 
 const (
-	SandboxPhaseWarm                 SandboxPhase = "Warm"
-	SandboxPhaseActive               SandboxPhase = "Active"
-	SandboxPhaseResetting            SandboxPhase = "Resetting"
-	SandboxPhaseTerminating          SandboxPhase = "Terminating"
-	SandboxPhaseBackgroundRunning    SandboxPhase = "BackgroundRunning"
-	SandboxPhaseBackgroundCompleted  SandboxPhase = "BackgroundCompleted"
+	SandboxPhaseWarm                SandboxPhase = "Warm"
+	SandboxPhaseActive              SandboxPhase = "Active"
+	SandboxPhaseResetting           SandboxPhase = "Resetting"
+	SandboxPhaseTerminating         SandboxPhase = "Terminating"
+	SandboxPhaseBackgroundRunning   SandboxPhase = "BackgroundRunning"
+	SandboxPhaseBackgroundCompleted SandboxPhase = "BackgroundCompleted"
 )
 
 // +genclient

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -405,7 +406,13 @@ func (o *Orchestrator) DestroySession(ctx context.Context, sessionID string) err
 		}
 	}
 	if podIP != "" {
-		o.resetWorkspace(ctx, podIP)
+		// M1 slice 2: a session with a workspace scope resets only its own
+		// isolated subdir; unscoped sessions reset the whole /workspace.
+		if session.Status.WorkspaceScope != "" {
+			o.resetWorkspaceScope(ctx, podIP, session.Status.WorkspaceScope)
+		} else {
+			o.resetWorkspace(ctx, podIP)
+		}
 		// 3. Relabel pod: active → resetting, remove session-id
 		if podName != "" {
 			o.releasePod(ctx, podName)
@@ -430,6 +437,18 @@ func (o *Orchestrator) findPodBySession(ctx context.Context, sessionID string) (
 // resetWorkspace calls sandboxd's /workspace/reset endpoint and waits for completion.
 func (o *Orchestrator) resetWorkspace(ctx context.Context, podIP string) {
 	url := fmt.Sprintf("http://%s:2024/workspace/reset", podIP)
+	resetWorkspaceURL(ctx, url)
+}
+
+// resetWorkspaceScope resets only a session's isolated workspace subdirectory
+// (M1 slice 2, KIP-16 L1): sandboxd wipes /workspace/<scope> without touching
+// the parent's files.
+func (o *Orchestrator) resetWorkspaceScope(ctx context.Context, podIP, scope string) {
+	url := fmt.Sprintf("http://%s:2024/workspace/reset?path=%s", podIP, url.QueryEscape(scope))
+	resetWorkspaceURL(ctx, url)
+}
+
+func resetWorkspaceURL(ctx context.Context, url string) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
 	if err != nil {
 		return
@@ -559,6 +578,9 @@ func (o *Orchestrator) RunSubAgent(ctx context.Context, req *pb.RunSubAgentReque
 	child.Status.Phase = sandboxv1.SandboxPhaseActive
 	child.Status.PodIP = parent.Status.PodIP
 	child.Status.WorkspacePVC = parentPVC
+	// M1 slice 2: sub-agent gets an isolated workspace subdir so its files
+	// reset independently of the parent (KIP-16 L1 workspace-session semantics).
+	child.Status.WorkspaceScope = fmt.Sprintf(".sessions/%s", childID)
 	child.Status.CreatedAt = &metav1.Time{Time: time.Now()}
 	o.updateSessionStatus(ctx, child)
 

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -600,6 +600,13 @@ func TestRunSubAgent_Success(t *testing.T) {
 	if child.Status.PodName != "" {
 		t.Fatalf("expected child to have no own PodName (shares parent pod), got %q", child.Status.PodName)
 	}
+	// M1 slice 2: child gets an isolated workspace scope for independent reset.
+	if child.Status.WorkspaceScope == "" {
+		t.Fatal("expected child to have an isolated WorkspaceScope")
+	}
+	if !strings.HasPrefix(child.Status.WorkspaceScope, ".sessions/") {
+		t.Fatalf("expected scope under .sessions/, got %q", child.Status.WorkspaceScope)
+	}
 }
 
 func TestRunSubAgent_NoParentPVC_FailedPrecondition(t *testing.T) {

--- a/sandboxd/src/main.zig
+++ b/sandboxd/src/main.zig
@@ -159,7 +159,7 @@ fn handleRequest(allocator: std.mem.Allocator, client_fd: i32) !void {
     } else if (std.mem.eql(u8, path, "/exec/stream") and std.mem.eql(u8, method, "POST")) {
         try exec.handleExec(allocator, client_fd, body, true);
     } else if (std.mem.eql(u8, path, "/workspace/reset") and std.mem.eql(u8, method, "POST")) {
-        try workspace.handleReset(allocator, client_fd);
+        try workspace.handleReset(allocator, client_fd, query);
     } else if (std.mem.eql(u8, path, "/exec/background") and std.mem.eql(u8, method, "POST")) {
         try background.handleBgSubmit(allocator, client_fd, body);
     } else if (std.mem.startsWith(u8, path, "/exec/background/")) {

--- a/sandboxd/src/workspace.zig
+++ b/sandboxd/src/workspace.zig
@@ -1,10 +1,28 @@
 const std = @import("std");
 const main = @import("main.zig");
 
-/// handleReset removes all files/dirs under /workspace using raw syscalls,
+/// handleReset removes all files/dirs under /workspace (or a scoped subdir
+/// when ?path=<sub> is given, KIP-16 M1 slice 2 — per-session isolation),
 /// then recreates the directory. POST /workspace/reset
-pub fn handleReset(allocator: std.mem.Allocator, client_fd: i32) !void {
+pub fn handleReset(allocator: std.mem.Allocator, client_fd: i32, query: []const u8) !void {
+    var scope: []const u8 = "";
+    var params = std.mem.splitScalar(u8, query, '&');
+    while (params.next()) |pair| {
+        var kv = std.mem.splitScalar(u8, pair, '=');
+        const key = kv.next() orelse continue;
+        const val = kv.next() orelse continue;
+        if (std.mem.eql(u8, key, "path")) {
+            scope = val;
+        }
+    }
+
+    // Scope root: /workspace or /workspace/<scope>.
     const workspace_path = "/workspace";
+    var scope_buf: [512]u8 = undefined;
+    const reset_root = if (scope.len > 0)
+        std.fmt.bufPrint(&scope_buf, "{s}/{s}", .{ workspace_path, scope }) catch workspace_path
+    else
+        workspace_path;
 
     // Collect all paths to delete by walking the directory
     var paths = std.array_list.Managed([]const u8).init(allocator);
@@ -12,10 +30,13 @@ pub fn handleReset(allocator: std.mem.Allocator, client_fd: i32) !void {
         for (paths.items) |p| allocator.free(p);
         paths.deinit();
     }
-    collectPaths(allocator, &paths, workspace_path, "") catch |err| {
+    const sub_prefix: []const u8 = if (scope.len > 0) scope else "";
+    collectPaths(allocator, &paths, reset_root, sub_prefix) catch |err| {
         if (err == error.FileNotFound or err == error.NotDir) {
-            // /workspace doesn't exist or is gone — recreate and return
-            _ = std.os.linux.mkdir(@ptrCast(workspace_path.ptr), 0o755);
+            // The reset root doesn't exist — recreate (or leave scoped absent)
+            if (scope.len == 0) {
+                _ = std.os.linux.mkdir(@ptrCast(workspace_path.ptr), 0o755);
+            }
             try sendOK(client_fd);
             return;
         }
@@ -27,7 +48,7 @@ pub fn handleReset(allocator: std.mem.Allocator, client_fd: i32) !void {
     while (i > 0) {
         i -= 1;
         const entry = paths.items[i];
-        const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ workspace_path, entry });
+        const full_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ reset_root, entry });
         defer allocator.free(full_path);
         const full_z = try allocator.dupeZ(u8, full_path);
         defer allocator.free(full_z);
@@ -36,8 +57,11 @@ pub fn handleReset(allocator: std.mem.Allocator, client_fd: i32) !void {
         _ = std.os.linux.unlink(full_z.ptr);
     }
 
-    // Recreate /workspace
-    _ = std.os.linux.mkdir(@ptrCast(workspace_path.ptr), 0o755);
+    // Recreate the reset root (only for the unscoped /workspace; scoped roots
+    // stay absent so the session appears fresh).
+    if (scope.len == 0) {
+        _ = std.os.linux.mkdir(@ptrCast(workspace_path.ptr), 0o755);
+    }
     try sendOK(client_fd);
 }
 


### PR DESCRIPTION
## Summary

KIP-16 M1 slice 2 (issue #514): **per-session workspace isolation** — the ephemeral-sandbox workspace-session semantics. **Stacked on #520** (sub-agent pod reuse).

## What
- Sub-agent sessions get `status.workspaceScope = .sessions/<sid>`
- sandboxd `/workspace/reset?path=<scope>` wipes **only that subdirectory**
- `DestroySession` for a scoped session resets only its own subdir — never the parent's workspace or the shared pod
- Unscoped sessions keep full `/workspace` reset (unchanged behavior)

## Why (KIP-16 L1)
ephemeral-sandbox's core reuse unit is the workspace-session: N sessions share one sandbox base but reset independently. This brings that to k8e's sub-agent model — a child's work is torn down without disturbing the parent.

## Tests
- `TestRunSubAgent_Success`: child has isolated `.sessions/` scope
- Full zig suite passes in debian container (scoped reset path compiles + runs)
- sandboxmatrix/sandboxcli all green

## Follow-ups (#514)
- Exec workdir routing to the scope (sub-agent `run --workdir .sessions/<sid>` helper)