### PR TITLE
docs(kip-19,kip-20): sandbox PTY primitive + dsh plugin proposals

### DIFF
--- a/docs/kip-19-sandbox-pty-terminal-primitive.md
+++ b/docs/kip-19-sandbox-pty-terminal-primitive.md
@@ -1,0 +1,328 @@
+# KIP-19: sandbox PTY 终端原语
+
+| Author | Updated | Status |
+|--------|---------|--------|
+| @xiaods | 2026-08-15 | Draft |
+
+> 关联 KIP：KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog M9）、KIP-18（E2B 兼容）、**KIP-20（k8e-sandbox-dsh 插件——其 Phase 2 的 `spawnTerminal` 依赖本 KIP 先行）**。
+> 本 KIP 是 KIP-20 已决问题 #2 的展开：为 k8e sandbox 增加 PTY 原语，使 dsh 的 terminal seam（以及 E2B SDK 的 `pty.*` 面）能被完整实现。
+
+## 摘要
+
+给 k8e sandbox 的 gRPC 网关与 `sandboxd` 增加一套 **PTY 终端原语**：在沙箱 pod 内分配伪终端（`/dev/ptmx`）、把请求的 argv 作为**会话首领 + 控制终端**进程启动（不做 shell 解释）、双向字节流（输入写 master、输出读 master）、窗口尺寸调整（`TIOCSWINSZ`）、前台进程组查询与信号（`tcgetpgrp` / `kill -PGID`）、以及会话树级别的终止（TERM → grace → KILL）。
+
+表面是 7 个 gRPC RPC（`CreateTerminal` / `TerminalStream` / `TerminalWrite` / `TerminalResize` / `TerminalForeground` / `TerminalSignal` / `TerminalDestroy`），底层是 `sandboxd` 的一个 `pty` 模块 + 终端会话表 + 网关的终端路由注册表。
+
+它一次性服务两个消费者：
+
+1. **dsh 的 `spawnTerminal`**（`SubprocessRuntime.spawnTerminal` → `SubprocessTerminalHandle`），让 KIP-20 的 `@k8e/dsh-k8e-sandbox-subprocess` 在 Phase 2 真正实现 terminal seam，进而让 dsh 的 `terminal-bash`（持久终端）跑进 gVisor/Kata/Firecracker pod。
+2. **E2B SDK 的 `pty.create` / `pty.sendInput` / `pty.resize` / `pty.kill`**（KIP-18 E2B 兼容面当前缺的一角），与已有的 `/exec/stream` + `/exec/processes` + `/exec/attach` 补齐 E2B 进程控制面。
+
+## 背景与动机
+
+### 现状：没有 PTY
+
+- `sandboxd`（沙箱 pod 内 PID 1 的 Zig 守护进程，监听 `:2024`）目前只有管道式 exec：`/exec`（单次、stdout/stderr 分管道）、`/exec/stream`（SSE 流、stdout 单管道、stdin 经 `/exec/stdin`）、`/exec/background`（后台 + poll）、`/exec/signal`、`/exec/processes`、`/exec/attach`。
+- 这些 exec 全走 `fork + dup2(pipe)`，**没有控制终端**：没有 `setsid` 会话、没有 `TIOCSCTTY`、没有前台进程组、没有 `TIOCSWINSZ` 尺寸、没有行规程（line discipline）下的 echo/规范模式/信号（`Ctrl-C` 不会产生 `SIGINT` 给前台组）。
+- gRPC 面 `proto/sandbox/v1/sandbox.proto` 的 `Exec`/`ExecStream` 也都没有 PTY 概念。
+
+### 为什么需要 PTY
+
+真实终端不是"一条字节管道"，而是一个有控制终端的**会话（session）**：
+
+- **任务控制（job control）**：`Ctrl-C`（`SIGINT`）、`Ctrl-Z`（`SIGTSTP`）要送达**前台进程组**，而不是某个固定 pid。
+- **前台进程组可查可杀**：`tcgetpgrp` / `kill(-PGID)` 是交互式 shell、TUI 程序、`vim`/`less`/REPL 的硬前提。
+- **窗口尺寸**：`TIOCSWINSZ` + `SIGWINCH` 是 `htop`/`vim`/全屏 TUI 正确渲染的前提。
+- **行规程**：echo、规范模式、`Ctrl-D` EOF 等，都由内核在 PTY 上完成，管道做不到。
+
+dsh 的 `SubprocessRuntime.spawnTerminal` 明确把这些需求写进契约：`write`（输入文本，无隐式换行）、`output`（按投递顺序的 UTF-8 输出字节）、`inspectForeground`（前台 pgid + 是否在等输入）、`signalForeground`（`SIGINT/SIGTERM/SIGKILL/SIGTSTP/SIGHUP`）、`terminate`（整棵会话树 TERM→grace→KILL 且等待 quiescence）。
+
+## 目标与非目标
+
+### 目标
+
+1. 在 `sandboxd` 分配 PTY 并启动 argv 作为控制终端会话首领（`setsid` + `TIOCSCTTY` + `dup2` 到 0/1/2）。
+2. 双向字节流：输入写 master、输出读 master；输出有可重连的环形缓冲（对齐 `/exec/attach` 的 replay 模型）。
+3. 窗口尺寸调整、前台进程组查询、前台进程组信号、会话树终止（TERM→grace→KILL，可证明 quiescence）。
+4. gRPC 面：7 个 RPC，网关路由到 session 的 pod，`TerminalStream` 复用现有 `ExecStream` 的 SSE→gRPC 代理模式。
+5. 服务 dsh `spawnTerminal` 与 E2B `pty.*` 两个消费者，语义与 E2B 的 pty 面对齐。
+
+### 非目标
+
+- 不做窗口标题/OSC 序列解析、彩色解析、输出渲染——PTY 面只做**透明字节传递**，呈现归上层（dsh UI / E2B SDK）。
+- 不做跨 pod 终端迁移（pause/resume、pod 回收即终端消亡，见"保真度差距"）。
+- 不做多 reader 的实时扇出（单 reader + 环形缓冲 replay；第二个实时 reader 推迟）。
+- 不改动 `Exec`/`ExecStream` 的既有语义；PTY 是独立新面。
+- 不在本 KIP 内做 `input_waiting` 的 /proc 精确证明：本 KIP 只承诺 **positive-proof-only** 语义（M1 恒 `false`，见"已决问题"）。
+
+## 现状盘点
+
+| 组件 | 现状 | 需要新增 |
+|---|---|---|
+| `sandboxd`（Zig，`src/main.zig`） | 裸 HTTP/1.1，线程/连接，路由表硬编码 | `/pty/*` 7 个端点 + `pty.zig` 模块 |
+| `sandboxd` `execctl.zig` | 进程控制表：pid → {stdin_fd, 配置快照, 环形输出, done}，自旋锁保护 | 并行的**终端会话表**（terminal_id → {master_fd, 会话首领 pid, rows/cols, 环形输出, 前台 pgid 缓存, done}） |
+| 网关 `pkg/sandboxmatrix/grpc/server.go` | `sandboxdPost/Get` 代理、`ExecStream` 代理 `/exec/stream` SSE | 7 个 RPC 处理器 + `TerminalStream` SSE 代理 + terminal_id 路由注册表 |
+| 网关 `mTLSStreamInterceptor` | 流式 RPC 除 `ExecStream` 外强制 mTLS（`server.go:959`） | 把 `TerminalStream` 纳入与 `ExecStream` 相同的处置并显式登记 |
+| proto | `SandboxService` 单服务 | 新增 7 个 RPC + 消息 + `TerminalSignal` 枚举（首个 `oneof` 用于终端流） |
+
+## 设计
+
+### 5.1 终端语义（PTY 分配与进程启动）
+
+`CreateTerminal` 在 sandboxd 内执行：
+
+1. 打开 `/dev/ptmx` 得到 master fd；`ioctl(TIOCGPTN)` 取 pty 号、`ioctl(TIOCSPTLCK, 0)` 解锁；打开对应 `/dev/pts/N` 得到 slave fd。
+2. `fork`；子进程：
+   - `setsid()` 成为新会话首领（脱离沙箱 init 的会话，避免继承控制终端）；
+   - `ioctl(slave, TIOCSCTTY, 0)` 把 slave 设为本会话控制终端；
+   - `dup2(slave, 0/1/2)`，关闭多余 fd；
+   - `chdir(workdir)`、应用 `env`（复用 `exec.zig` 的 `buildEnvp` 语义：默认 PATH/VIRTUAL_ENV + 用户 env 覆盖）；
+   - `execve(argv[0], argv, envp)` —— **argv 不经过 `/bin/sh -c`**，这是与 `Exec` 的本质区别。
+3. 父进程：持有 master fd，把它登记进终端会话表，返回 `terminal_id` + 会话首领 pid。
+
+`argv` 由调用方提供完整数组（`argv[0]` 即程序），因此 dsh 可以启动 `bash`（交互式）作为终端，而不是 `sh -c "bash"` 这种失去任务控制的退化形态。
+
+### 5.2 proto 面（`proto/sandbox/v1/sandbox.proto` 追加）
+
+沿用单 `SandboxService`（与 `ExecStream`/`GetTranscript` 的增量历史一致；独立 `TerminalService` 见"备选方案"）。
+
+```proto
+// ── PTY terminal primitive (KIP-19) ─────────────────────────────────────────
+rpc CreateTerminal(CreateTerminalRequest) returns (CreateTerminalResponse);
+rpc TerminalStream(TerminalStreamRequest) returns (stream TerminalStreamResponse);
+rpc TerminalWrite(TerminalWriteRequest)   returns (TerminalWriteResponse);
+rpc TerminalResize(TerminalResizeRequest) returns (TerminalResizeResponse);
+rpc TerminalForeground(TerminalForegroundRequest) returns (TerminalForegroundResponse);
+rpc TerminalSignal(TerminalSignalRequest) returns (TerminalSignalResponse);
+rpc TerminalDestroy(TerminalDestroyRequest) returns (TerminalDestroyResponse);
+
+message CreateTerminalRequest {
+  string session_id = 1;
+  repeated string argv = 2;   // argv[0] 即程序；不 shell 解释
+  string workdir = 3;
+  map<string,string> env = 4; // 非敏感环境；secret 仍走 CreateSession 的 secret_refs
+  int32  rows = 5;            // 初始窗口行数（>=1）
+  int32  cols = 6;            // 初始窗口列数（>=1）
+}
+message CreateTerminalResponse {
+  string terminal_id = 1;     // 不透明、branded；后续所有 terminal RPC 的句柄
+  int32  pid = 2;             // 会话首领 pid（沙箱 pid 空间）
+}
+
+message TerminalStreamRequest { string terminal_id = 1; }
+message TerminalStreamResponse {
+  oneof frame {
+    bytes data = 1;           // 终端输出字节，按投递顺序
+    TerminalExit exit = 2;    // 终帧：顶层进程关闭
+  }
+}
+message TerminalExit {
+  int32  exit_code = 1;       // 进程退出码；0 = 正常
+  string signal    = 2;       // 终止信号名（正常退出为空）
+}
+
+message TerminalWriteRequest {
+  string terminal_id = 1;
+  bytes  data = 2;            // 原始字节，无隐式换行
+}
+message TerminalWriteResponse { bool ok = 1; }
+
+message TerminalResizeRequest {
+  string terminal_id = 1;
+  int32 rows = 2;
+  int32 cols = 3;
+}
+message TerminalResizeResponse { bool ok = 1; }
+
+message TerminalForegroundRequest { string terminal_id = 1; }
+message TerminalForegroundResponse {
+  int32 process_group_id = 1; // 当前前台进程组 id；-1 表示无法解析
+  bool  input_waiting = 2;    // 尽力而为；MVP 恒 false（见保真度差距）
+}
+
+enum TerminalSignal {
+  TERMINAL_SIGNAL_UNSPECIFIED = 0;
+  TERMINAL_SIGNAL_INT  = 1;   // SIGINT
+  TERMINAL_SIGNAL_TERM = 2;   // SIGTERM
+  TERMINAL_SIGNAL_KILL = 3;   // SIGKILL
+  TERMINAL_SIGNAL_TSTP = 4;   // SIGTSTP
+  TERMINAL_SIGNAL_HUP  = 5;   // SIGHUP
+}
+message TerminalSignalRequest {
+  string terminal_id = 1;
+  TerminalSignal signal = 2;
+}
+message TerminalSignalResponse { int32 process_group_id = 1; } // 实际收到信号的 pgid
+
+message TerminalDestroyRequest {
+  string terminal_id = 1;
+  int32  grace_ms = 2;        // TERM → grace → KILL 升级上限
+}
+message TerminalDestroyResponse { bool ok = 1; }
+```
+
+设计要点：
+
+- `terminal_id` 是**不透明 branded id**（遵循仓库"跨边界 id 必须 branded"惯例），网关生成并持有 `terminal_id → session` 映射；后续 RPC 只带 `terminal_id`，不重复带 `session_id`。
+- `TerminalStreamResponse` 用 `oneof` 区分数据帧与终帧——这是 proto 里**第一个 oneof**，因为终端流是判别式的（数据 vs 退出事实），比"字段为空即终帧"更无歧义。
+- `TerminalSignal` 覆盖 dsh `SubprocessTerminalSignal` 的全集（`INT/TERM/KILL/TSTP/HUP`）。
+
+### 5.3 sandboxd 实现（`src/pty.zig` + 终端会话表）
+
+新增 `pty.zig`，并在 `main.zig` 路由表追加端点：
+
+| 端点 | 方法 | 作用 | 映射 RPC |
+|---|---|---|---|
+| `/pty/create` | POST | 分配 PTY + 启动 argv 为控制终端会话首领 | `CreateTerminal` |
+| `/pty/stream` | GET | SSE 流：终端输出（单 reader）+ 终帧 `{"exit":N,"signal":"…"}` | `TerminalStream` |
+| `/pty/input` | POST | 写 master（base64 载荷，同 `/exec/stdin` 风格） | `TerminalWrite` |
+| `/pty/resize` | POST | `ioctl(TIOCSWINSZ)` | `TerminalResize` |
+| `/pty/foreground` | GET | `tcgetpgrp(master)` + 尽力 `input_waiting` | `TerminalForeground` |
+| `/pty/signal` | POST | `kill(-pgid, sig)` 前台进程组 | `TerminalSignal` |
+| `/pty/destroy` | POST | 会话树 TERM→grace→KILL + 等 quiescence + 关 master + 注销 | `TerminalDestroy` |
+
+**终端会话表**（并行于 `execctl`，固定槽位 + 自旋锁）：
+
+```
+terminal_id → {
+  master_fd,        // PTY master
+  pid,              // 会话首领（session leader）
+  rows, cols,       // 当前尺寸
+  ring[BUFFER_MAX], // 输出环形缓冲（attach/replay；64KiB，对齐 execctl）
+  fg_pgid,          // 前台 pgid 缓存（tcgetpgrp 惰性刷新）
+  done,             // 顶层进程已收割
+}
+```
+
+**关键并发设计——daemon 侧泵线程**：sandboxd 是"线程/连接"模型，`/pty/stream` 连接可能随时断开，但 master 必须有人持续排水，否则 slave 侧写满内核缓冲区后前台进程会阻塞。因此每个终端在创建时启动一个**daemon 拥有的 reader 线程**，独占 master fd：
+
+1. 循环 `read(master)` → 追加环形缓冲 → 唤醒当前 stream 订阅者（条件变量/通知）。
+2. 顶层进程退出 → 读满余量 → 置 `done` → 广播终帧 → 结束 pump。
+3. `destroy` 时关闭 master、通知 pump 退出、注销表项。
+
+这样 `TerminalStream` 订阅者可以中途断开/重连而不影响终端运行；重连走环形缓冲 replay（对齐 `/exec/attach` 语义），`truncated` 标记缓冲溢出。
+
+**会话树终止**：`TerminalDestroy` 不以"杀一个 pid"为目标，而是枚举该会话（`ps -eo sid=,pgid=,stat=`，sid == 会话首领 pid 且非 Z/X 态）的所有进程组，先 `kill -TERM -- -PGID`，`grace_ms` 内轮询空，未空则 `kill -KILL`，最后校验无存活组、无存活首领 pid 才返回 `ok`（复用 E2B `terminal.ts` 的 `sessionProcessGroups`/`awaitSessionEmpty` 语义，但下沉到 sandboxd 原生实现，不再靠多次 `Exec 'ps'` 拼装）。
+
+**PTY 分配与 Zig 版本**：Zig std 的 PTY 辅助随版本不同（`std.posix.openpty` 是否可用取决于 Zig 0.16）。实现按最小依赖走 `/dev/ptmx` + `ioctl(TIOCGPTN/TIOCSPTLCK)` + 打开 `/dev/pts/N`，避免依赖 std 的 PTY 封装；`grantpt/unlockpt` 由 `TIOCGPTN/TIOCSPTLCK` 等效替代。此细节在实现时按仓库当前 Zig 版本落地。
+
+### 5.4 gateway 实现
+
+| RPC | 网关动作 |
+|---|---|
+| `CreateTerminal` | 解析 session → pod IP → `POST /pty/create` → 生成 branded `terminal_id` → 记录 `terminal_id → session_id` → 返回 |
+| `TerminalStream` | `GET /pty/stream`，把 SSE 帧映射为 `TerminalStreamResponse`（data 帧 → `data`，exit 帧 → `exit`）；复用 `ExecStream` 的 SSE→gRPC 流代理 |
+| `TerminalWrite` / `TerminalResize` / `TerminalForeground` / `TerminalSignal` | 查 `terminal_id → session` → pod IP → 对应 sandboxd 端点（unary） |
+| `TerminalDestroy` | 对应 `POST /pty/destroy`；成功后从路由注册表移除 `terminal_id` |
+
+**terminal_id 路由注册表**：与现有后台 run 注册表（`GetSessionResponse.background_runs`）同构——`CreateTerminal` 登记、`TerminalDestroy` 移除、session 销毁/pod 回收时 GC。注册表是有界的（上限对齐后台 run 注册表），`terminal_id` 经注册表解析为 session → pod IP，因此**任意控制面节点都能服务任意终端 RPC**（节点无关，延续 KIP-18 P1 的"沙箱自有 pid / 节点无关"哲学）。
+
+**mTLS**：`TerminalStream` 是流式 RPC，须显式纳入 `mTLSStreamInterceptor` 的处置（与 `ExecStream` 一致），并写测试证明"未认证的 TerminalStream 被拒、认证的通过"。
+
+### 5.5 生命周期与并发
+
+- 终端随 pod 生命周期：session 的 pod 回收（destroy / 温暖池回收 / pause）即终端消亡；`TerminalDestroy` 是显式提前回收，不销毁则随 pod 一并回收。
+- `TerminalWrite` / `TerminalResize` / `TerminalSignal` / `TerminalForeground` 对同一终端的并发调用，由终端会话表的自旋锁串行化 master/`fg_pgid` 访问（对齐 `execctl` 的锁模型）。
+- `TerminalDestroy` 幂等：已注销/已消亡的 terminal_id 返回干净的 not-found（对齐 `/exec/signal` 对已收割 pid 的处理）。
+- 终端数量有界（沙箱 pod 内固定槽位，如 64，对齐 `execctl` 的 64 槽）；槽满则 `CreateTerminal` fail-loud，而不是静默降级。
+
+## 与 dsh terminal seam 的映射
+
+`@k8e/dsh-k8e-sandbox-subprocess`（KIP-20 Phase 2）实现 `SubprocessRuntime.spawnTerminal`，映射如下：
+
+| dsh `SubprocessTerminalHandle` | k8e RPC |
+|---|---|
+| 创建（`rows`/`cols`/`argv`/`cwd`/`env`） | `CreateTerminal` |
+| `output`（Readable，UTF-8 输出字节） | `TerminalStream`（data 帧 → 流；exit 帧 → `done`） |
+| `write(data)` | `TerminalWrite` |
+| `inspectForeground()` | `TerminalForeground` |
+| `signalForeground(sig)` | `TerminalSignal` |
+| `terminate()`（TERM→grace→KILL，等 quiescence） | `TerminalDestroy` |
+| `pid` | `CreateTerminalResponse.pid` |
+| `done`（exitCode/signal） | `TerminalExit` |
+
+> dsh 的 `spawnTerminal` handle 契约本身不含 resize；但 `dsh-terminal` 更上层（`terminal-bash` 的终端 UI）需要 resize。`TerminalResize` 为这一层服务，dsh 侧 provider 可用它按需补充（或在终端 UI 层调用）。
+
+## 与 E2B pty 兼容的映射（KIP-18）
+
+E2B SDK 的 `sandbox.pty.*` 面可直接落到本原语：
+
+| E2B SDK | k8e RPC |
+|---|---|
+| `pty.create({ rows, cols, cwd, envs, onData })` | `CreateTerminal` + `TerminalStream`（`onData` 回调） |
+| `pty.sendInput(pid, data)` | `TerminalWrite`（pid→terminal_id 映射归 KIP-18 兼容层，见下） |
+| `pty.resize(pid, rows, cols)` | `TerminalResize` |
+| `pty.kill(pid)` | `TerminalSignal`(KILL) / `TerminalDestroy` |
+
+E2B 兼容层（KIP-18）用 `pid` 寻址，而本原语只暴露 canonical `terminal_id`（`CreateTerminalResponse` 同时返回 `terminal_id` 与 `pid`）。**`pid → terminal_id` 映射归 KIP-18 兼容层自建**：兼容层在 `pty.create` 时记录两者关联即可闭合。网关不引入 pid 别名——避免 pid 复用导致的双身份歧义，也保持原语身份单一。
+
+## 保真度差距（诚实清单）
+
+| 维度 | 目标 | 现状/限制 |
+|---|---|---|
+| `input_waiting` | 证明前台组正阻塞于 `read(0)` | M1 恒 `false`（positive-proof-only：`false` 含"不可证明"，绝不表示"确定不在等"）；精确的 `/proc wchan` 判定因 gVisor/Kata/Firecracker 的 procfs 语义不同，留待后续 KIP 按 runtime 验证 |
+| 多 reader 实时扇出 | 多个并发 `TerminalStream` | 单 reader + 环形缓冲 replay；第二个实时 reader 推迟 |
+| 输出完整性 | 全量输出 | 环形缓冲有界（64KiB），断线重连只回放尾部，`truncated` 标记；已连接的活跃 reader 不受此限（pump 直发） |
+| 跨 pod 迁移 | pause/resume 后终端仍在 | 不支持：终端绑定 pod 的 pid 空间与 PTY，pause/resume 或 pod 回收即消亡 |
+| 窗口标题/OSC | 解析标题、光标 | 不做解析，透明传字节，归上层 |
+| `Ctrl-C` 语义 | 前台组收 SIGINT | 由 PTY 行规程天然提供（`ISIG` 默认开启）；raw 模式程序可关 |
+
+这些差距不阻塞 MVP（dsh terminal 与 E2B pty 都接受 `input_waiting=false`、单 reader、pod 绑定）。
+
+## 安全
+
+- **控制终端权限**：PTY 在沙箱 pod 内分配，master 只由 sandboxd 持有，slave 归终端进程；网关进程不接触 master fd，不放大主机权限。
+- **argv 不 shell 解释**：杜绝 `Exec` 的 `/bin/sh -c` 注入面；argv 逐项传递（NUL 拒绝，对齐 dsh `serializeValues`）。
+- **env 不注入 secret**：`TerminalWrite` 面只传字节；secret 仍走 `CreateSession` 的 `secret_refs`，不进 `CreateTerminal.env`。
+- **会话树终止可证明**：`TerminalDestroy` 用 `ps` 会话枚举 + 存活校验，避免"杀了首领、孤儿进程组还活着"；`grace_ms` 有界，拒绝无界等待。
+- **mTLS**：`TerminalStream` 纳入 mTLS 流拦截器，与 `ExecStream` 同策略，杜绝未认证的终端流。
+- **资源上限**：终端表有界（固定槽位），`TerminalDestroy`/session 回收负责 GC；避免终端泄漏撑爆 sandboxd。
+
+## 验收标准
+
+- [ ] `CreateTerminal` 在沙箱内分配 PTY，argv 作为会话首领 + 控制终端启动（`ps -o sid=,tpgid=` 验证 sid == pid，tpgid == pid）。
+- [ ] `TerminalWrite` 写 master → 终端进程在 slave 收到；`TerminalStream` 收到 echo/输出，顺序正确，UTF-8 不破。
+- [ ] `TerminalResize` 后 `stty size`（或 `TIOCGWINSZ`）反映新 rows/cols，SIGWINCH 送达。
+- [ ] `TerminalForeground` 返回正确前台 pgid；`TerminalSignal`(INT/TSTP/TERM/KILL/HUP) 送达该 pgid。
+- [ ] `TerminalDestroy`：TERM→grace→KILL 升级，返回时 `ps` 证明该会话无存活进程组；幂等，重复 destroy 干净 not-found。
+- [ ] `TerminalStream` 断线重连回放环形缓冲；`truncated` 在缓冲溢出时置位；终帧 exit_code/signal 正确。
+- [ ] 网关：terminal_id 路由注册表在 create/destroy/session 销毁时正确增删；`TerminalStream` 走 mTLS 且被未认证调用拒绝。
+- [ ] dsh 快照：`@k8e/dsh-k8e-sandbox-subprocess` 的 `spawnTerminal` 在 mock/真实网关上演 `bash` 终端，验证 write/read/Ctrl-C/resize/destroy 全链路。
+- [ ] E2B 兼容：`pty.create/sendInput/resize/kill` 经兼容层闭合（KIP-18）。
+- [ ] 文档：本 KIP + proto 注释 + `SKILL.md`/README 一处更新说明 PTY 面。
+
+## 实现地图
+
+| 阶段 | 内容 | 位置 |
+|---|---|---|
+| M1 | proto：7 RPC + 消息 + `TerminalSignal` 枚举 + `oneof` | `proto/sandbox/v1/sandbox.proto`，`make generate` 重生成 `pb` |
+| M1 | sandboxd：`pty.zig`（分配/启动/输入/输出泵/尺寸/前台/信号/销毁）+ 终端会话表 + 路由 | `sandboxd/src/pty.zig`、`main.zig` |
+| M1 | gateway：7 个 RPC 处理器 + `TerminalStream` SSE 代理 + terminal_id 路由注册表 + mTLS 登记 | `pkg/sandboxmatrix/grpc/server.go`（+ 新 `terminal.go`） |
+| M2 | 单元/集成测试 | `sandboxd/src/pty_test.zig`、`pkg/sandboxmatrix/grpc/*_test.go` |
+| M3 | dsh 消费：KIP-20 `spawnTerminal` 接本原语 | `plugins/deepseek-harness/packages/k8e-sandbox-dsh-subprocess` |
+| M4 | E2B 兼容层 `pty.*` 闭合 | KIP-18 兼容层 |
+
+## 测试计划
+
+- **sandboxd 单测（Zig）**：PTY 分配与 slave 打开、`setsid`/`TIOCSCTTY` 会话首领断言、`tcgetpgrp` 前台组、`TIOCSWINSZ` 尺寸、`kill(-pgid)` 前台信号、会话树枚举 + TERM→KILL 升级 + 空集校验、环形缓冲 replay 与 `truncated`、并发 input/signal 串行化。
+- **gateway 单测（Go）**：RPC↔sandboxd 代理、`TerminalStream` SSE 帧→`oneof` 映射、terminal_id 注册表增删/GC、mTLS 拦截器对 `TerminalStream` 的通过/拒绝。
+- **e2e**：真实 K8E 集群里 `CreateTerminal` 启 `bash` → write `echo hi\n` → stream 读到输出 → resize → `Ctrl-C`（`\x03`）→ 前台组收 SIGINT → destroy → `ps` 证明无孤儿。
+- **dsh keyless 快照**：脚本化模型 + mock gateway，外部断言 transcript（对齐 KIP-20 的测试契约）。
+- **契约**：`k8e-sandbox-cli catalog`（KIP-16 M9）纳入 7 个终端 RPC，作为 CLI/SDK 生成的校验输入。
+
+## 备选方案
+
+| 方案 | 为什么不选 |
+|---|---|
+| 单条双向 `Terminal` bidi stream（控制+数据混流） | 需自造帧多路复用协议；与 k8e 现有 unary-heavy + SSE 代理风格不符，网关代理与测试更重 |
+| 用 `Exec` + `script`/`tmux` 模拟 PTY | 在沙箱内再起一层进程/会话管理器，前台组语义丢失，脆弱且非原生 |
+| 只做 dsh，跳过 E2B pty 兼容 | 同一原语即服务两者；E2B `pty.*` 是 KIP-18 已知缺口，不合并即重复造 |
+| 独立 `TerminalService`（不改 `SandboxService`） | 可隔离，但网关当前单服务注册，拆第二个服务收益小；RPC 命名已带 `Terminal` 前缀，语义清晰 |
+| 终帧用"字段为空即终帧"而非 `oneof` | 判别式协议用 `oneof` 更无歧义，且这是新增协议无兼容包袱 |
+
+## 已决问题
+
+| # | 问题 | 决定 |
+|---|---|---|
+| 1 | `input_waiting` 精确化 | **positive-proof-only，M1 恒 `false`**。`false` 语义为"不可证明"，绝不表示"确定不在等"（与 dsh 契约的 provable 措辞及 E2B 对齐）。精确判定依赖 `/proc` wchan，而 gVisor/Kata/Firecracker 的 procfs 语义不同，留待后续 KIP 按 runtime 验证 |
+| 2 | E2B pid 寻址 | **`pid → terminal_id` 映射归 KIP-18 兼容层**。网关只暴露 canonical `terminal_id`（`CreateTerminalResponse` 已同时返回 pid 供需要者），不引入 pid 别名，避免 pid 复用歧义 |

--- a/docs/kip-19-sandbox-pty-terminal-primitive.md
+++ b/docs/kip-19-sandbox-pty-terminal-primitive.md
@@ -4,7 +4,7 @@
 |--------|---------|--------|
 | @xiaods | 2026-08-15 | Draft |
 
-> 关联 KIP：KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog M9）、KIP-18（E2B 兼容）、**KIP-20（k8e-sandbox-dsh 插件——其 Phase 2 的 `spawnTerminal` 依赖本 KIP 先行）**。
+> 关联 KIP：KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog M9）、KIP-18（E2B 兼容）、**KIP-20（dsh-k8e-sandbox 插件——其 Phase 2 的 `spawnTerminal` 依赖本 KIP 先行）**。
 > 本 KIP 是 KIP-20 已决问题 #2 的展开：为 k8e sandbox 增加 PTY 原语，使 dsh 的 terminal seam（以及 E2B SDK 的 `pty.*` 面）能被完整实现。
 
 ## 摘要
@@ -299,7 +299,7 @@ E2B 兼容层（KIP-18）用 `pid` 寻址，而本原语只暴露 canonical `ter
 | M1 | sandboxd：`pty.zig`（分配/启动/输入/输出泵/尺寸/前台/信号/销毁）+ 终端会话表 + 路由 | `sandboxd/src/pty.zig`、`main.zig` |
 | M1 | gateway：7 个 RPC 处理器 + `TerminalStream` SSE 代理 + terminal_id 路由注册表 + mTLS 登记 | `pkg/sandboxmatrix/grpc/server.go`（+ 新 `terminal.go`） |
 | M2 | 单元/集成测试 | `sandboxd/src/pty_test.zig`、`pkg/sandboxmatrix/grpc/*_test.go` |
-| M3 | dsh 消费：KIP-20 `spawnTerminal` 接本原语 | `plugins/deepseek-harness/packages/k8e-sandbox-dsh-subprocess` |
+| M3 | dsh 消费：KIP-20 `spawnTerminal` 接本原语 | `plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess` |
 | M4 | E2B 兼容层 `pty.*` 闭合 | KIP-18 兼容层 |
 
 ## 测试计划

--- a/docs/kip-20-dsh-k8e-sandbox-plugin.md
+++ b/docs/kip-20-dsh-k8e-sandbox-plugin.md
@@ -1,4 +1,4 @@
-# KIP-20: k8e-sandbox-dsh — 让 DeepSeek Harness 以插件方式调用 k8e-sandbox
+# KIP-20: dsh-k8e-sandbox — 让 DeepSeek Harness 以插件方式调用 k8e-sandbox
 
 | Author | Updated | Status |
 |--------|---------|--------|
@@ -9,7 +9,7 @@
 
 ## 摘要
 
-本 KIP 提出 `k8e-sandbox-dsh`：一个**完全树外（out-of-tree）**的 dsh 插件族，让 DeepSeek Harness 把"执行世界"（文件读写 + 进程执行）整体搬到 k8e-sandbox 里，与 k8e 现有的 `k8e-sandbox-cli` / gRPC 网关 / 温暖池共用同一套基础设施。
+本 KIP 提出 `dsh-k8e-sandbox`：一个**完全树外（out-of-tree）**的 dsh 插件族，让 DeepSeek Harness 把"执行世界"（文件读写 + 进程执行）整体搬到 k8e-sandbox 里，与 k8e 现有的 `k8e-sandbox-cli` / gRPC 网关 / 温暖池共用同一套基础设施。
 
 核心结论有三条：
 
@@ -89,18 +89,18 @@ k8e-sandbox 与 E2B 在抽象层面是同一类东西：一个远端 Linux 执�
 ```
 plugins/deepseek-harness/
 ├── packages/
-│   ├── k8e-sandbox-dsh/            # 所有者服务：ctx.k8eSandbox（会话生命周期 + 共享客户端）
-│   ├── k8e-sandbox-dsh-fs/         # ctx.fs provider（K8eFileSystem extends FileSystem）
-│   ├── k8e-sandbox-dsh-subprocess/ # ctx.subprocess provider（K8eSubprocessRuntime extends SubprocessRuntime）
-│   ├── k8e-sandbox-dsh-client/     # 内部传输抽象：CliClient / GrpcClient 共用一个接口
-│   ├── k8e-sandbox-dsh-tool/       # 可选：模型面工具（session/snapshot/confirm/ps 等沙箱专属动词）
-│   └── k8e-sandbox-dsh-bundle/     # bundle 包：dsh.bundle.patch → cordis.patch.yml，挂载上面所有行
+│   ├── dsh-k8e-sandbox/            # 所有者服务：ctx.k8eSandbox（会话生命周期 + 共享客户端）
+│   ├── dsh-k8e-sandbox-fs/         # ctx.fs provider（K8eFileSystem extends FileSystem）
+│   ├── dsh-k8e-sandbox-subprocess/ # ctx.subprocess provider（K8eSubprocessRuntime extends SubprocessRuntime）
+│   ├── dsh-k8e-sandbox-client/     # 内部传输抽象：CliClient / GrpcClient 共用一个接口
+│   ├── dsh-k8e-sandbox-tool/       # 可选：模型面工具（session/snapshot/confirm/ps 等沙箱专属动词）
+│   └── dsh-k8e-sandbox-bundle/     # bundle 包：dsh.bundle.patch → cordis.patch.yml，挂载上面所有行
 ├── package.json                    # pnpm workspace
 ├── pnpm-workspace.yaml
 └── tsconfig.base.json
 ```
 
-> npm scope 统一为 `@k8e/`，发布名按 `@k8e/dsh-*`：所有者 `@k8e/dsh-k8e-sandbox`、fs `@k8e/dsh-k8e-sandbox-fs`、subprocess `@k8e/dsh-k8e-sandbox-subprocess`、client `@k8e/dsh-k8e-sandbox-client`、tool `@k8e/dsh-k8e-sandbox-tool`、bundle `@k8e/dsh-k8e-sandbox-bundle`。目录短名（`k8e-sandbox-dsh*`）不变。
+> npm scope 统一为 `@k8e/`，命名统一为 `dsh-k8e-sandbox`：所有者 `@k8e/dsh-k8e-sandbox`、fs `@k8e/dsh-k8e-sandbox-fs`、subprocess `@k8e/dsh-k8e-sandbox-subprocess`、client `@k8e/dsh-k8e-sandbox-client`、tool `@k8e/dsh-k8e-sandbox-tool`、bundle `@k8e/dsh-k8e-sandbox-bundle`；目录短名与之对齐（`dsh-k8e-sandbox*`）。
 
 ### 加载方式（非侵入通道）
 
@@ -117,7 +117,7 @@ dsh --profile k8e --dump-config
 dsh --profile k8e
 ```
 
-`k8e-sandbox-dsh-bundle/package.json` 声明 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`；`cordis.patch.yml` 插入四行（顺序关键——先所有者，再 fs/subprocess，后可选工具）：
+`dsh-k8e-sandbox-bundle/package.json` 声明 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`；`cordis.patch.yml` 插入四行（顺序关键——先所有者，再 fs/subprocess，后可选工具）：
 
 ```yaml
 - insert:
@@ -192,7 +192,7 @@ dsh --profile k8e
 
 这正是 E2B README 描述的"换 provider 换掉整个执行世界"。
 
-### 7.5 可选：模型面工具 `k8e-sandbox-dsh-tool`
+### 7.5 可选：模型面工具 `dsh-k8e-sandbox-tool`
 
 fs/subprocess 覆盖不了 k8e 的**沙箱专属动词**。提供一个模型面工具（挂 `ctx.tools`，schema 随 prompt 装配），暴露：`session`（create/get/list/destroy/pause/resume）、`snapshot`（save/list/restore/delete）、`ps`、`confirm`/`approve`、`poll`。这些是 k8e 独有能力，不进 fs/subprocess 缝，作为 Consumer 补齐"缝"的第三角。Phase 1 可先省（SKILL 已覆盖），Phase 2 再上。
 
@@ -200,7 +200,7 @@ fs/subprocess 覆盖不了 k8e 的**沙箱专属动词**。提供一个模型面
 
 ### 客户端抽象
 
-fs/subprocess 不直接依赖"CLI 还是 gRPC"。`k8e-sandbox-dsh-client` 定义一个内部接口（最小方法集：`createSession/destroySession/exec/execStream/writeFile/readFile/listFiles/pollRun/getProcesses/...`），两个实现：
+fs/subprocess 不直接依赖"CLI 还是 gRPC"。`dsh-k8e-sandbox-client` 定义一个内部接口（最小方法集：`createSession/destroySession/exec/execStream/writeFile/readFile/listFiles/pollRun/getProcesses/...`），两个实现：
 
 - `CliK8eClient`：包装 `k8e-sandbox-cli`（spawn 子进程，解析 JSON / `--raw` 流）。
 - `GrpcK8eClient`：从 `proto/sandbox/v1/sandbox.proto` 生成 TS（`@grpc/grpc-js` + `ts-proto` 或 `protobuf-ts`），mTLS 读 `~/.k8e/sandbox/` 证书，到期经 `Login` RPC 惰性续期。
@@ -213,7 +213,7 @@ fs/subprocess 不直接依赖"CLI 还是 gRPC"。`k8e-sandbox-dsh-client` 定义
 
 ### Phase 2：直连 gRPC（补保真度）
 
-- 从 proto 生成 TS 客户端（放在 `k8e-sandbox-dsh-client/`，随 proto 一起由 `make generate` 触发）。
+- 从 proto 生成 TS 客户端（放在 `dsh-k8e-sandbox-client/`，随 proto 一起由 `make generate` 触发）。
 - mTLS 材料与 CLI 共享（同一 cert 目录 / 同一 profile），续期逻辑复用 KIP-14 语义。
 - 用 `ExecStream` 做流式 stdout，`PollRun`/`GetTranscript` 做增量与后台，`GetProcesses` + `Exec kill` 做进程组终止，逼近 E2B 的保真度。
 
@@ -234,7 +234,7 @@ fs/subprocess 不直接依赖"CLI 还是 gRPC"。`k8e-sandbox-dsh-client` 定义
 
 ## 配置面
 
-Schemastery schema（`k8e-sandbox-dsh` 的 `Config`），字段尽量与 CLI flag 对齐：
+Schemastery schema（`dsh-k8e-sandbox` 的 `Config`），字段尽量与 CLI flag 对齐：
 
 | 字段 | 默认 | 说明 |
 |---|---|---|
@@ -262,7 +262,7 @@ Schemastery schema（`k8e-sandbox-dsh` 的 `Config`），字段尽量与 CLI fla
 
 ## 验收标准
 
-- [ ] 树外 bundle 能通过 `dsh plugin --profile k8e add …` 安装并 `dsh --profile k8e --dump-config` 显示 `k8e-sandbox-dsh` 层。
+- [ ] 树外 bundle 能通过 `dsh plugin --profile k8e add …` 安装并 `dsh --profile k8e --dump-config` 显示 `dsh-k8e-sandbox` 层。
 - [ ] 挂载后 `ctx.fs` / `ctx.subprocess` 被 k8e 实现占据，dsh 的 `bash` 与文件工具在沙箱 pod 内执行（用 `ps`/`list` 验证是沙箱而非 host）。
 - [ ] fs：`read/write/edit/list/stat` 通过 `WriteFile/ReadFile/ListFiles/Exec` 正确映射；原子写与版本守卫有单测。
 - [ ] subprocess：`spawn` 单次 exec 返回正确 stdout/stderr/exit_code；`terminate` 走 kill+存活观察；`resolveExecutable` 正确。
@@ -276,12 +276,12 @@ Schemastery schema（`k8e-sandbox-dsh` 的 `Config`），字段尽量与 CLI fla
 
 | 阶段 | 内容 | 位置 |
 |---|---|---|
-| Phase 1 | 所有者服务 + CLI 客户端抽象 | `plugins/deepseek-harness/packages/k8e-sandbox-dsh{,-client}` |
-| Phase 1 | fs provider（CLI 传输） | `.../k8e-sandbox-dsh-fs` |
-| Phase 1 | subprocess provider（单次 exec + 后台） | `.../k8e-sandbox-dsh-subprocess` |
-| Phase 1 | bundle 包 + cordis.patch.yml | `.../k8e-sandbox-dsh-bundle` |
-| Phase 2 | gRPC TS 客户端（proto 生成 + mTLS 续期） | `.../k8e-sandbox-dsh-client/src/grpc`，proto 生成接 `make generate` |
-| Phase 2 | 流式 stdio / 进程组终止 / 模型面工具 | subprocess、`k8e-sandbox-dsh-tool` |
+| Phase 1 | 所有者服务 + CLI 客户端抽象 | `plugins/deepseek-harness/packages/dsh-k8e-sandbox{,-client}` |
+| Phase 1 | fs provider（CLI 传输） | `.../dsh-k8e-sandbox-fs` |
+| Phase 1 | subprocess provider（单次 exec + 后台） | `.../dsh-k8e-sandbox-subprocess` |
+| Phase 1 | bundle 包 + cordis.patch.yml | `.../dsh-k8e-sandbox-bundle` |
+| Phase 2 | gRPC TS 客户端（proto 生成 + mTLS 续期） | `.../dsh-k8e-sandbox-client/src/grpc`，proto 生成接 `make generate` |
+| Phase 2 | 流式 stdio / 进程组终止 / 模型面工具 | subprocess、`dsh-k8e-sandbox-tool` |
 | Phase 2 | `spawnTerminal`（**依赖 KIP-19（sandbox PTY 终端原语）先落地**） | subprocess + k8e 侧 PTY RPC |
 | 后续 | — | — |
 

--- a/docs/kip-20-k8e-sandbox-dsh-plugin.md
+++ b/docs/kip-20-k8e-sandbox-dsh-plugin.md
@@ -1,0 +1,311 @@
+# KIP-20: k8e-sandbox-dsh — 让 DeepSeek Harness 以插件方式调用 k8e-sandbox
+
+| Author | Updated | Status |
+|--------|---------|--------|
+| @xiaods | 2026-08-15 | Draft |
+
+> 关联 KIP：KIP-3（sandbox matrix）、KIP-8（skill-cli 取代 MCP）、KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog）、KIP-17（CLI 多 profile 与 API key TTL）、KIP-18（E2B 兼容）、**KIP-19（sandbox PTY 终端原语——本 KIP Phase 2 的 `spawnTerminal` 依赖它先行）**。
+> 关联仓库：`deepseek-harness`（下称 **dsh**）——插件化 agent harness，vendored Cordis，"everything is a plugin"。
+
+## 摘要
+
+本 KIP 提出 `k8e-sandbox-dsh`：一个**完全树外（out-of-tree）**的 dsh 插件族，让 DeepSeek Harness 把"执行世界"（文件读写 + 进程执行）整体搬到 k8e-sandbox 里，与 k8e 现有的 `k8e-sandbox-cli` / gRPC 网关 / 温暖池共用同一套基础设施。
+
+核心结论有三条：
+
+1. **不改 dsh 源码**。dsh 把能力抽象成"缝"（capability seam）：`ctx.fs`（文件系统）、`ctx.subprocess`（子进程）等都是可替换的 Service Provider。k8e 插件只需实现这两条缝的 provider，挂到 Cordis 树上即可。加载方式是 dsh 已经原生支持的树外 bundle：`dsh plugin --profile <name> add <package>`。
+2. **照搬 dsh 仓库里的 E2B POC 作为模板**。E2B POC（`@deepseek-ai/dsh-e2b` + `fs-e2b` + `subprocess-e2b`）已经证明了"一个沙箱所有者服务 + 两个 OS 适配器"这套组合：挂上 `ctx.fs` + `ctx.subprocess` 后，bash、terminal、LSP 这些上层消费者**自动**进入沙箱，无需为它们各写一个 fork。
+3. **分两阶段落地**：Phase 1 用 `k8e-sandbox-cli` 作为传输层（零新 k8e 面，复用 mTLS/profile/state），先打通 fs + 单次 exec；Phase 2 直连 gRPC（从 `proto/sandbox/v1/sandbox.proto` 生成 TS 客户端），补齐流式 stdio 与进程组终止的子进程保真度。
+
+## 背景与动机
+
+k8e 目前给 AI agent 的入口是两条：
+
+- **`k8e-sandbox-cli`（SKILL 驱动）**：agent 通过 SKILL.md 把目标拆成一串 `k8e-sandbox-cli run/write/read/...` 命令。它在 Claude Code / Codex / Pi 上工作良好，但**每个操作都是一次 CLI 进程 spawn**，且 agent 的"文件"和"执行"被暴露成命令行字符串，而不是 harness 原生的结构化工具（`read`/`edit`/`bash`/`terminal`）。
+- **gRPC / Python / TS SDK**：直接编程接口，但 agent harness 不会自己写 SDK 调用。
+
+DeepSeek Harness 是一个**插件化**的 agent harness：它的 Bash、文件读写、终端、LSP 全都构建在两个可替换的 provider 缝上。因此对 dsh 而言，"接入 k8e-sandbox"的正确姿势不是再写一套 skill 命令，而是**实现 `ctx.fs` + `ctx.subprocess` 两条缝的 provider**，让 dsh 里所有依赖这两条缝的能力（bash、terminal、LSP、`read`/`write`/`edit` 工具）一次性地跑进 k8e 沙箱。
+
+这样 k8e 得到的是：
+
+- **原生工具体验**：dsh 的 `bash` 工具、`str_replace_editor`/文件工具、terminal、LSP 全部在 gVisor/Kata/Firecracker pod 里执行，agent 无感知。
+- **复用基础设施**：温暖池、session CRD、tenant 复用、mTLS、快照、审批流，全都不重造。
+- **不侵入 dsh**：插件独立成包，随 k8e 仓库维护，dsh 一行源码都不改。
+
+## 目标与非目标
+
+### 目标
+
+1. 一个 k8e 仓库内的树外 dsh 插件族，通过 `dsh plugin add` 安装，**不修改 dsh 源码**。
+2. 实现 `ctx.fs` 与 `ctx.subprocess` 两条缝的 k8e provider，让 dsh 的 bash/文件/终端/LSP 在 k8e 沙箱中运行。
+3. 会话生命周期映射到 k8e `SandboxSession`：创建/销毁（可选暂停/恢复）、tenant 复用、温暖池收益。
+4. 与 k8e 现有 CLI/SKILL 共享同一套 mTLS、profile、API key、审批语义（KIP-14 / KIP-17）。
+
+### 非目标
+
+- 不改动 dsh 的 `packages/`、`docs/architecture.md`、agent-loop。
+- 不把 k8e 变成 dsh 的 MCP server（KIP-8 已否掉 MCP 路线）。
+- 不在本 KIP 内实现 PTY 终端（k8e gRPC 当前无 PTY 原语，见"保真度差距"）。
+- 不在本 KIP 内做"k8e session ↔ dsh session"的双向持久化绑定；dsh 的 session log 仍由 dsh 自己管，k8e 只提供执行世界。
+- 不追求与 E2B SDK 的二进制兼容（那是 KIP-18 的范畴）。
+
+## 关键约束与前提
+
+### dsh 侧（已核对源码）
+
+- **一切都是插件**：每个贡献通过 `ctx.effect()` / `ctx.on()` 挂在 Cordis 上下文上；"扩展 dsh = 在别的插件旁边挂一个插件"，没有需要 patch 的特权核心。
+- **能力缝 = Service Definition / Service Provider / Consumer 三角色**。缝是可替换的：换一个 provider 就能换掉整个执行世界（`docs/architecture.md` 的"Where new behavior goes"表明确写了：加文件系统能力 → 注册 `ctx.fs` provider；加 shell → 注册 `ctx.shell` backend，而本地 bash backend 内部通过 `ctx.subprocess` spawn）。
+- **E2B POC 是权威模板**（`packages/e2b/`）：`@deepseek-ai/dsh-e2b`（`ctx.e2b` 所有者服务，持有一个共享沙箱 handle，负责创建/清理）、`@deepseek-ai/dsh-fs-e2b`（`ctx.fs`）、`@deepseek-ai/dsh-subprocess-e2b`（`ctx.subprocess`）。E2B README 明确：`dsh-bash-local` / `dsh-terminal-bash` / `dsh-lsp-stdio` **不需要 E2B 专用 fork**，因为它们只委托 `ctx.fs` / `ctx.subprocess`。
+- **两条缝的抽象契约**：
+  - `FileSystem`（`ctx.fs`）：`resolve` / `processPath` / `fileUrl` / `contains` / `stat` / `lstat` / `readText` / `streamText` / `readBytes` / `listDir` / `writeText` / `editText`，外加 `sandboxMode` getter（backend 是否自带隔离）。
+  - `SubprocessRuntime`（`ctx.subprocess`）：`resolveExecutable` / `spawn` / `spawnTerminal`。`spawn` 返回带 stdin/stdout/stderr、`terminate()`（SIGTERM→grace→SIGKILL，进程组范围）、`waitForExit()` 的 live handle。
+- **树外加载**：`dsh plugin --profile <name> add <package>` 把包安装进 profile；bundle = `package.json` 里声明 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }` 的 npm 包；profile = `$DSH_HOME/profiles/<name>` 下的 `package.json`（含 `dsh.profile.bundles` 有序列表）+ 用户 `cordis.patch.yml`。加载顺序：各 bundle patch → profile patch → home patch → `--patch` 覆盖。**这就是"不侵入源码"的官方通道**（`docs/user/develop/basic/publish.md`）。
+
+### k8e 侧（已核对源码）
+
+- gRPC `SandboxService`（`proto/sandbox/v1/sandbox.proto`）：`CreateSession` / `GetSession` / `ListSessions` / `DestroySession` / `PauseSession` / `ResumeSession` / `Exec` / `ExecStream` / `WriteFile` / `ReadFile` / `ListFiles` / `PipInstall` / `RunSubAgent` / `ConfirmAction` / `ApproveAction` / `Login` / `PollRun` / `GetTranscript` / `GetEvents` / `Snapshot*` / `GetProcesses`。
+- `k8e-sandbox-cli` 提供与上述 RPC 一一对应的命令（含 `--raw` 流式、`--background` + `poll`、`ps`、`snapshot`、`confirm`/`approve`、`catalog`）。
+- mTLS 材料在 `~/.k8e/sandbox/`（`ca.crt` / `client.crt` / `client.key`），由 `connect` / `login` 建立，90 天证书 + <30 天惰性续期；多集群用 `profiles.yaml`（KIP-17）。
+- 仓库内**只有 Go gRPC 客户端**（`pkg/sandbox/client`）；Python/TS SDK 不在本仓库。仓库内无 TS 客户端。
+
+## 总体设计
+
+### 与 E2B POC 的同构
+
+k8e-sandbox 与 E2B 在抽象层面是同一类东西：一个远端 Linux 执行世界 + 会话生命周期 + 文件/进程两个底层原语。因此 k8e 插件族直接镜像 E2B 的三包结构：
+
+| E2B POC 包 | `ctx` key | k8e 对应包（本 KIP） |
+|---|---|---|
+| `@deepseek-ai/dsh-e2b` | `ctx.e2b` | `@k8e/dsh-k8e-sandbox`（`ctx.k8eSandbox`） |
+| `@deepseek-ai/dsh-fs-e2b` | `ctx.fs` | `@k8e/dsh-k8e-sandbox-fs` |
+| `@deepseek-ai/dsh-subprocess-e2b` | `ctx.subprocess` | `@k8e/dsh-k8e-sandbox-subprocess` |
+
+差别只在**传输层**：E2B 用其 SDK（API key），k8e 用 `k8e-sandbox-cli`（Phase 1）或直连 gRPC + mTLS（Phase 2）。
+
+### 包结构
+
+插件族以 `plugins/deepseek-harness/` 目录放在 k8e 仓库内（单仓，独立于 k8e 的 Go 构建），每个子包是一个可独立发布的 npm 包：
+
+```
+plugins/deepseek-harness/
+├── packages/
+│   ├── k8e-sandbox-dsh/            # 所有者服务：ctx.k8eSandbox（会话生命周期 + 共享客户端）
+│   ├── k8e-sandbox-dsh-fs/         # ctx.fs provider（K8eFileSystem extends FileSystem）
+│   ├── k8e-sandbox-dsh-subprocess/ # ctx.subprocess provider（K8eSubprocessRuntime extends SubprocessRuntime）
+│   ├── k8e-sandbox-dsh-client/     # 内部传输抽象：CliClient / GrpcClient 共用一个接口
+│   ├── k8e-sandbox-dsh-tool/       # 可选：模型面工具（session/snapshot/confirm/ps 等沙箱专属动词）
+│   └── k8e-sandbox-dsh-bundle/     # bundle 包：dsh.bundle.patch → cordis.patch.yml，挂载上面所有行
+├── package.json                    # pnpm workspace
+├── pnpm-workspace.yaml
+└── tsconfig.base.json
+```
+
+> npm scope 统一为 `@k8e/`，发布名按 `@k8e/dsh-*`：所有者 `@k8e/dsh-k8e-sandbox`、fs `@k8e/dsh-k8e-sandbox-fs`、subprocess `@k8e/dsh-k8e-sandbox-subprocess`、client `@k8e/dsh-k8e-sandbox-client`、tool `@k8e/dsh-k8e-sandbox-tool`、bundle `@k8e/dsh-k8e-sandbox-bundle`。目录短名（`k8e-sandbox-dsh*`）不变。
+
+### 加载方式（非侵入通道）
+
+用户侧零改 dsh 源码：
+
+```sh
+# 初始化 profile（首次会自动引入 @deepseek-ai/dsh-base）
+dsh plugin --profile k8e add <path-or-tarball-or-github>
+# 或发布到 npm 后：
+dsh plugin --profile k8e add @k8e/dsh-k8e-sandbox-bundle
+
+# 验证层 + 启动
+dsh --profile k8e --dump-config
+dsh --profile k8e
+```
+
+`k8e-sandbox-dsh-bundle/package.json` 声明 `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }`；`cordis.patch.yml` 插入四行（顺序关键——先所有者，再 fs/subprocess，后可选工具）：
+
+```yaml
+- insert:
+    - id: k8e-sandbox
+      name: '@k8e/dsh-k8e-sandbox'
+      config:
+        # endpoint / apikey / profile / cert_dir 走与 CLI 相同的解析；留空则用 ~/.k8e/sandbox
+        cwd: /workspace
+        runtimeClass: gvisor
+    - id: k8e-sandbox-fs
+      name: '@k8e/dsh-k8e-sandbox-fs'
+    - id: k8e-sandbox-subprocess
+      name: '@k8e/dsh-k8e-sandbox-subprocess'
+```
+
+依赖注入与 E2B 相同：`K8eFileSystem` 和 `K8eSubprocessRuntime` 都 `static inject = ['k8eSandbox']`，靠 Cordis 的依赖声明保证加载顺序（不需要手工 boot 序列）。挂载这两行后，dsh 的 `ctx.fs` / `ctx.subprocess` 即被 k8e 实现占据——dsh 里所有委托这两条缝的消费者自动进入沙箱。
+
+## 能力缝映射
+
+### 7.1 所有者服务 `ctx.k8eSandbox`
+
+镜像 `E2BRuntime`：持有**一个** k8e session，暴露 `getClient()`（或 `getSession()`），在 dispose 时销毁（或按配置暂停）session。
+
+**会话粒度（已决）：每 dsh 会话一个 k8e session（E2B 语义）。** 即 `ctx.k8eSandbox` 随 dsh 会话的加载/卸载而创建/销毁，不做"按 tenant 全局共享一个 pod"的默认行为；`tenant` 仅作为**显式**的跨进程复用开关保留（见下表"复用"行）。
+
+| 职责 | k8e 映射 |
+|---|---|
+| 创建执行世界 | `CreateSession`（`runtimeClass`、`tenant`、`allowed_hosts`、`env`、`secret_refs`），`cwd` 默认 `/workspace` |
+| 共享 handle | 单例懒初始化 `Promise<SessionHandle>`；fs/subprocess 在第一次操作前 await |
+| 清理 | dispose → `DestroySession`（可配 `pauseOnDispose` 走 `PauseSession` 以保留 PVC） |
+| 复用 | 可选：显式 `tenant` 映射 k8e 的 `tenant_id`，跨 dsh 进程复用同一 pod（KIP-3/`FindActiveSession`）；默认不开启 |
+
+配置项（Schemastery，与 E2B 同风格）：`endpoint?` / `apiKey?` / `profile?` / `certDir?` / `cwd` / `runtimeClass` / `timeoutMs` / `tenant?` / `allowedHosts?` / `env?` / `pauseOnDispose?`。解析顺序复用 CLI 语义：flag → env（`K8E_SANDBOX_*`）→ profile → 默认（本地自动发现）。
+
+### 7.2 文件系统 provider `ctx.fs`
+
+`K8eFileSystem extends FileSystem`，`static inject = ['k8eSandbox']`，覆盖：
+
+| seam 方法 | k8e 映射 | 备注 |
+|---|---|---|
+| `resolve` | `Exec 'realpath -mz …'`（绝对路径正则化 + 存在性探测） | 相对路径按 `cwd` 解析；targetKey 用规范化绝对路径 |
+| `processPath` / `fileUrl` / `contains` | 纯路径运算（posix） | 执行世界 = 沙箱 Linux，直接返回沙箱内绝对路径 |
+| `stat` / `lstat` | `Exec 'stat -c …'` 或 `ListFiles` 探测 | k8e 无原生 stat RPC，走 exec 兜底 |
+| `readText` / `readBytes` / `streamText` | `ReadFile` | `ReadFile` 返回整文件内容，无流式；大文件读走 exec 分块或受 `maxBytes` 限制 |
+| `listDir` | `ListFiles`（过滤直接子项） | `ListFiles` 是扁平列表（path + mtime），需自行拼目录条目与类型 |
+| `writeText` | `WriteFile` + `Exec 'mv'/'ln -T'` 原子发布 | `WriteFile` 无原子 rename；用 staging 目录 + `mv` 保证原子与锁 |
+| `editText` | `readText` → 本地字面替换 → `writeText`（同锁） | 版本守卫用 `FsVersion` |
+| `sandboxMode` | 返回沙箱后端模式（gVisor/Kata/Firecracker 视为隔离执行世界） | 让 dsh 工具层如实广播"已在沙箱内" |
+
+`FsVersion` 由 `(mtime, size, path)` 哈希生成（`ListFiles`/`stat` 只给 mtime，无 mode/size 时退化到内容哈希或 `readText` 后哈希）。
+
+### 7.3 子进程 provider `ctx.subprocess`
+
+`K8eSubprocessRuntime extends SubprocessRuntime`，`static inject = ['k8eSandbox']`：
+
+| seam 方法 | k8e 映射 |
+|---|---|
+| `resolveExecutable` | `Exec "command -v …"`（绝对路径先 `test -f/-x`） |
+| `spawn(spec)` | `Exec{background:true}` 拿 `run_id`，包装器把 pid/status 写入沙箱文件，stdout/stderr 走 `ExecStream` 或 `PollRun`；`terminate()` 用 `Exec 'kill …'` + `GetProcesses` 观察进程组存活 |
+| `spawnTerminal` | **Phase 2（依赖 KIP-19 sandbox PTY 终端原语）**；Phase 1 返回明确的"未实现"错误，terminal 消费者降级或禁用 |
+
+实现方式与 E2B `subprocess-e2b` 的 `process.ts` 同构：单次 `Exec` 无法表达"常驻进程 + 管道 stdio + 进程组终止"，所以 provider 用一个远端 wrapper（`setsid` 建进程组、发布 pid/status 到私有文件、tee 输出），终止时 `kill -- -PGID` 并按 `graceMs` 升级到 SIGKILL。
+
+### 7.4 上层消费者（免费获得）
+
+挂载 `ctx.fs` + `ctx.subprocess` 后，**无需为它们写任何 k8e fork**：
+
+- `dsh-bash-local`（`bash` 工具）→ 委托 `ctx.subprocess` + `ctx.fs`。
+- `dsh-terminal-bash`（terminal）→ 委托 `ctx.subprocess`（PTY 部分见差距）。
+- `dsh-lsp-stdio`（LSP）→ 委托 `ctx.subprocess`。
+- 文件工具（`read`/`write`/`edit`）→ 委托 `ctx.fs`。
+
+这正是 E2B README 描述的"换 provider 换掉整个执行世界"。
+
+### 7.5 可选：模型面工具 `k8e-sandbox-dsh-tool`
+
+fs/subprocess 覆盖不了 k8e 的**沙箱专属动词**。提供一个模型面工具（挂 `ctx.tools`，schema 随 prompt 装配），暴露：`session`（create/get/list/destroy/pause/resume）、`snapshot`（save/list/restore/delete）、`ps`、`confirm`/`approve`、`poll`。这些是 k8e 独有能力，不进 fs/subprocess 缝，作为 Consumer 补齐"缝"的第三角。Phase 1 可先省（SKILL 已覆盖），Phase 2 再上。
+
+## 传输层设计
+
+### 客户端抽象
+
+fs/subprocess 不直接依赖"CLI 还是 gRPC"。`k8e-sandbox-dsh-client` 定义一个内部接口（最小方法集：`createSession/destroySession/exec/execStream/writeFile/readFile/listFiles/pollRun/getProcesses/...`），两个实现：
+
+- `CliK8eClient`：包装 `k8e-sandbox-cli`（spawn 子进程，解析 JSON / `--raw` 流）。
+- `GrpcK8eClient`：从 `proto/sandbox/v1/sandbox.proto` 生成 TS（`@grpc/grpc-js` + `ts-proto` 或 `protobuf-ts`），mTLS 读 `~/.k8e/sandbox/` 证书，到期经 `Login` RPC 惰性续期。
+
+### Phase 1：CLI 包装（MVP）
+
+- **复用** `k8e-sandbox-cli` 的 connect/mTLS/profile/state 逻辑，零新 k8e 面。
+- fs 全量 + `spawn` 单次 exec + `--background`/`poll` 后台执行。
+- 缺点：每操作一次进程 spawn；`--raw` 只有合并 stdout 流，无独立 stderr 流、无 stdin 管道。
+
+### Phase 2：直连 gRPC（补保真度）
+
+- 从 proto 生成 TS 客户端（放在 `k8e-sandbox-dsh-client/`，随 proto 一起由 `make generate` 触发）。
+- mTLS 材料与 CLI 共享（同一 cert 目录 / 同一 profile），续期逻辑复用 KIP-14 语义。
+- 用 `ExecStream` 做流式 stdout，`PollRun`/`GetTranscript` 做增量与后台，`GetProcesses` + `Exec kill` 做进程组终止，逼近 E2B 的保真度。
+
+## 保真度差距（诚实清单）
+
+| 维度 | E2B SDK | k8e gRPC 现状 | 影响与对策 |
+|---|---|---|---|
+| 流式 stdout | 有 | `ExecStream` 只有合并 `chunk` | Phase 1 走 `--raw` 合并流；Phase 2 用 `GetTranscript`/`PollRun` 增量；stderr 区分受限于协议 |
+| 独立 stderr | 有 | `Exec` 分 stdout/stderr，`ExecStream` 合并 | 单次 exec 可用；流式场景先合并 |
+| stdin 到运行中进程 | 有 | `Exec` 无 stdin 字段 | 进程启动时用 wrapper 传文件/stdin；运行中 stdin 缺口 |
+| PTY / 终端 | 有 | 无 PTY 原语 | Phase 1 `spawnTerminal` 明确报未实现、terminal 消费者降级；Phase 2 依赖 KIP-19（sandbox PTY 终端原语） |
+| 原子写 | `files` API | `WriteFile` 无 rename | 用 staging + `Exec mv` 补偿 |
+| stat（mode/size） | 有 | `ListFiles` 只有 path+mtime | `Exec 'stat'` 兜底；`FsVersion` 退化策略 |
+| 进程组终止 | `kill` | 无终止 RPC | `Exec kill -- -PGID` + `GetProcesses` 存活观察 |
+| 目录列表（类型/子项） | 有 | 扁平列表 | 前端拼装 + `stat` 补类型 |
+
+这些差距**不阻塞 MVP**，但决定了 Phase 1 只能承诺"单次 exec + 文件读写"级别的体验，Phase 2 才能补齐流式与进程组。
+
+## 配置面
+
+Schemastery schema（`k8e-sandbox-dsh` 的 `Config`），字段尽量与 CLI flag 对齐：
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `endpoint` | 空（本地自动发现） | gRPC `host:port` |
+| `apiKey` | 空（读 mTLS/环境） | bootstrap 或远程一次性密钥，绝不写进沙箱 |
+| `profile` | 空 | `~/.k8e/sandbox/profiles.yaml` 的命名 profile |
+| `certDir` | `~/.k8e/sandbox` | mTLS 材料目录 |
+| `cwd` | `/workspace` | 沙箱工作目录 |
+| `runtimeClass` | `gvisor` | gvisor / kata / firecracker |
+| `timeoutMs` | 300000 | 会话生命周期；到期销毁 |
+| `tenant` | 空 | 显式跨进程 session 复用（非默认；默认每 dsh 会话一个 k8e session） |
+| `allowedHosts` | 空 | egress 白名单 |
+| `env` | 空 | 非敏感环境变量 |
+| `pauseOnDispose` | false | dispose 时 pause 而非 destroy（保 PVC） |
+
+解析优先级与 SKILL.md 一致：flag → env → profile → 默认。
+
+## 安全
+
+- **mTLS 复用**：直接读 `~/.k8e/sandbox/` 证书；私钥不出本机；续期复用 KIP-14。
+- **凭据隔离**：`apiKey` 只用于 gateway 握手，绝不通过 `env` 注入沙箱；dsh 自身的 `DEEPSEEK_API_KEY` 等凭据形环境变量由 `scrubbedParentEnv` 在 spawn 前剔除。
+- **secret 走 SecretRef**：非敏感配置才进 `env`（KIP-12 语义），敏感值用 `secret_refs`（`ENV=secretName:key`）。
+- **审批流**：破坏性动作映射到 k8e `confirm` → `approve`（人在环），与 SKILL 的安全红线一致；dsh 侧也可接 `interaction`/`approval` 能力。
+- **沙箱即隔离**：`sandboxMode` 如实上报后端隔离（gVisor/Kata/Firecracker），让 dsh 工具层正确广播"已在沙箱内"而不误报 host 执行。
+
+## 验收标准
+
+- [ ] 树外 bundle 能通过 `dsh plugin --profile k8e add …` 安装并 `dsh --profile k8e --dump-config` 显示 `k8e-sandbox-dsh` 层。
+- [ ] 挂载后 `ctx.fs` / `ctx.subprocess` 被 k8e 实现占据，dsh 的 `bash` 与文件工具在沙箱 pod 内执行（用 `ps`/`list` 验证是沙箱而非 host）。
+- [ ] fs：`read/write/edit/list/stat` 通过 `WriteFile/ReadFile/ListFiles/Exec` 正确映射；原子写与版本守卫有单测。
+- [ ] subprocess：`spawn` 单次 exec 返回正确 stdout/stderr/exit_code；`terminate` 走 kill+存活观察；`resolveExecutable` 正确。
+- [ ] 会话生命周期：dispose → DestroySession；`pauseOnDispose` → PauseSession；`tenant` 复用同一 pod。
+- [ ] mTLS/profile/env 解析与 CLI 一致（KIP-17 表）。
+- [ ] 快照/审批/`ps` 等专属动词（可选工具）行为与 SKILL 对齐。
+- [ ] keyless dsh 快照：一个脚本化模型跑在 mock k8e gateway 上，产出可复放的 transcript。
+- [ ] 文档：本 KIP + 插件 README + `SKILL.md` 一处更新说明"dsh 用户也可用插件接入"。
+
+## 实现地图
+
+| 阶段 | 内容 | 位置 |
+|---|---|---|
+| Phase 1 | 所有者服务 + CLI 客户端抽象 | `plugins/deepseek-harness/packages/k8e-sandbox-dsh{,-client}` |
+| Phase 1 | fs provider（CLI 传输） | `.../k8e-sandbox-dsh-fs` |
+| Phase 1 | subprocess provider（单次 exec + 后台） | `.../k8e-sandbox-dsh-subprocess` |
+| Phase 1 | bundle 包 + cordis.patch.yml | `.../k8e-sandbox-dsh-bundle` |
+| Phase 2 | gRPC TS 客户端（proto 生成 + mTLS 续期） | `.../k8e-sandbox-dsh-client/src/grpc`，proto 生成接 `make generate` |
+| Phase 2 | 流式 stdio / 进程组终止 / 模型面工具 | subprocess、`k8e-sandbox-dsh-tool` |
+| Phase 2 | `spawnTerminal`（**依赖 KIP-19（sandbox PTY 终端原语）先落地**） | subprocess + k8e 侧 PTY RPC |
+| 后续 | — | — |
+
+## 测试计划
+
+- **单测**：配置解析、路径映射、`FsVersion` 生成、`listDir` 拼装、原子写状态机、进程组终止状态机（Vitest，mirror `fs-e2b`/`subprocess-e2b` 的 spec）。
+- **快照**：一个 mock k8e gateway（或 `CliK8eClient` 打到假 CLI）跑 keyless dsh replay，外部断言 transcript。
+- **e2e**：真实 K8E 集群（`make test` 集成环境）验证 bash/文件/终端进入沙箱 pod、温暖池收益、destroy/pause。
+- **契约**：`k8e-sandbox-cli catalog`（KIP-16 M9）作为 CLI 客户端的生成/校验输入，防止 CLI 面漂移。
+
+## 备选方案
+
+| 方案 | 为什么不选 |
+|---|---|
+| 只写一个 dsh 的 SKILL（复用 `k8e-sandbox-cli`） | 命令字符串而非原生工具，文件/执行不成结构化能力，terminal/LSP 无法受益 |
+| 在 dsh 仓库内加 `packages/k8e/*` | 侵入 dsh 源码，违反"树外"约束 |
+| 做一个 k8e MCP server 给 dsh | KIP-8 已否掉 MCP 路线；且 dsh 的 MCP 是额外适配层，不如 provider 缝原生 |
+| 直连 gRPC 一步到位（跳过 CLI） | 需先补齐 proto TS 生成 + mTLS 续期，Phase 1 拉长；CLI 包装能更快验证缝的语义 |
+| 复用 E2B 兼容层（KIP-18）接入 dsh 的 E2B provider | 依赖 KIP-18 的 E2B 兼容面是否到位，且绕开了 k8e 原生 session/snapshot/审批能力 |
+
+## 已决问题
+
+| # | 问题 | 决定 |
+|---|---|---|
+| 1 | npm scope | 统一 `@k8e/dsh-*`（所有者 `@k8e/dsh-k8e-sandbox` 等，见"包结构"） |
+| 2 | PTY 时间表 | `spawnTerminal` 放在 Phase 2，且**依赖 KIP-19（sandbox PTY 终端原语）先行**；本 KIP 只到"非 PTY 子进程" |
+| 3 | session 复用粒度 | **每 dsh 会话一个 k8e session（E2B 语义）**；`tenant` 仅作显式跨进程复用开关，不作默认全局共享 |


### PR DESCRIPTION
> 关联 issue：#542（feat: Support Deepseek Harness sidebar integration）

## 概述

两个新 KIP 设计文档，进入评审。

### KIP-19 — sandbox PTY 终端原语
给 `sandboxd` + gRPC 网关增加 7 个终端 RPC（`CreateTerminal` / `TerminalStream` / `TerminalWrite` / `TerminalResize` / `TerminalForeground` / `TerminalSignal` / `TerminalDestroy`），服务两个消费者：
- dsh 的 `spawnTerminal`（KIP-20 Phase 2）
- E2B SDK 的 `pty.*`（补 KIP-18 的缺口）

### KIP-20 — k8e-sandbox-dsh 插件
树外 DeepSeek Harness 插件族（`@k8e/dsh-k8e-sandbox{,-fs,-subprocess,-client,-tool,-bundle}`），通过 `dsh plugin add` 以插件方式让 dsh 调用 k8e-sandbox，**不侵入 dsh 源码**。

## 依赖顺序（只向前引用）

```
KIP-18（E2B 兼容）
  → KIP-19（PTY 原语）
    → KIP-20（dsh 插件，Phase 2 spawnTerminal 依赖 KIP-19）
```

## 评审重点

- **KIP-19**：PTY 分配 / 会话首领 / 前台进程组 / 会话树终止语义是否完整；`oneof` 终端流与 `terminal_id` 路由注册表是否合理。
- **KIP-20**：fs/subprocess 能力缝映射是否贴合 dsh 的 E2B POC 模板；传输层分阶段（Phase 1 CLI → Phase 2 直连 gRPC）是否稳妥。

## 已决问题（记录在 KIP 内）

- npm scope：`@k8e/dsh-*`
- session 粒度：每 dsh 会话一个 k8e session（E2B 语义）
- `input_waiting`：positive-proof-only，M1 恒 `false`
- E2B pid 寻址：映射归 KIP-18 兼容层
