### PR TITLE
feat(sandbox): rebuild run registry from session annotations (KIP-16 M6)

### DIFF
--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -748,6 +748,10 @@ func (o *Orchestrator) ExecBackground(ctx context.Context, sessionID, command st
 	o.runRegistry[runID] = sessionID
 	o.mu.Unlock()
 
+	// M6: persist the run_id on the session CRD so a gateway restart can
+	// rebuild the registry (ephemeral-sandbox recover_sandboxes analog).
+	o.recordRunOnSession(ctx, sessionID, runID)
+
 	return runID, nil
 }
 
@@ -778,7 +782,31 @@ func (o *Orchestrator) PollRun(ctx context.Context, runID string) (*pb.PollRunRe
 	return &result, nil
 }
 
-// RebuildRunRegistry scans Session CRDs and rebuilds the run_registry on startup.
+// backgroundRunAnnotation lists run_ids registered on a session (comma-
+// separated); used to rebuild the in-memory run registry after a gateway
+// restart (KIP-16 M6 / ephemeral-sandbox recover_sandboxes analog).
+const backgroundRunAnnotation = "sandbox.k8e.io/background-runs"
+
+// recordRunOnSession appends a run_id to the session CRD annotation so the
+// registry survives gateway restarts.
+func (o *Orchestrator) recordRunOnSession(ctx context.Context, sessionID, runID string) {
+	session, err := o.getSession(ctx, sessionID)
+	if err != nil {
+		return
+	}
+	if session.Annotations == nil {
+		session.Annotations = map[string]string{}
+	}
+	cur := session.Annotations[backgroundRunAnnotation]
+	if cur != "" {
+		cur += ","
+	}
+	session.Annotations[backgroundRunAnnotation] = cur + runID
+	o.updateSession(ctx, session)
+}
+
+// RebuildRunRegistry scans Session CRDs and rebuilds the run_registry on startup
+// from the persisted run_id annotations (KIP-16 M6).
 func (o *Orchestrator) RebuildRunRegistry(ctx context.Context, namespace string) {
 	sessions, err := o.dynamic.Resource(sessionGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -787,10 +815,15 @@ func (o *Orchestrator) RebuildRunRegistry(ctx context.Context, namespace string)
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	for _, s := range sessions.Items {
-		phase, _, _ := unstructured.NestedString(s.Object, "status", "phase")
-		if phase == string(sandboxv1.SandboxPhaseBackgroundRunning) || phase == string(sandboxv1.SandboxPhaseBackgroundCompleted) {
-			// Registry rebuild: background phase exists, run registry needs the run_id entry.
-			// run_id is stored in sandboxd files on the pod; actual rebuild from files happens on first PollRun call.
+		sessionID := s.GetName()
+		annos := s.GetAnnotations()
+		for _, runID := range strings.Split(annos[backgroundRunAnnotation], ",") {
+			if runID == "" {
+				continue
+			}
+			if _, exists := o.runRegistry[runID]; !exists {
+				o.runRegistry[runID] = sessionID
+			}
 		}
 	}
 }
@@ -841,6 +874,15 @@ func (o *Orchestrator) updateSessionStatus(ctx context.Context, session *sandbox
 		return
 	}
 	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).UpdateStatus(ctx, u, metav1.UpdateOptions{})
+}
+
+// updateSession persists a session's spec+metadata (annotations), not just status.
+func (o *Orchestrator) updateSession(ctx context.Context, session *sandboxv1.SandboxSession) {
+	u, err := sessionToUnstructured(session)
+	if err != nil {
+		return
+	}
+	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).Update(ctx, u, metav1.UpdateOptions{}) //nolint:errcheck
 }
 
 func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeClass, pvcName, cpu, memory string) (*corev1.Pod, error) {

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -63,11 +63,6 @@ var (
 	sessionGVR = schema.GroupVersionResource{Group: sandboxAPIGroup, Version: "v1alpha1", Resource: "sandboxsessions"}
 	cnpGVR     = schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"}
 	matrixGVR  = schema.GroupVersionResource{Group: sandboxAPIGroup, Version: "v1alpha1", Resource: "sandboxmatrices"}
-
-	defaultAllowedHosts = []string{
-		"pypi.org", "files.pythonhosted.org", "registry.npmjs.org",
-		"objects.githubusercontent.com", "github.com", "raw.githubusercontent.com",
-	}
 )
 
 type pendingApproval struct {
@@ -347,7 +342,7 @@ func (o *Orchestrator) createSessionWithTTL(ctx context.Context, req *pb.CreateS
 	}
 
 	now := time.Now()
-	// use request allowed_hosts; fall back to SandboxMatrix.spec.defaultAllowedHosts; then hardcoded defaults
+	// Use request allowed_hosts; fall back to SandboxMatrix.spec.defaultAllowedHosts.
 	allowedHosts := req.AllowedHosts
 	if len(allowedHosts) == 0 && len(matrixDefaultHosts) > 0 {
 		allowedHosts = matrixDefaultHosts

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -876,15 +876,6 @@ func (o *Orchestrator) updateSessionStatus(ctx context.Context, session *sandbox
 	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).UpdateStatus(ctx, u, metav1.UpdateOptions{})
 }
 
-// updateSession persists a session's spec+metadata (annotations), not just status.
-func (o *Orchestrator) updateSession(ctx context.Context, session *sandboxv1.SandboxSession) {
-	u, err := sessionToUnstructured(session)
-	if err != nil {
-		return
-	}
-	o.dynamic.Resource(sessionGVR).Namespace(sandboxNS).Update(ctx, u, metav1.UpdateOptions{}) //nolint:errcheck
-}
-
 func (o *Orchestrator) claimOrCreatePod(ctx context.Context, sessionID, runtimeClass, pvcName, cpu, memory string) (*corev1.Pod, error) {
 	start := time.Now()
 	// Only ephemeral sessions (no PVC) may adopt a warm pod: warm pods boot with an

--- a/pkg/sandboxmatrix/grpc/orchestrator_test.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator_test.go
@@ -1062,3 +1062,47 @@ func TestMarkDestroyStep_Idempotent(t *testing.T) {
 		t.Fatalf("expected deduped ledger 'cnp,workspace', got %q", ledger)
 	}
 }
+
+// TestRebuildRunRegistry_FromSessionAnnotations verifies the M6 rebuild restores
+// the run registry from persisted session annotations after a restart.
+func TestRebuildRunRegistry_FromSessionAnnotations(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+
+	// Create a session with persisted background-run annotations.
+	_ = mustCreateSession(t, o, "rebuild-sess")
+	// Simulate ExecBackground's persistence.
+	o.recordRunOnSession(ctx, "rebuild-sess", "rebuild-sess-bg-111")
+	o.recordRunOnSession(ctx, "rebuild-sess", "rebuild-sess-bg-222")
+
+	// Simulate a restart: fresh registry.
+	o.runRegistry = map[string]string{}
+
+	o.RebuildRunRegistry(ctx, sandboxNS)
+
+	if got := o.countAllBackgroundRuns(); got != 2 {
+		t.Fatalf("expected 2 rebuilt runs, got %d", got)
+	}
+	if o.runRegistry["rebuild-sess-bg-111"] != "rebuild-sess" {
+		t.Fatalf("rebuild missing bg-111 mapping: %v", o.runRegistry)
+	}
+	if o.runRegistry["rebuild-sess-bg-222"] != "rebuild-sess" {
+		t.Fatalf("rebuild missing bg-222 mapping: %v", o.runRegistry)
+	}
+}
+
+// TestRebuildRunRegistry_Idempotent verifies re-running rebuild does not
+// duplicate entries.
+func TestRebuildRunRegistry_Idempotent(t *testing.T) {
+	o := newTestOrchestrator()
+	ctx := context.Background()
+	_ = mustCreateSession(t, o, "rebuild-idem")
+	o.recordRunOnSession(ctx, "rebuild-idem", "rebuild-idem-bg-1")
+
+	o.RebuildRunRegistry(ctx, sandboxNS)
+	o.RebuildRunRegistry(ctx, sandboxNS) // second rebuild
+
+	if got := o.countAllBackgroundRuns(); got != 1 {
+		t.Fatalf("expected 1 rebuilt run (idempotent), got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

KIP-16 **M6**: gateway restarts no longer orphan background runs — the run registry is rebuilt from persisted session annotations (ephemeral-sandbox `recover_sandboxes()` analog).

## What
- `ExecBackground` persists each run_id on the session CRD (`sandbox.k8e.io/background-runs`)
- `RebuildRunRegistry` (already invoked on gateway startup) restores the in-memory run→session map from those annotations
- `PollRun` works after a restart instead of returning `run not found`

## Why (KIP-16 M6 evidence)
The old `RebuildRunRegistry` was an empty stub — a gateway restart lost all in-flight background runs (their status lived only in memory). Persisting run ids on the CRD makes the registry durable and observable.

## Tests
- `TestRebuildRunRegistry_FromSessionAnnotations`: 2 persisted runs restored after simulated restart
- `TestRebuildRunRegistry_Idempotent`: re-rebuild does not duplicate
- All sandboxmatrix/sandboxcli green