### PR TITLE
feat(skill): upgrade k8e-sandbox SKILL.md capabilities + document binary naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ k8e sandbox-apikey create my-agent
 
 Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`
 
+> **One binary, two names:** the downloaded `k8e-sandbox-cli-linux-amd64` file **is** the `k8e-sandbox-cli` command the skill uses. `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs the `/k8e-sandbox` skill into your agent harnesses, so every skill example (`k8e-sandbox-cli run ...`) is the same file you just downloaded.
+
 Then ask your agent naturally:
 
 > "Run this Python snippet in a sandbox"
@@ -304,6 +306,8 @@ chmod +x k8e-sandbox-cli-linux-amd64
 ```
 
 Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`
+
+> **One binary, two names:** the downloaded `k8e-sandbox-cli-linux-amd64` file **is** the `k8e-sandbox-cli` command the skill uses. `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs the `/k8e-sandbox` skill, so every skill example (`k8e-sandbox-cli run ...`) is the same file you just downloaded.
 
 Then in your agent harness:
 

--- a/README.md
+++ b/README.md
@@ -187,12 +187,15 @@ Download the standalone sandbox CLI, authenticate, and install the skill into yo
 curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64
 chmod +x k8e-sandbox-cli-linux-amd64
 
+# Rename to the plain command name used by the skill
+mv k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli
+
 # Create an API key on the server
 k8e sandbox-apikey create my-agent
 # → {"name":"my-agent","key":"k8e-abc123..."}
 
 # Connect: authenticate (mTLS) + install /k8e-sandbox skill into agent harnesses
-./k8e-sandbox-cli-linux-amd64 --endpoint <server-ip>:50051 --apikey k8e-abc123... connect
+./k8e-sandbox-cli --endpoint <server-ip>:50051 --apikey k8e-abc123... connect
 ```
 
 > **Local usage:** If you're on the same machine as the K8E server, the CLI auto-discovers TLS certs — just run `k8e-sandbox-cli connect`.
@@ -300,9 +303,12 @@ k8e sandbox-apikey create my-agent
 curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64
 chmod +x k8e-sandbox-cli-linux-amd64
 
-# 2. Connect: mTLS auth + install /k8e-sandbox skill into Claude/Codex/Pi
+# 2. Rename to the plain command name used by the skill
+mv k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli
+
+# 3. Connect: mTLS auth + install /k8e-sandbox skill into Claude/Codex/Pi
 #    Note: --endpoint and --apikey are global flags, placed before the subcommand
-./k8e-sandbox-cli-linux-amd64 --endpoint <server-ip>:50051 --apikey k8e-abc123... connect
+./k8e-sandbox-cli --endpoint <server-ip>:50051 --apikey k8e-abc123... connect
 ```
 
 Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`

--- a/README.md
+++ b/README.md
@@ -183,12 +183,13 @@ kubectl -n sandbox-matrix get pods   # Sandbox Matrix starts automatically
 Download the standalone sandbox CLI, authenticate, and install the skill into your agent:
 
 ```bash
-# Download sandbox CLI (~44MB)
+# Download sandbox CLI (~44MB) — pick your platform suffix
+#   k8e-sandbox-cli-linux-amd64 / linux-arm64 / darwin-amd64 / darwin-arm64 / windows-amd64.exe
 curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64
 chmod +x k8e-sandbox-cli-linux-amd64
 
-# Rename to the plain command name used by the skill
-mv k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli
+# Symlink the plain command name to the downloaded file (do not rename)
+ln -s k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli
 
 # Create an API key on the server
 k8e sandbox-apikey create my-agent
@@ -200,7 +201,7 @@ k8e sandbox-apikey create my-agent
 
 > **Local usage:** If you're on the same machine as the K8E server, the CLI auto-discovers TLS certs — just run `k8e-sandbox-cli connect`.
 
-Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`
+Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}` (Windows: `k8e-sandbox-cli-windows-amd64.exe`, symlink via `mklink k8e-sandbox-cli.exe k8e-sandbox-cli-windows-amd64.exe`)
 
 > **One binary, two names:** the downloaded `k8e-sandbox-cli-linux-amd64` file **is** the `k8e-sandbox-cli` command the skill uses. `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs the `/k8e-sandbox` skill into your agent harnesses, so every skill example (`k8e-sandbox-cli run ...`) is the same file you just downloaded.
 
@@ -300,20 +301,21 @@ k8e sandbox-apikey create my-agent
 
 ```bash
 # 1. Download the platform-specific binary (~44MB)
+#    k8e-sandbox-cli-linux-amd64 / linux-arm64 / darwin-amd64 / darwin-arm64 / windows-amd64.exe
 curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64
 chmod +x k8e-sandbox-cli-linux-amd64
 
-# 2. Rename to the plain command name used by the skill
-mv k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli
+# 2. Symlink the plain command name to the downloaded file (do not rename)
+ln -s k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli
 
 # 3. Connect: mTLS auth + install /k8e-sandbox skill into Claude/Codex/Pi
 #    Note: --endpoint and --apikey are global flags, placed before the subcommand
 ./k8e-sandbox-cli --endpoint <server-ip>:50051 --apikey k8e-abc123... connect
 ```
 
-Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`
+Platform binaries: `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}` (Windows: `k8e-sandbox-cli-windows-amd64.exe`, symlink via `mklink k8e-sandbox-cli.exe k8e-sandbox-cli-windows-amd64.exe`)
 
-> **One binary, two names:** the downloaded `k8e-sandbox-cli-linux-amd64` file **is** the `k8e-sandbox-cli` command the skill uses. `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs the `/k8e-sandbox` skill, so every skill example (`k8e-sandbox-cli run ...`) is the same file you just downloaded.
+> **One binary, two names:** the downloaded `k8e-sandbox-cli-linux-amd64` file **is** the `k8e-sandbox-cli` command the skill uses — the symlink is just a plain-name alias to the same file. `connect` installs the `/k8e-sandbox` skill, so every skill example (`k8e-sandbox-cli run ...`) is the same file you just downloaded.
 
 Then in your agent harness:
 

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -27,10 +27,11 @@ If `$ARGUMENTS` is empty and no goal is otherwise provided, ask the user for a s
 `k8e-sandbox-cli-linux-amd64` (and `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`) is the **platform-suffixed download name** of the very same binary this skill invokes as `k8e-sandbox-cli`. They are the same file:
 
 1. Download: `curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64 && chmod +x k8e-sandbox-cli-linux-amd64`
-2. Run `./k8e-sandbox-cli-linux-amd64 ... connect` — `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs this skill into your agent harnesses.
-3. From then on, this skill and all examples use the plain name `k8e-sandbox-cli` — same binary.
+2. Rename the downloaded file to the plain command name: `mv k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli` (optionally move it into a `PATH` directory, e.g. `~/.local/bin/`)
+3. Run `./k8e-sandbox-cli ... connect` — `connect` installs this skill into your agent harnesses and ensures `k8e-sandbox-cli` is on `PATH`.
+4. From then on, this skill and all examples use the plain name `k8e-sandbox-cli` — same binary.
 
-If you only see `k8e-sandbox-cli-linux-amd64` in the user's environment (no `k8e-sandbox-cli` yet), use that file directly: `./k8e-sandbox-cli-linux-amd64 status` etc. Both spellings are interchangeable; never tell the user they are missing a second binary.
+If you only see `k8e-sandbox-cli-linux-amd64` in the user's environment (not yet renamed), use that file directly: `./k8e-sandbox-cli-linux-amd64 status` etc. Both spellings are interchangeable; never tell the user they are missing a second binary.
 
 ## Hard rules
 

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -26,7 +26,7 @@ If `$ARGUMENTS` is empty and no goal is otherwise provided, ask the user for a s
 
 `k8e-sandbox-cli-linux-amd64` (and `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`) is the **platform-suffixed download name** of the very same binary this skill invokes as `k8e-sandbox-cli`. They are the same file:
 
-1. Download: `curl -sLO .../k8e-sandbox-cli-linux-amd64 && chmod +x k8e-sandbox-cli-linux-amd64`
+1. Download: `curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64 && chmod +x k8e-sandbox-cli-linux-amd64`
 2. Run `./k8e-sandbox-cli-linux-amd64 ... connect` — `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs this skill into your agent harnesses.
 3. From then on, this skill and all examples use the plain name `k8e-sandbox-cli` — same binary.
 

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -24,14 +24,32 @@ If `$ARGUMENTS` is empty and no goal is otherwise provided, ask the user for a s
 
 ## Binary naming (read this first)
 
-`k8e-sandbox-cli-linux-amd64` (and `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`) is the **platform-suffixed download name** of the very same binary this skill invokes as `k8e-sandbox-cli`. They are the same file:
+The downloaded file name carries a **platform suffix** — pick the one for the user's machine:
 
-1. Download: `curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64 && chmod +x k8e-sandbox-cli-linux-amd64`
-2. Rename the downloaded file to the plain command name: `mv k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli` (optionally move it into a `PATH` directory, e.g. `~/.local/bin/`)
-3. Run `./k8e-sandbox-cli ... connect` — `connect` installs this skill into your agent harnesses and ensures `k8e-sandbox-cli` is on `PATH`.
-4. From then on, this skill and all examples use the plain name `k8e-sandbox-cli` — same binary.
+| Platform | Download name |
+|----------|---------------|
+| Linux amd64 | `k8e-sandbox-cli-linux-amd64` |
+| Linux arm64 | `k8e-sandbox-cli-linux-arm64` |
+| macOS amd64 | `k8e-sandbox-cli-darwin-amd64` |
+| macOS arm64 | `k8e-sandbox-cli-darwin-arm64` |
+| Windows amd64 | `k8e-sandbox-cli-windows-amd64.exe` |
 
-If you only see `k8e-sandbox-cli-linux-amd64` in the user's environment (not yet renamed), use that file directly: `./k8e-sandbox-cli-linux-amd64 status` etc. Both spellings are interchangeable; never tell the user they are missing a second binary.
+It is the **same binary** this skill invokes as `k8e-sandbox-cli` — just under the platform-suffixed name. To make the plain name work without renaming, create a **symlink** (do not rename the file):
+
+```bash
+# Example for Linux amd64 — substitute the platform name for other OS/arch
+curl -sLO https://github.com/xiaods/k8e/releases/latest/download/k8e-sandbox-cli-linux-amd64
+chmod +x k8e-sandbox-cli-linux-amd64
+ln -s k8e-sandbox-cli-linux-amd64 k8e-sandbox-cli          # symlink, original file stays
+# optionally move both into a PATH dir, e.g. ~/.local/bin/
+./k8e-sandbox-cli ... connect                             # connect installs this skill + ensures PATH
+```
+
+(Windows: use `mklink k8e-sandbox-cli.exe k8e-sandbox-cli-windows-amd64.exe` in cmd.)
+
+From then on, this skill and all examples use the plain name `k8e-sandbox-cli` — same binary.
+
+If you only see a platform-suffixed name in the user's environment (no symlink yet), use that file directly: `./k8e-sandbox-cli-linux-amd64 status` etc. All spellings are interchangeable; never tell the user they are missing a second binary.
 
 ## Hard rules
 

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -22,6 +22,16 @@ $ARGUMENTS
 
 If `$ARGUMENTS` is empty and no goal is otherwise provided, ask the user for a sandbox goal and **stop** (do not invent work).
 
+## Binary naming (read this first)
+
+`k8e-sandbox-cli-linux-amd64` (and `k8e-sandbox-cli-{darwin,linux,windows}-{amd64,arm64}`) is the **platform-suffixed download name** of the very same binary this skill invokes as `k8e-sandbox-cli`. They are the same file:
+
+1. Download: `curl -sLO .../k8e-sandbox-cli-linux-amd64 && chmod +x k8e-sandbox-cli-linux-amd64`
+2. Run `./k8e-sandbox-cli-linux-amd64 ... connect` — `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli` (on PATH) and installs this skill into your agent harnesses.
+3. From then on, this skill and all examples use the plain name `k8e-sandbox-cli` — same binary.
+
+If you only see `k8e-sandbox-cli-linux-amd64` in the user's environment (no `k8e-sandbox-cli` yet), use that file directly: `./k8e-sandbox-cli-linux-amd64 status` etc. Both spellings are interchangeable; never tell the user they are missing a second binary.
+
 ## Hard rules
 
 1. **All code and shell execution goes through `k8e-sandbox-cli`** — never run `python3`, `node`, `pip`, `npm`, `curl`, compilers, or tests on the host for this goal.
@@ -58,9 +68,19 @@ k8e-sandbox-cli run 'pip install pandas' --lang bash
 # write via stdin:
 # cat analysis.py | k8e-sandbox-cli write <session_id> /workspace/analysis.py
 # k8e-sandbox-cli run 'python3 /workspace/analysis.py' --session-id <session_id>
+
+# Background exec (returns run_id immediately)
+k8e-sandbox-cli run 'sleep 30; echo done' --background
+k8e-sandbox-cli poll <run-id>            # wait + stream output
+
+# Tenant reuse (share one session across CLI calls)
+k8e-sandbox-cli run 'echo hi' --tenant my-project
+
+# Sub-agent: child session sharing parent pod + workspace (no new pod)
+k8e-sandbox-cli subagent <parent-sid>
 ```
 
-Useful commands: `run`, `write`, `read`, `list`, `create`, `get`, `sessions`, `destroy`, `status`.
+Useful commands: `run`, `write`, `read`, `list`, `create`, `get`, `sessions`, `destroy`, `status`, `log`, `events`, `ps`, `poll`, `subagent`, `confirm`, `approve`, `snapshot`, `benchmark`, `catalog`.
 
 ### 4. Report
 
@@ -76,7 +96,7 @@ k8e-sandbox-cli connect
 k8e-sandbox-cli connect --endpoint <server-ip>:50051 --apikey k8e-...
 ```
 
-`connect` authenticates, verifies the gateway, puts `k8e-sandbox-cli` on PATH when needed, and installs this skill into Claude / Codex / Pi discovery paths.
+`connect` authenticates, verifies the gateway, puts `k8e-sandbox-cli` on PATH when needed (symlink to `~/.local/bin/k8e-sandbox-cli`), and installs this skill into Claude / Codex / Pi discovery paths.
 
 ## Command reference
 
@@ -86,23 +106,21 @@ k8e-sandbox-cli connect --endpoint <server-ip>:50051 --apikey k8e-...
 | `k8e-sandbox-cli connect --skill-only` | Re-install this skill only (no gateway dial) |
 | `k8e-sandbox-cli login` | Remote mTLS only (no skill install) |
 | `k8e-sandbox-cli status` | Gateway + session probe |
-| `k8e-sandbox-cli run <code>` | Exec in sandbox (`--lang`, `--raw`, `--session-id`, `--tenant`, `--background`) |
-| `k8e-sandbox-cli create` | Manual session (`--runtime`, `--env`, `--secret`, `--allowed-hosts`) |
+| `k8e-sandbox-cli run <code>` | Exec in sandbox (`--lang`, `--timeout`, `--raw`, `--session-id`, `--tenant`, `--background`, `--manifest`, `--git-repo`, `--allowed-hosts`) |
+| `k8e-sandbox-cli create` | Manual session (`--runtime`, `--env`, `--secret`, `--allowed-hosts`, `--manifest`, `--git-repo`) |
 | `k8e-sandbox-cli get <sid>` | Session introspection (phase, runtime, env keys) |
 | `k8e-sandbox-cli sessions` | List sessions |
 | `k8e-sandbox-cli write/read/list` | Workspace files; `list --since <ts>` for changed-file diff |
-| `k8e-sandbox-cli log <sid>` | Replay exec transcript | `--offset`, `--limit`, `--follow` |
-| `k8e-sandbox-cli events <sid>` | Read daemon NDJSON event stream | `--limit` |
-| `k8e-sandbox-cli ps <sid>` | List processes in the sandbox pod | pid, comm, state |
-| `k8e-sandbox-cli poll <run-id>` | Poll a background run | |
+| `k8e-sandbox-cli log <sid>` | Replay exec transcript (`--offset`, `--limit`, `--follow`) |
+| `k8e-sandbox-cli events <sid>` | Read daemon NDJSON event stream (`--limit`) |
+| `k8e-sandbox-cli ps <sid>` | List processes in the sandbox pod (pid, comm, state) |
+| `k8e-sandbox-cli poll <run-id>` | Poll a background run (`--follow`) |
 | `k8e-sandbox-cli subagent <parent-sid>` | Spawn child session (shares parent's pod + workspace — no new pod) |
-
-| `k8e-sandbox-cli subagent <parent-sid>` | Spawn child session (shares parent pod + workspace) |
-| `k8e-sandbox-cli confirm <sid> <action>` | Gate destructive action on human approval |
-| `k8e-sandbox-cli approve <aid>` | Approve a pending confirm | `--reject` |
-| `k8e-sandbox-cli snapshot save/restore/list/delete` | Content-addressed snapshots | `save --remote`, `restore --base <snap>` |
-| `k8e-sandbox-cli benchmark` | Warm-pool latency metrics | `--pool-size`, `--iterations` |
-| `k8e-sandbox-cli catalog` | Emit machine-readable command surface (SDK generation) | |
+| `k8e-sandbox-cli confirm <sid> <action>` | Gate destructive action on human approval (`--timeout`, `--no-wait`) |
+| `k8e-sandbox-cli approve <aid>` | Approve a pending confirm (`--reject`, `--reason`) |
+| `k8e-sandbox-cli snapshot save/restore/list/delete` | Content-addressed snapshots (`save --remote`, `restore --base <snap>`) |
+| `k8e-sandbox-cli benchmark` | Warm-pool latency metrics (`--pool-size`, `--iterations`) |
+| `k8e-sandbox-cli catalog` | Emit machine-readable command surface (SDK generation) |
 | `k8e-sandbox-cli destroy <sid>` | Tear down session |
 
 Default run output is JSON: `stdout`, `stderr`, `exit_code`, `session_id`. Use `--raw` to stream text.
@@ -124,6 +142,7 @@ Default allowed hosts (kernel eBPF): `pypi.org`, `files.pythonhosted.org`, `regi
 - `--env` is for non-sensitive config only (stored on CRD). Use `--secret ENV=secret:key` for secrets.
 - Never pass host secrets into sandbox flags in chat logs if avoidable.
 - Never `sudo` via sandbox CLI.
+- Destructive sandbox actions require `confirm` → `approve` (human in the loop); don't skip it.
 
 ## Error quick reference
 


### PR DESCRIPTION
## Summary

Upgrades the embedded `k8e-sandbox` agent skill (stays at `pkg/sandboxcli/skills/k8e-sandbox/SKILL.md`) and documents that the downloaded `k8e-sandbox-cli-linux-amd64` binary is the same file as the `k8e-sandbox-cli` command the skill uses.

### Changes

**SKILL.md upgrade**
- Full command surface: `snapshot`, `benchmark`, `catalog`, `subagent`, `confirm`/`approve`, `log`/`events`/`ps`/`poll`, `run --background/--tenant/--secret/--manifest/--git-repo`
- Removed duplicated `subagent` table row
- New "Binary naming" section: `k8e-sandbox-cli-linux-amd64` (downloaded file) **is** `k8e-sandbox-cli` (PATH command) — `connect` symlinks it to `~/.local/bin/k8e-sandbox-cli`
- Added human-in-loop `confirm → approve` red line

**README**
- Step 4 + Install-the-Skill: explicit one-binary-two-names note

### Validation
- `go build ./cmd/sandboxcli/` ✓
- `go test ./pkg/sandboxcli/...` ✓
- `go vet ./pkg/sandboxcli/` ✓