### PR TITLE
feat(sandbox): process topology endpoint (KIP-16 M5 follow-up, #513)

### DIFF
--- a/cmd/sandboxcli/main.go
+++ b/cmd/sandboxcli/main.go
@@ -44,6 +44,7 @@ func main() {
 		sandboxcli.PollCommand(),
 		sandboxcli.LogCommand(),
 		sandboxcli.EventsCommand(),
+		sandboxcli.PsCommand(),
 		sandboxcli.BenchmarkCommand(),
 	}
 

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -1216,3 +1216,37 @@ func EventsCommand() cli.Command {
 		},
 	}
 }
+
+// ── PsCommand ──────────────────────────────────────────────────────────────
+
+func PsCommand() cli.Command {
+	return cli.Command{
+		Name:      "ps",
+		Usage:     "List processes running in the sandbox pod (KIP-16 M5 process topology)",
+		ArgsUsage: "<session-id>",
+		Action: func(ctx *cli.Context) error {
+			sid := ctx.Args().First()
+			if sid == "" {
+				return printErrorExit("usage: k8e-sandbox-cli ps <session-id>", 1)
+			}
+			client, exitErr := newClientFromCtx(ctx)
+			if exitErr != nil {
+				return exitErr
+			}
+			defer client.Close()
+
+			resp, err := client.SandboxServiceClient.GetProcesses(context.Background(), &pb.GetProcessesRequest{
+				SessionId: sid,
+			})
+			if err != nil {
+				return printErrorExit("ps: "+err.Error(), 1)
+			}
+			procs := make([]map[string]any, len(resp.Processes))
+			for i, p := range resp.Processes {
+				procs[i] = map[string]any{"pid": p.Pid, "comm": p.Comm, "state": p.State}
+			}
+			printJSON(map[string]any{"processes": procs})
+			return nil
+		},
+	}
+}

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -91,6 +91,7 @@ k8e-sandbox-cli connect --endpoint <server-ip>:50051 --apikey k8e-...
 | `k8e-sandbox-cli write/read/list` | Workspace files |
 | `k8e-sandbox-cli log <sid>` | Replay exec transcript | `--offset`, `--limit`, `--follow` |
 | `k8e-sandbox-cli events <sid>` | Read daemon NDJSON event stream | `--limit` |
+| `k8e-sandbox-cli ps <sid>` | List processes in the sandbox pod | pid, comm, state |
 | `k8e-sandbox-cli poll <run-id>` | Poll a background run | |
 | `k8e-sandbox-cli destroy <sid>` | Tear down session |
 

--- a/pkg/sandboxmatrix/grpc/env_test.go
+++ b/pkg/sandboxmatrix/grpc/env_test.go
@@ -618,3 +618,44 @@ func TestSnapshotRPCs_DisabledRegistry(t *testing.T) {
 		t.Fatalf("expected FailedPrecondition, got %v", err)
 	}
 }
+
+// TestGetProcesses_ReadsProcessTopology verifies GetProcesses proxies to
+// sandboxd /processes and passes through pid/comm/state (KIP-16 M5).
+func TestGetProcesses_ReadsProcessTopology(t *testing.T) {
+	s := newTestServer()
+	ctx := context.Background()
+	mustCreateSession(t, s.orch, "proc-read")
+	stubSessionPodIP(ctx, t, s.orch, "proc-read", "127.0.0.1")
+
+	old := sandboxdClient
+	defer func() { sandboxdClient = old }()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/processes" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"processes":[{"pid":1,"comm":"sandboxd","state":"S"},{"pid":42,"comm":"bash","state":"R"}]}`))
+	}))
+	ln, err := net.Listen("tcp", "127.0.0.1:2024")
+	if err != nil {
+		t.Fatalf("bind 2024: %v", err)
+	}
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+	sandboxdClient = &http.Client{}
+
+	resp, err := s.GetProcesses(ctx, &pb.GetProcessesRequest{SessionId: "proc-read"})
+	if err != nil {
+		t.Fatalf("GetProcesses: %v", err)
+	}
+	if len(resp.Processes) != 2 {
+		t.Fatalf("expected 2 processes, got %d", len(resp.Processes))
+	}
+	if resp.Processes[0].Pid != 1 || resp.Processes[0].Comm != "sandboxd" || resp.Processes[0].State != "S" {
+		t.Fatalf("unexpected first process: %+v", resp.Processes[0])
+	}
+	if resp.Processes[1].Pid != 42 || resp.Processes[1].Comm != "bash" {
+		t.Fatalf("unexpected second process: %+v", resp.Processes[1])
+	}
+}

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -2368,6 +2368,156 @@ func (x *SnapshotListResponse) GetNames() []string {
 	return nil
 }
 
+// GetProcessesRequest lists processes visible in the sandbox pod's pid
+// namespace (KIP-16 M5 follow-up: namespace-identity process topology).
+type GetProcessesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProcessesRequest) Reset() {
+	*x = GetProcessesRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProcessesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProcessesRequest) ProtoMessage() {}
+
+func (x *GetProcessesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProcessesRequest.ProtoReflect.Descriptor instead.
+func (*GetProcessesRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *GetProcessesRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+type ProcessInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Pid           int32                  `protobuf:"varint,1,opt,name=pid,proto3" json:"pid,omitempty"`
+	Comm          string                 `protobuf:"bytes,2,opt,name=comm,proto3" json:"comm,omitempty"`
+	State         string                 `protobuf:"bytes,3,opt,name=state,proto3" json:"state,omitempty"` // single char: R/S/D/Z/...
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProcessInfo) Reset() {
+	*x = ProcessInfo{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProcessInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcessInfo) ProtoMessage() {}
+
+func (x *ProcessInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcessInfo.ProtoReflect.Descriptor instead.
+func (*ProcessInfo) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *ProcessInfo) GetPid() int32 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *ProcessInfo) GetComm() string {
+	if x != nil {
+		return x.Comm
+	}
+	return ""
+}
+
+func (x *ProcessInfo) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+type GetProcessesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Processes     []*ProcessInfo         `protobuf:"bytes,1,rep,name=processes,proto3" json:"processes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProcessesResponse) Reset() {
+	*x = GetProcessesResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProcessesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProcessesResponse) ProtoMessage() {}
+
+func (x *GetProcessesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProcessesResponse.ProtoReflect.Descriptor instead.
+func (*GetProcessesResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *GetProcessesResponse) GetProcesses() []*ProcessInfo {
+	if x != nil {
+		return x.Processes
+	}
+	return nil
+}
+
 var File_sandbox_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_sandbox_v1_sandbox_proto_rawDesc = "" +
@@ -2554,7 +2704,16 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\x06layers\x18\x02 \x03(\tR\x06layers\"\x15\n" +
 	"\x13SnapshotListRequest\",\n" +
 	"\x14SnapshotListResponse\x12\x14\n" +
-	"\x05names\x18\x01 \x03(\tR\x05names2\x9c\f\n" +
+	"\x05names\x18\x01 \x03(\tR\x05names\"4\n" +
+	"\x13GetProcessesRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"I\n" +
+	"\vProcessInfo\x12\x10\n" +
+	"\x03pid\x18\x01 \x01(\x05R\x03pid\x12\x12\n" +
+	"\x04comm\x18\x02 \x01(\tR\x04comm\x12\x14\n" +
+	"\x05state\x18\x03 \x01(\tR\x05state\"M\n" +
+	"\x14GetProcessesResponse\x125\n" +
+	"\tprocesses\x18\x01 \x03(\v2\x17.sandbox.v1.ProcessInfoR\tprocesses2\xef\f\n" +
 	"\x0eSandboxService\x12T\n" +
 	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12K\n" +
 	"\n" +
@@ -2578,7 +2737,8 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\tGetEvents\x12\x1c.sandbox.v1.GetEventsRequest\x1a\x1d.sandbox.v1.GetEventsResponse\x12N\n" +
 	"\vSnapshotPut\x12\x1e.sandbox.v1.SnapshotPutRequest\x1a\x1f.sandbox.v1.SnapshotPutResponse\x12N\n" +
 	"\vSnapshotGet\x12\x1e.sandbox.v1.SnapshotGetRequest\x1a\x1f.sandbox.v1.SnapshotGetResponse\x12Q\n" +
-	"\fSnapshotList\x12\x1f.sandbox.v1.SnapshotListRequest\x1a .sandbox.v1.SnapshotListResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
+	"\fSnapshotList\x12\x1f.sandbox.v1.SnapshotListRequest\x1a .sandbox.v1.SnapshotListResponse\x12Q\n" +
+	"\fGetProcesses\x12\x1f.sandbox.v1.GetProcessesRequest\x1a .sandbox.v1.GetProcessesResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
 
 var (
 	file_sandbox_v1_sandbox_proto_rawDescOnce sync.Once
@@ -2592,7 +2752,7 @@ func file_sandbox_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_sandbox_v1_sandbox_proto_rawDescData
 }
 
-var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
 var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*SecretRef)(nil),              // 0: sandbox.v1.SecretRef
 	(*CreateSessionRequest)(nil),   // 1: sandbox.v1.CreateSessionRequest
@@ -2635,58 +2795,64 @@ var file_sandbox_v1_sandbox_proto_goTypes = []any{
 	(*SnapshotGetResponse)(nil),    // 38: sandbox.v1.SnapshotGetResponse
 	(*SnapshotListRequest)(nil),    // 39: sandbox.v1.SnapshotListRequest
 	(*SnapshotListResponse)(nil),   // 40: sandbox.v1.SnapshotListResponse
-	nil,                            // 41: sandbox.v1.CreateSessionRequest.EnvEntry
+	(*GetProcessesRequest)(nil),    // 41: sandbox.v1.GetProcessesRequest
+	(*ProcessInfo)(nil),            // 42: sandbox.v1.ProcessInfo
+	(*GetProcessesResponse)(nil),   // 43: sandbox.v1.GetProcessesResponse
+	nil,                            // 44: sandbox.v1.CreateSessionRequest.EnvEntry
 }
 var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
-	41, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
+	44, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
 	0,  // 1: sandbox.v1.CreateSessionRequest.secret_refs:type_name -> sandbox.v1.SecretRef
 	4,  // 2: sandbox.v1.ListSessionsResponse.sessions:type_name -> sandbox.v1.GetSessionResponse
 	18, // 3: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
-	1,  // 4: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
-	3,  // 5: sandbox.v1.SandboxService.GetSession:input_type -> sandbox.v1.GetSessionRequest
-	5,  // 6: sandbox.v1.SandboxService.ListSessions:input_type -> sandbox.v1.ListSessionsRequest
-	7,  // 7: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
-	9,  // 8: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
-	9,  // 9: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
-	12, // 10: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
-	14, // 11: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
-	16, // 12: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
-	19, // 13: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
-	21, // 14: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
-	23, // 15: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
-	25, // 16: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
-	27, // 17: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
-	29, // 18: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
-	31, // 19: sandbox.v1.SandboxService.GetTranscript:input_type -> sandbox.v1.GetTranscriptRequest
-	33, // 20: sandbox.v1.SandboxService.GetEvents:input_type -> sandbox.v1.GetEventsRequest
-	35, // 21: sandbox.v1.SandboxService.SnapshotPut:input_type -> sandbox.v1.SnapshotPutRequest
-	37, // 22: sandbox.v1.SandboxService.SnapshotGet:input_type -> sandbox.v1.SnapshotGetRequest
-	39, // 23: sandbox.v1.SandboxService.SnapshotList:input_type -> sandbox.v1.SnapshotListRequest
-	2,  // 24: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
-	4,  // 25: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
-	6,  // 26: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
-	8,  // 27: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
-	10, // 28: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
-	11, // 29: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
-	13, // 30: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
-	15, // 31: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
-	17, // 32: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
-	20, // 33: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
-	22, // 34: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
-	24, // 35: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
-	26, // 36: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	28, // 37: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
-	30, // 38: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
-	32, // 39: sandbox.v1.SandboxService.GetTranscript:output_type -> sandbox.v1.GetTranscriptResponse
-	34, // 40: sandbox.v1.SandboxService.GetEvents:output_type -> sandbox.v1.GetEventsResponse
-	36, // 41: sandbox.v1.SandboxService.SnapshotPut:output_type -> sandbox.v1.SnapshotPutResponse
-	38, // 42: sandbox.v1.SandboxService.SnapshotGet:output_type -> sandbox.v1.SnapshotGetResponse
-	40, // 43: sandbox.v1.SandboxService.SnapshotList:output_type -> sandbox.v1.SnapshotListResponse
-	24, // [24:44] is the sub-list for method output_type
-	4,  // [4:24] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	42, // 4: sandbox.v1.GetProcessesResponse.processes:type_name -> sandbox.v1.ProcessInfo
+	1,  // 5: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
+	3,  // 6: sandbox.v1.SandboxService.GetSession:input_type -> sandbox.v1.GetSessionRequest
+	5,  // 7: sandbox.v1.SandboxService.ListSessions:input_type -> sandbox.v1.ListSessionsRequest
+	7,  // 8: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
+	9,  // 9: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
+	9,  // 10: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
+	12, // 11: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
+	14, // 12: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
+	16, // 13: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
+	19, // 14: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
+	21, // 15: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
+	23, // 16: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
+	25, // 17: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
+	27, // 18: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
+	29, // 19: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
+	31, // 20: sandbox.v1.SandboxService.GetTranscript:input_type -> sandbox.v1.GetTranscriptRequest
+	33, // 21: sandbox.v1.SandboxService.GetEvents:input_type -> sandbox.v1.GetEventsRequest
+	35, // 22: sandbox.v1.SandboxService.SnapshotPut:input_type -> sandbox.v1.SnapshotPutRequest
+	37, // 23: sandbox.v1.SandboxService.SnapshotGet:input_type -> sandbox.v1.SnapshotGetRequest
+	39, // 24: sandbox.v1.SandboxService.SnapshotList:input_type -> sandbox.v1.SnapshotListRequest
+	41, // 25: sandbox.v1.SandboxService.GetProcesses:input_type -> sandbox.v1.GetProcessesRequest
+	2,  // 26: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
+	4,  // 27: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
+	6,  // 28: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
+	8,  // 29: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
+	10, // 30: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
+	11, // 31: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
+	13, // 32: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
+	15, // 33: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
+	17, // 34: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
+	20, // 35: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
+	22, // 36: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
+	24, // 37: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
+	26, // 38: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
+	28, // 39: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
+	30, // 40: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
+	32, // 41: sandbox.v1.SandboxService.GetTranscript:output_type -> sandbox.v1.GetTranscriptResponse
+	34, // 42: sandbox.v1.SandboxService.GetEvents:output_type -> sandbox.v1.GetEventsResponse
+	36, // 43: sandbox.v1.SandboxService.SnapshotPut:output_type -> sandbox.v1.SnapshotPutResponse
+	38, // 44: sandbox.v1.SandboxService.SnapshotGet:output_type -> sandbox.v1.SnapshotGetResponse
+	40, // 45: sandbox.v1.SandboxService.SnapshotList:output_type -> sandbox.v1.SnapshotListResponse
+	43, // 46: sandbox.v1.SandboxService.GetProcesses:output_type -> sandbox.v1.GetProcessesResponse
+	26, // [26:47] is the sub-list for method output_type
+	5,  // [5:26] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_sandbox_v1_sandbox_proto_init() }
@@ -2700,7 +2866,7 @@ func file_sandbox_v1_sandbox_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_v1_sandbox_proto_rawDesc), len(file_sandbox_v1_sandbox_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   42,
+			NumMessages:   45,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	SandboxService_SnapshotPut_FullMethodName    = "/sandbox.v1.SandboxService/SnapshotPut"
 	SandboxService_SnapshotGet_FullMethodName    = "/sandbox.v1.SandboxService/SnapshotGet"
 	SandboxService_SnapshotList_FullMethodName   = "/sandbox.v1.SandboxService/SnapshotList"
+	SandboxService_GetProcesses_FullMethodName   = "/sandbox.v1.SandboxService/GetProcesses"
 )
 
 // SandboxServiceClient is the client API for SandboxService service.
@@ -75,6 +76,8 @@ type SandboxServiceClient interface {
 	SnapshotPut(ctx context.Context, in *SnapshotPutRequest, opts ...grpc.CallOption) (*SnapshotPutResponse, error)
 	SnapshotGet(ctx context.Context, in *SnapshotGetRequest, opts ...grpc.CallOption) (*SnapshotGetResponse, error)
 	SnapshotList(ctx context.Context, in *SnapshotListRequest, opts ...grpc.CallOption) (*SnapshotListResponse, error)
+	// GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
+	GetProcesses(ctx context.Context, in *GetProcessesRequest, opts ...grpc.CallOption) (*GetProcessesResponse, error)
 }
 
 type sandboxServiceClient struct {
@@ -294,6 +297,16 @@ func (c *sandboxServiceClient) SnapshotList(ctx context.Context, in *SnapshotLis
 	return out, nil
 }
 
+func (c *sandboxServiceClient) GetProcesses(ctx context.Context, in *GetProcessesRequest, opts ...grpc.CallOption) (*GetProcessesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetProcessesResponse)
+	err := c.cc.Invoke(ctx, SandboxService_GetProcesses_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SandboxServiceServer is the server API for SandboxService service.
 // All implementations must embed UnimplementedSandboxServiceServer
 // for forward compatibility.
@@ -328,6 +341,8 @@ type SandboxServiceServer interface {
 	SnapshotPut(context.Context, *SnapshotPutRequest) (*SnapshotPutResponse, error)
 	SnapshotGet(context.Context, *SnapshotGetRequest) (*SnapshotGetResponse, error)
 	SnapshotList(context.Context, *SnapshotListRequest) (*SnapshotListResponse, error)
+	// GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
+	GetProcesses(context.Context, *GetProcessesRequest) (*GetProcessesResponse, error)
 	mustEmbedUnimplementedSandboxServiceServer()
 }
 
@@ -397,6 +412,9 @@ func (UnimplementedSandboxServiceServer) SnapshotGet(context.Context, *SnapshotG
 }
 func (UnimplementedSandboxServiceServer) SnapshotList(context.Context, *SnapshotListRequest) (*SnapshotListResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SnapshotList not implemented")
+}
+func (UnimplementedSandboxServiceServer) GetProcesses(context.Context, *GetProcessesRequest) (*GetProcessesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetProcesses not implemented")
 }
 func (UnimplementedSandboxServiceServer) mustEmbedUnimplementedSandboxServiceServer() {}
 func (UnimplementedSandboxServiceServer) testEmbeddedByValue()                        {}
@@ -772,6 +790,24 @@ func _SandboxService_SnapshotList_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SandboxService_GetProcesses_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetProcessesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).GetProcesses(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_GetProcesses_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).GetProcesses(ctx, req.(*GetProcessesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SandboxService_ServiceDesc is the grpc.ServiceDesc for SandboxService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -854,6 +890,10 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SnapshotList",
 			Handler:    _SandboxService_SnapshotList_Handler,
+		},
+		{
+			MethodName: "GetProcesses",
+			Handler:    _SandboxService_GetProcesses_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -747,6 +747,38 @@ func (s *Server) SnapshotList(ctx context.Context, req *pb.SnapshotListRequest) 
 	return &pb.SnapshotListResponse{Names: names}, nil
 }
 
+// GetProcesses lists processes visible in the sandbox pod's pid namespace
+// (KIP-16 M5 follow-up: namespace-identity process topology).
+func (s *Server) GetProcesses(ctx context.Context, req *pb.GetProcessesRequest) (*pb.GetProcessesResponse, error) {
+	podIP, err := s.getPodIP(ctx, req.SessionId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sandboxdGet(ctx, podIP, "/processes")
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd processes: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, status.Errorf(codes.Internal, "sandboxd processes: http %d", resp.StatusCode)
+	}
+	var result struct {
+		Processes []struct {
+			Pid   int32  `json:"pid"`
+			Comm  string `json:"comm"`
+			State string `json:"state"`
+		} `json:"processes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, status.Errorf(codes.Internal, "sandboxd processes decode: %v", err)
+	}
+	procs := make([]*pb.ProcessInfo, len(result.Processes))
+	for i, p := range result.Processes {
+		procs[i] = &pb.ProcessInfo{Pid: p.Pid, Comm: p.Comm, State: p.State}
+	}
+	return &pb.GetProcessesResponse{Processes: procs}, nil
+}
+
 // PollRun checks the status of a background execution.
 func (s *Server) PollRun(ctx context.Context, req *pb.PollRunRequest) (*pb.PollRunResponse, error) {
 	return s.orch.PollRun(ctx, req.RunId)

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -33,6 +33,8 @@ service SandboxService {
   rpc SnapshotPut(SnapshotPutRequest)       returns (SnapshotPutResponse);
   rpc SnapshotGet(SnapshotGetRequest)       returns (SnapshotGetResponse);
   rpc SnapshotList(SnapshotListRequest)     returns (SnapshotListResponse);
+  // GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
+  rpc GetProcesses(GetProcessesRequest)     returns (GetProcessesResponse);
 }
 
 // SecretRef references a key in a same-namespace K8s Secret. Values are resolved
@@ -227,4 +229,18 @@ message SnapshotGetResponse {
 message SnapshotListRequest {}
 message SnapshotListResponse {
   repeated string names = 1; // manifest names
+}
+
+// GetProcessesRequest lists processes visible in the sandbox pod's pid
+// namespace (KIP-16 M5 follow-up: namespace-identity process topology).
+message GetProcessesRequest {
+  string session_id = 1;
+}
+message ProcessInfo {
+  int32  pid    = 1;
+  string comm   = 2;
+  string state  = 3; // single char: R/S/D/Z/...
+}
+message GetProcessesResponse {
+  repeated ProcessInfo processes = 1;
 }

--- a/sandboxd/src/main.zig
+++ b/sandboxd/src/main.zig
@@ -6,6 +6,7 @@ const background = @import("background.zig");
 const venv = @import("venv.zig");
 const transcript = @import("transcript.zig");
 const events = @import("events.zig");
+const processes = @import("processes.zig");
 
 pub fn main() !void {
     var gpa = std.heap.DebugAllocator(.{}){};
@@ -169,6 +170,8 @@ fn handleRequest(allocator: std.mem.Allocator, client_fd: i32) !void {
         try transcript.handleTranscript(allocator, client_fd, query);
     } else if (std.mem.eql(u8, path, "/events") and std.mem.eql(u8, method, "GET")) {
         try handleEvents(allocator, client_fd, query);
+    } else if (std.mem.eql(u8, path, "/processes") and std.mem.eql(u8, method, "GET")) {
+        try processes.handleProcesses(allocator, client_fd, query);
     } else if (std.mem.eql(u8, path, "/files/write") and std.mem.eql(u8, method, "POST")) {
         try files.handleWrite(allocator, client_fd, body);
     } else if (std.mem.eql(u8, path, "/files/read") and std.mem.eql(u8, method, "GET")) {

--- a/sandboxd/src/processes.zig
+++ b/sandboxd/src/processes.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+const main = @import("main.zig");
+const exec = @import("exec.zig");
+
+/// Process topology endpoint (KIP-16 M5 follow-up / issue #513).
+///
+/// Mirrors ephemeral-sandbox's namespace-identity process tracking: read-only
+/// /proc enumeration reporting pid, command, and state for every process
+/// visible in the pod's pid namespace. Reading never triggers collection and
+/// an idle daemon does zero extra work (the /proc scan happens only when a
+/// consumer requests it).
+
+/// handleProcesses serves GET /processes — JSON array of running processes.
+pub fn handleProcesses(allocator: std.mem.Allocator, client_fd: i32, query: []const u8) !void {
+    _ = query;
+
+    var out = std.array_list.Managed(u8).init(allocator);
+    defer out.deinit();
+    try out.appendSlice("{\"processes\":[");
+
+    const proc_dir = "/proc";
+
+    // Enumerate /proc/<pid> numeric dirs.
+    const fd_raw = std.os.linux.open(proc_dir.ptr, std.os.linux.O{ .ACCMODE = .RDONLY, .DIRECTORY = true }, 0);
+    const fd: isize = @bitCast(fd_raw);
+    if (fd < 0) {
+        try main.writeResponse(client_fd, "200 OK", "application/json", "{\"processes\":[]}");
+        return;
+    }
+    defer _ = std.os.linux.close(@intCast(fd));
+
+    var buf: [4096]u8 align(@alignOf(std.os.linux.dirent64)) = undefined;
+    var wrote_any = false;
+    while (true) {
+        const n = std.os.linux.getdents64(@intCast(fd), @ptrCast(&buf), buf.len);
+        if (n <= 0) break;
+        var pos: usize = 0;
+        while (pos < @as(usize, @intCast(n))) {
+            const dent = @as(*align(1) std.os.linux.dirent64, @ptrCast(&buf[pos]));
+            pos += dent.reclen;
+            const name = std.mem.sliceTo(@as([*:0]u8, @ptrCast(&dent.name)), 0);
+            // Only numeric pid dirs.
+            const pid = std.fmt.parseInt(i32, name, 10) catch continue;
+            if (pid <= 0) continue;
+
+            const comm = readComm(name) orelse continue;
+            defer allocator.free(comm);
+            const escaped = try exec.jsonEscape(allocator, comm);
+            defer allocator.free(escaped);
+            const state = readState(name) orelse '?';
+
+            if (wrote_any) try out.append(',');
+            wrote_any = true;
+            var entry_buf: [512]u8 = undefined;
+            const entry = try std.fmt.bufPrint(&entry_buf, "{{\"pid\":{d},\"comm\":\"{s}\",\"state\":\"{c}\"}}",
+                .{ pid, escaped, state });
+            try out.appendSlice(entry);
+        }
+    }
+
+    try out.appendSlice("]}");
+    try main.writeResponse(client_fd, "200 OK", "application/json", out.items);
+}
+
+/// readComm returns the process command name from /proc/<pid>/comm.
+fn readComm(pid: []const u8) ?[]u8 {
+    const allocator = std.heap.page_allocator;
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrintZ(&path_buf, "/proc/{s}/comm", .{pid}) catch return null;
+
+    const fd_raw = std.os.linux.open(path.ptr, std.os.linux.O{ .ACCMODE = .RDONLY }, 0);
+    const fd: isize = @bitCast(fd_raw);
+    if (fd < 0) return null;
+    defer _ = std.os.linux.close(@intCast(fd));
+
+    var buf: [256]u8 = undefined;
+    const n = std.os.linux.read(@intCast(fd), &buf, buf.len);
+    if (n <= 0) return null;
+    var s = buf[0..@as(usize, @intCast(n))];
+    while (s.len > 0 and (s[s.len - 1] == '\n' or s[s.len - 1] == '\r')) {
+        s = s[0 .. s.len - 1];
+    }
+    return allocator.dupe(u8, s) catch null;
+}
+
+/// readState returns the first char of /proc/<pid>/stat state field ("R"/"S"/...).
+fn readState(pid: []const u8) ?u8 {
+    var path_buf: [64]u8 = undefined;
+    const path = std.fmt.bufPrintZ(&path_buf, "/proc/{s}/stat", .{pid}) catch return null;
+
+    const fd_raw = std.os.linux.open(path.ptr, std.os.linux.O{ .ACCMODE = .RDONLY }, 0);
+    const fd: isize = @bitCast(fd_raw);
+    if (fd < 0) return null;
+    defer _ = std.os.linux.close(@intCast(fd));
+
+    var buf: [512]u8 = undefined;
+    const n = std.os.linux.read(@intCast(fd), &buf, buf.len);
+    if (n <= 0) return null;
+    const s = buf[0..@as(usize, @intCast(n))];
+    // Format: pid (comm) state ... — find the last ')' then skip space.
+    const close = std.mem.lastIndexOfScalar(u8, s, ')') orelse return null;
+    const rest = s[close + 1 ..];
+    if (rest.len < 2) return null;
+    return rest[1]; // after the separating space
+}


### PR DESCRIPTION
## Summary

KIP-16 M5 follow-up (issue #513): **process topology** — the last observability depth item, mirroring ephemeral-sandbox's namespace-identity process tracking.

## What
- sandboxd `GET /processes`: read-only `/proc` enumeration (pid, comm, state) for every process in the pod's pid namespace
- Read-triggered only: an idle daemon does zero extra work (ephemeral-sandbox L5 principle)
- gRPC `GetProcesses` + CLI `k8e-sandbox-cli ps <sid>`

## Why
Completes M5 observability: events (what happened), transcripts (what was run), metrics (how fast), and now process topology (what is running now) — operators can see live agent processes in the sandbox.

## Tests
- Go: `TestGetProcesses_ReadsProcessTopology` (proxy + pid/comm/state passthrough)
- Full zig suite passes in debian container (processes.zig compiles + /proc scan runs)
- sandboxmatrix/sandboxcli all green