### PR TITLE
fix(sandbox): disambiguate CLI profiles from server config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ k8e sandbox-apikey create my-agent
 # Connect: authenticate (mTLS) + install /k8e-sandbox skill into agent harnesses
 ./k8e-sandbox-cli --endpoint <server-ip>:50051 --apikey k8e-abc123... connect
 
-# Optional multi-cluster profiles (~/.k8e/config.yaml) — see docs/kip-17-sandbox-cli-profiles-and-apikey-ttl.md
+# Optional multi-cluster profiles (~/.k8e/sandbox/profiles.yaml — not server /etc/k8e/config.yaml)
+# See docs/kip-17-sandbox-cli-profiles-and-apikey-ttl.md
 # ./k8e-sandbox-cli --profile prod connect --apikey k8e-...
 ```
 
@@ -332,7 +333,7 @@ Or ask naturally: *"Run this Python snippet in a sandbox"* — the skill drives 
 
 | Command | Description |
 |---|---|
-| `k8e-sandbox-cli --profile <name> …` | Use named profile from `~/.k8e/config.yaml` (KIP-17) |
+| `k8e-sandbox-cli --profile <name> …` | Use named profile from `~/.k8e/sandbox/profiles.yaml` (KIP-17; not `/etc/k8e/config.yaml`) |
 | `k8e-sandbox-cli connect` | Connect local/remote gateway and install `/k8e-sandbox` agent skill |
 | `k8e-sandbox-cli connect --skill-only` | Re-install agent skill only (no gateway dial) |
 | `k8e-sandbox-cli login` | Authenticate only (mTLS cert; no skill install) |

--- a/cmd/sandboxcli/main.go
+++ b/cmd/sandboxcli/main.go
@@ -24,7 +24,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "endpoint", EnvVar: "K8E_SANDBOX_ENDPOINT", Usage: "gRPC endpoint (default: 127.0.0.1:50051)"},
 		cli.StringFlag{Name: "apikey", EnvVar: "K8E_SANDBOX_APIKEY", Usage: "API key for remote cluster authentication"},
-		cli.StringFlag{Name: "profile", EnvVar: "K8E_SANDBOX_PROFILE", Usage: "Named profile from ~/.k8e/config.yaml (KIP-17)"},
+		cli.StringFlag{Name: "profile", EnvVar: "K8E_SANDBOX_PROFILE", Usage: "Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17; not server /etc/k8e/config.yaml)"},
 	}
 	commands := []cli.Command{
 		sandboxcli.ConnectCommand(),

--- a/docs/kip-17-sandbox-cli-profiles-and-apikey-ttl.md
+++ b/docs/kip-17-sandbox-cli-profiles-and-apikey-ttl.md
@@ -8,44 +8,48 @@
 
 Make remote sandbox auth usable for humans and AI agents that talk to **more than one** K8E cluster, and make bootstrap API keys **short-lived by default**.
 
-1. **Multi-profile `config.yaml`** — named endpoints + optional per-profile cert directories, selected by `--profile` / `K8E_SANDBOX_PROFILE`.
+1. **Multi-profile `profiles.yaml`** — named endpoints + optional per-profile cert directories, selected by `--profile` / `K8E_SANDBOX_PROFILE`.
 2. **API key TTL** — `k8e sandbox-apikey create` defaults to **30 days**; gateway Login rejects expired keys.
 3. **Compatible with KIP-14 / issue #538 mTLS** — profiles only choose *where* certs live; Login still issues 90-day client certs with 30-day lazy renew.
 
 ## Motivation
 
-Issue #538 sketched:
+Users need multiple gateway endpoints without juggling env vars. A naive `~/.k8e/config.yaml` **collides in name** with the server daemon flag file `/etc/k8e/config.yaml` (written at install / parsed by `configfilearg`). Those two files are **not the same format** and must stay distinct (same lesson as kip-4 sandbox-mcp: never overload `config.yaml`).
 
-```yaml
-# ~/.k8e/config.yaml
-profiles:
-  default:
-    endpoint: 10.0.0.1:50051
-  prod:
-    endpoint: prod.k8e.example:50051
-    cert_dir: ~/.k8e/sandbox-prod
-```
+| File | Owner | Purpose | Format |
+|------|-------|---------|--------|
+| `/etc/k8e/config.yaml` | **k8e server/agent** | Daemon CLI flags (`write-kubeconfig-mode`, `tls-san`, …) | flag keys → `configfilearg` |
+| `~/.k8e/sandbox/profiles.yaml` | **k8e-sandbox-cli** | Named remote gateways + cert dirs | `version` + `profiles` map |
+| `~/.k8e/sandbox/config.json` | **k8e-sandbox-cli** | Last successful connect stamp | JSON `{mode,endpoint,agents}` |
+| `~/.k8e/sandbox/{ca,client}.*` | **k8e-sandbox-cli** | mTLS material for active cert dir | PEM |
 
-Today the CLI stores a single last-used connection in `~/.k8e/sandbox/config.json` and a single cert cache. Switching clusters requires manual env overrides and easily reuses the wrong mTLS material.
-
-API keys are currently immortal secrets in `sandbox-matrix/sandbox-apikeys`. Bootstrap tokens should be revocable by time as well as by delete.
+API keys remain immortal-or-TTL secrets in `sandbox-matrix/sandbox-apikeys` (not in any local yaml).
 
 ## Design
 
 ### Part A — Profile file
 
+**Canonical path:** `~/.k8e/sandbox/profiles.yaml`  
+(or `$K8E_SANDBOX_CERT_DIR/profiles.yaml` when cert dir is overridden)
+
 **Path resolution (first hit wins):**
 
 | Priority | Source |
 |----------|--------|
-| 1 | `K8E_SANDBOX_CONFIG` (absolute or relative path) |
-| 2 | `~/.k8e/config.yaml` |
+| 1 | `K8E_SANDBOX_CONFIG` (explicit path) |
+| 2 | `~/.k8e/sandbox/profiles.yaml` (canonical) |
+| 3 | `~/.k8e/config.yaml` (**legacy only** — deprecation warning on stderr; migrate away) |
 
-k8e does **not** use `XDG_CONFIG_HOME`; paths stay under `~/.k8e/` (or explicit `K8E_SANDBOX_*` overrides).
+**Why not `config.yaml` for the CLI:**
+
+- Server already owns `/etc/k8e/config.yaml` as the only well-known `config.yaml` for k8e.
+- `configfilearg` strips unknown keys; dropping a profiles document there would silently break server startup if someone merged files.
+- A verb-named file (`profiles.yaml`) next to certs matches “client multi-cluster” mental model.
 
 **Schema (`version: 1`):**
 
 ```yaml
+# ~/.k8e/sandbox/profiles.yaml  — NOT /etc/k8e/config.yaml
 version: 1
 current_profile: default   # used when --profile / env unset
 profiles:
@@ -84,7 +88,8 @@ Applying a profile with `cert_dir` sets `K8E_SANDBOX_CERT_DIR` for the process s
 
 **Non-goals (this KIP):**
 
-- Storing API keys inside `config.yaml` (still env / flag only)
+- Storing API keys inside profiles.yaml (still env / flag only)
+- Writing profiles into `/etc/k8e/config.yaml` (server-only)
 - Interactive profile wizard
 - Syncing profiles via cluster CRDs
 
@@ -149,5 +154,6 @@ Default client cert lifetime (KIP-14 / #538) stays **90 days** with lazy renew a
 | Option | Why not |
 |--------|---------|
 | One cert dir, multiple endpoint stamps only | Still no named ergonomics; agents need stable `--profile prod` |
-| Store keys in config.yaml | Secrets in user config files leak into backups/chat |
+| Store keys in profiles.yaml | Secrets in user config files leak into backups/chat |
+| Reuse name `~/.k8e/config.yaml` | Collides with server `/etc/k8e/config.yaml` in user mental model |
 | Force-migrate legacy keys to 30d | Breaks existing clusters; migrate only on new create |

--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -23,7 +23,7 @@ const errSessionNotFound = "not found"
 var ErrSessionGone = errors.New("sandbox session expired or destroyed")
 
 // newClientFromCtx creates a gRPC client using endpoint/apikey from global flags,
-// env, and optional ~/.k8e/config.yaml profile (KIP-17).
+// env, and optional ~/.k8e/sandbox/profiles.yaml profile (KIP-17).
 func newClientFromCtx(ctx *cli.Context) (*client.Client, *ExitError) {
 	resolved, err := ResolveConn(ctx.GlobalString("endpoint"), ctx.GlobalString("apikey"), ctx.GlobalString("profile"), "")
 	if err != nil {

--- a/pkg/sandboxcli/connect.go
+++ b/pkg/sandboxcli/connect.go
@@ -250,7 +250,8 @@ func printConnectSuccess(mode, endpoint, cliPath string, agents []string, result
 	}
 	fmt.Fprintf(os.Stderr, "✓ Connected to K8E sandbox (%s)\n", mode)
 	fmt.Fprintf(os.Stderr, "  Endpoint: %s\n", ep)
-	fmt.Fprintf(os.Stderr, "  Config:   ~/.k8e/sandbox/config.json (profiles: ~/.k8e/config.yaml)\n")
+	fmt.Fprintf(os.Stderr, "  Config:   ~/.k8e/sandbox/config.json (last connect)\n")
+	fmt.Fprintf(os.Stderr, "  Profiles: ~/.k8e/sandbox/profiles.yaml (CLI only; server uses /etc/k8e/config.yaml)\n")
 	if mode == "remote" {
 		fmt.Fprintf(os.Stderr, "  Creds:    ~/.k8e/sandbox/{ca.crt,client.crt,client.key} (or profile cert_dir)\n")
 	}

--- a/pkg/sandboxcli/profile.go
+++ b/pkg/sandboxcli/profile.go
@@ -9,7 +9,17 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// ProfileFile is the multi-cluster CLI config (KIP-17): ~/.k8e/config.yaml.
+// Canonical multi-profile file for k8e-sandbox-cli (KIP-17).
+// Intentionally NOT named config.yaml — that name is reserved for the
+// k8e server/agent daemon flag file at /etc/k8e/config.yaml (configfilearg).
+const profilesFileName = "profiles.yaml"
+
+// legacyHomeProfilesPath is the short-lived KIP-17 path that collided in name
+// with the server config. Still read for one release with a stderr warning.
+const legacyHomeProfilesRel = ".k8e/config.yaml"
+
+// ProfileFile is the multi-cluster CLI config (KIP-17).
+// Default path: ~/.k8e/sandbox/profiles.yaml
 type ProfileFile struct {
 	Version        int                `yaml:"version"`
 	CurrentProfile string             `yaml:"current_profile"`
@@ -32,19 +42,36 @@ type ResolvedConn struct {
 	Profile    string // empty if no profile file/selection
 }
 
-// profileConfigPaths returns candidate config.yaml paths in priority order.
+// DefaultProfilesPath returns the canonical user profiles file path.
+func DefaultProfilesPath() (string, error) {
+	dir, err := dataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, profilesFileName), nil
+}
+
+// profileConfigPaths returns candidate profile file paths in priority order.
+//
+//  1. K8E_SANDBOX_CONFIG (explicit override)
+//  2. ~/.k8e/sandbox/profiles.yaml (or $K8E_SANDBOX_CERT_DIR/profiles.yaml)
+//  3. ~/.k8e/config.yaml (legacy; name collides with server /etc/k8e/config.yaml)
 func profileConfigPaths() []string {
 	var paths []string
 	if p := strings.TrimSpace(os.Getenv("K8E_SANDBOX_CONFIG")); p != "" {
 		paths = append(paths, p)
 	}
+	if p, err := DefaultProfilesPath(); err == nil {
+		paths = append(paths, p)
+	}
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		paths = append(paths, filepath.Join(home, ".k8e", "config.yaml"))
+		paths = append(paths, filepath.Join(home, legacyHomeProfilesRel))
 	}
 	return paths
 }
 
 // LoadProfileFile reads the first existing profile config. Returns (nil, nil) when none exist.
+// If the legacy ~/.k8e/config.yaml path is used, a deprecation warning is printed to stderr.
 func LoadProfileFile() (*ProfileFile, string, error) {
 	for _, path := range profileConfigPaths() {
 		data, err := os.ReadFile(path)
@@ -52,18 +79,35 @@ func LoadProfileFile() (*ProfileFile, string, error) {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return nil, path, fmt.Errorf("read profile config %s: %w", path, err)
+			return nil, path, fmt.Errorf("read sandbox profiles %s: %w", path, err)
 		}
 		var f ProfileFile
 		if err := yaml.Unmarshal(data, &f); err != nil {
-			return nil, path, fmt.Errorf("parse profile config %s: %w", path, err)
+			return nil, path, fmt.Errorf("parse sandbox profiles %s: %w", path, err)
 		}
 		if f.Profiles == nil {
 			f.Profiles = map[string]Profile{}
 		}
+		if isLegacyHomeProfilesPath(path) {
+			canonical, _ := DefaultProfilesPath()
+			if canonical == "" {
+				canonical = "~/.k8e/sandbox/profiles.yaml"
+			}
+			fmt.Fprintf(os.Stderr, "⚠ sandbox profiles: %s is deprecated (name collides with server /etc/k8e/config.yaml).\n  Move this file to %s\n", path, canonical)
+		}
 		return &f, path, nil
 	}
 	return nil, "", nil
+}
+
+func isLegacyHomeProfilesPath(path string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	// Compare cleaned absolute-ish paths.
+	legacy := filepath.Clean(filepath.Join(home, legacyHomeProfilesRel))
+	return filepath.Clean(path) == legacy
 }
 
 // SelectProfileName picks the active profile name.
@@ -117,7 +161,7 @@ func ResolveConn(flagEndpoint, flagAPIKey, flagProfile, flagDevice string) (*Res
 	}
 	prof, ok := file.Profiles[name]
 	if !ok {
-		return nil, fmt.Errorf("sandbox profile %q not found in config.yaml", name)
+		return nil, fmt.Errorf("sandbox profile %q not found in profiles.yaml", name)
 	}
 	out.Profile = name
 	if out.Endpoint == "" {

--- a/pkg/sandboxcli/profile_test.go
+++ b/pkg/sandboxcli/profile_test.go
@@ -3,6 +3,7 @@ package sandboxcli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -42,8 +43,9 @@ func TestResolveConnProfileCertDir(t *testing.T) {
 	t.Setenv("K8E_SANDBOX_PROFILE", "")
 	t.Setenv("K8E_SANDBOX_DEVICE_NAME", "")
 
-	cfgDir := filepath.Join(home, ".k8e")
-	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+	// Canonical path: ~/.k8e/sandbox/profiles.yaml
+	profDir := filepath.Join(home, ".k8e", "sandbox")
+	if err := os.MkdirAll(profDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	yaml := []byte(`
@@ -57,7 +59,7 @@ profiles:
     cert_dir: ~/sandbox-prod
     device_name: ci-bot
 `)
-	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), yaml, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(profDir, profilesFileName), yaml, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,13 +96,104 @@ func TestResolveConnMissingProfile(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("K8E_SANDBOX_CONFIG", "")
+	t.Setenv("K8E_SANDBOX_CERT_DIR", "")
 	t.Setenv("K8E_SANDBOX_PROFILE", "")
-	cfgDir := filepath.Join(home, ".k8e")
-	_ = os.MkdirAll(cfgDir, 0700)
-	_ = os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("version: 1\nprofiles:\n  only:\n    endpoint: x:1\n"), 0600)
+	profDir := filepath.Join(home, ".k8e", "sandbox")
+	_ = os.MkdirAll(profDir, 0700)
+	_ = os.WriteFile(filepath.Join(profDir, profilesFileName), []byte("version: 1\nprofiles:\n  only:\n    endpoint: x:1\n"), 0600)
 
 	_, err := ResolveConn("", "", "nope", "")
 	if err == nil {
 		t.Fatal("expected missing profile error")
+	}
+	if !strings.Contains(err.Error(), "profiles.yaml") {
+		t.Fatalf("error should mention profiles.yaml: %v", err)
+	}
+}
+
+func TestLegacyHomeConfigYAMLStillLoads(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("K8E_SANDBOX_CONFIG", "")
+	t.Setenv("K8E_SANDBOX_CERT_DIR", "")
+	t.Setenv("K8E_SANDBOX_PROFILE", "")
+	t.Setenv("K8E_SANDBOX_ENDPOINT", "")
+	t.Setenv("K8E_SANDBOX_APIKEY", "")
+	t.Setenv("K8E_SANDBOX_DEVICE_NAME", "")
+
+	// Only legacy ~/.k8e/config.yaml present (no profiles.yaml).
+	legacyDir := filepath.Join(home, ".k8e")
+	if err := os.MkdirAll(legacyDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	legacy := []byte(`
+version: 1
+current_profile: legacy
+profiles:
+  legacy:
+    endpoint: legacy.example:50051
+`)
+	if err := os.WriteFile(filepath.Join(legacyDir, "config.yaml"), legacy, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := ResolveConn("", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Profile != "legacy" || r.Endpoint != "legacy.example:50051" {
+		t.Fatalf("legacy load failed: %+v", r)
+	}
+}
+
+func TestCanonicalProfilesPathPreferredOverLegacy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("K8E_SANDBOX_CONFIG", "")
+	t.Setenv("K8E_SANDBOX_CERT_DIR", "")
+	t.Setenv("K8E_SANDBOX_PROFILE", "")
+	t.Setenv("K8E_SANDBOX_ENDPOINT", "")
+
+	// Both files exist — canonical must win.
+	_ = os.MkdirAll(filepath.Join(home, ".k8e", "sandbox"), 0700)
+	_ = os.MkdirAll(filepath.Join(home, ".k8e"), 0700)
+	_ = os.WriteFile(filepath.Join(home, ".k8e", "sandbox", profilesFileName), []byte(`
+version: 1
+current_profile: new
+profiles:
+  new:
+    endpoint: new.example:1
+`), 0600)
+	_ = os.WriteFile(filepath.Join(home, ".k8e", "config.yaml"), []byte(`
+version: 1
+current_profile: old
+profiles:
+  old:
+    endpoint: old.example:1
+`), 0600)
+
+	r, err := ResolveConn("", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Profile != "new" || r.Endpoint != "new.example:1" {
+		t.Fatalf("canonical should win: %+v", r)
+	}
+}
+
+func TestDefaultProfilesPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("K8E_SANDBOX_CERT_DIR", "")
+	p, err := DefaultProfilesPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".k8e", "sandbox", profilesFileName)
+	if p != want {
+		t.Fatalf("got %q want %q", p, want)
 	}
 }

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -56,15 +56,24 @@ If you only see a platform-suffixed name in the user's environment (no symlink y
 1. **All code and shell execution goes through `k8e-sandbox-cli`** — never run `python3`, `node`, `pip`, `npm`, `curl`, compilers, or tests on the host for this goal.
 2. Prefer auto session mode: `k8e-sandbox-cli run "..."` (creates/reuses session).
 3. Parse JSON with `jq` unless `--raw` is used.
-4. If the gateway is unreachable, tell the user to run `k8e-sandbox-cli connect` (local) or `k8e-sandbox-cli connect --endpoint <host>:50051 --apikey <key>` (remote). Multi-cluster: `--profile <name>` / `~/.k8e/config.yaml` (KIP-17).
+4. If the gateway is unreachable, tell the user to run `k8e-sandbox-cli connect` (local) or `k8e-sandbox-cli connect --endpoint <host>:50051 --apikey <key>` (remote). Multi-cluster: `--profile <name>` / `~/.k8e/sandbox/profiles.yaml` (KIP-17).
 
 ## Auth & multi-profile (KIP-14 / KIP-17 / #538)
 
+**Do not confuse these files:**
+
+| Path | Who | What |
+|------|-----|------|
+| `/etc/k8e/config.yaml` | **k8e server/agent** | Daemon flags only |
+| `~/.k8e/sandbox/profiles.yaml` | **k8e-sandbox-cli** | Named gateways / cert dirs |
+| `~/.k8e/sandbox/config.json` | **k8e-sandbox-cli** | Last connect stamp |
+
 **mTLS bootstrap:** first remote connect/login uses an API key once; CLI stores `ca.crt` + `client.crt` + `client.key` (private key never leaves the machine). Client certs last **90 days** and auto-renew when **&lt;30 days** remain. API keys default to **30-day TTL** (`k8e sandbox-apikey create name`, override with `--ttl 90d|never`).
 
-**Profiles** (`~/.k8e/config.yaml`, optional `K8E_SANDBOX_CONFIG`):
+**Profiles** (`~/.k8e/sandbox/profiles.yaml`, override with `K8E_SANDBOX_CONFIG`):
 
 ```yaml
+# ~/.k8e/sandbox/profiles.yaml  — NOT /etc/k8e/config.yaml
 version: 1
 current_profile: default
 profiles:
@@ -82,7 +91,7 @@ k8e-sandbox-cli --profile prod run 'echo hi'
 # or: export K8E_SANDBOX_PROFILE=prod
 ```
 
-Priority: flags → env (`K8E_SANDBOX_ENDPOINT` / `APIKEY` / `CERT_DIR` / `PROFILE`) → profile → defaults. Cert dir: `K8E_SANDBOX_CERT_DIR` → `~/.k8e/sandbox` (no XDG).
+Priority: flags → env (`K8E_SANDBOX_ENDPOINT` / `APIKEY` / `CERT_DIR` / `PROFILE`) → profile → defaults. Cert dir: `K8E_SANDBOX_CERT_DIR` → `~/.k8e/sandbox`.
 
 ## Procedure (always)
 
@@ -152,7 +161,7 @@ k8e-sandbox-cli connect --endpoint <server-ip>:50051 --apikey k8e-...
 
 | Command | Purpose |
 |---------|---------|
-| `k8e-sandbox-cli --profile <name> …` | Use named profile from `~/.k8e/config.yaml` |
+| `k8e-sandbox-cli --profile <name> …` | Use named profile from `~/.k8e/sandbox/profiles.yaml` |
 | `k8e-sandbox-cli connect` | Local/remote auth + install this skill into agent harnesses |
 | `k8e-sandbox-cli connect --skill-only` | Re-install this skill only (no gateway dial) |
 | `k8e-sandbox-cli login` | Remote mTLS only (no skill install); optional `--device-name` |


### PR DESCRIPTION
## Summary

Follow-up to #539: avoid user confusion between two different `config.yaml` files.

| Path | Owner | Purpose |
|------|-------|---------|
| `/etc/k8e/config.yaml` | **k8e server/agent** | Daemon flags (`configfilearg`) |
| `~/.k8e/sandbox/profiles.yaml` | **k8e-sandbox-cli** | Multi-cluster profiles (KIP-17) |
| `~/.k8e/sandbox/config.json` | **k8e-sandbox-cli** | Last connect stamp |

### Changes
- Canonical CLI profile path: `~/.k8e/sandbox/profiles.yaml` (or `$K8E_SANDBOX_CERT_DIR/profiles.yaml`)
- Still reads legacy `~/.k8e/config.yaml` with a **stderr deprecation warning**
- Docs: KIP-17, SKILL.md, README, `connect` output, CLI flag help

## Test plan
- [x] `go test ./pkg/sandboxcli/`
- [ ] Manual: create `~/.k8e/sandbox/profiles.yaml` and `k8e-sandbox-cli --profile prod status`
- [ ] Manual: legacy `~/.k8e/config.yaml` still loads + prints deprecation hint