### PR TITLE
feat(sandbox): PTY terminal primitive (KIP-19)

### DIFF
--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -21,6 +21,64 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type TerminalSignal int32
+
+const (
+	TerminalSignal_TERMINAL_SIGNAL_UNSPECIFIED TerminalSignal = 0
+	TerminalSignal_TERMINAL_SIGNAL_INT         TerminalSignal = 1 // SIGINT
+	TerminalSignal_TERMINAL_SIGNAL_TERM        TerminalSignal = 2 // SIGTERM
+	TerminalSignal_TERMINAL_SIGNAL_KILL        TerminalSignal = 3 // SIGKILL
+	TerminalSignal_TERMINAL_SIGNAL_TSTP        TerminalSignal = 4 // SIGTSTP
+	TerminalSignal_TERMINAL_SIGNAL_HUP         TerminalSignal = 5 // SIGHUP
+)
+
+// Enum value maps for TerminalSignal.
+var (
+	TerminalSignal_name = map[int32]string{
+		0: "TERMINAL_SIGNAL_UNSPECIFIED",
+		1: "TERMINAL_SIGNAL_INT",
+		2: "TERMINAL_SIGNAL_TERM",
+		3: "TERMINAL_SIGNAL_KILL",
+		4: "TERMINAL_SIGNAL_TSTP",
+		5: "TERMINAL_SIGNAL_HUP",
+	}
+	TerminalSignal_value = map[string]int32{
+		"TERMINAL_SIGNAL_UNSPECIFIED": 0,
+		"TERMINAL_SIGNAL_INT":         1,
+		"TERMINAL_SIGNAL_TERM":        2,
+		"TERMINAL_SIGNAL_KILL":        3,
+		"TERMINAL_SIGNAL_TSTP":        4,
+		"TERMINAL_SIGNAL_HUP":         5,
+	}
+)
+
+func (x TerminalSignal) Enum() *TerminalSignal {
+	p := new(TerminalSignal)
+	*p = x
+	return p
+}
+
+func (x TerminalSignal) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TerminalSignal) Descriptor() protoreflect.EnumDescriptor {
+	return file_sandbox_v1_sandbox_proto_enumTypes[0].Descriptor()
+}
+
+func (TerminalSignal) Type() protoreflect.EnumType {
+	return &file_sandbox_v1_sandbox_proto_enumTypes[0]
+}
+
+func (x TerminalSignal) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TerminalSignal.Descriptor instead.
+func (TerminalSignal) EnumDescriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{0}
+}
+
 // SecretRef references a key in a same-namespace K8s Secret. Values are resolved
 // at exec time only and never stored on the SandboxSession CRD (#505 / KIP-12 B).
 type SecretRef struct {
@@ -2694,6 +2752,808 @@ func (x *GetProcessesResponse) GetProcesses() []*ProcessInfo {
 	return nil
 }
 
+type CreateTerminalRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	Argv          []string               `protobuf:"bytes,2,rep,name=argv,proto3" json:"argv,omitempty"` // argv[0] is the program; NOT shell-interpreted
+	Workdir       string                 `protobuf:"bytes,3,opt,name=workdir,proto3" json:"workdir,omitempty"`
+	Env           map[string]string      `protobuf:"bytes,4,rep,name=env,proto3" json:"env,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // non-sensitive env; secrets stay in CreateSession.secret_refs
+	Rows          int32                  `protobuf:"varint,5,opt,name=rows,proto3" json:"rows,omitempty"`                                                                        // initial window rows (>=1)
+	Cols          int32                  `protobuf:"varint,6,opt,name=cols,proto3" json:"cols,omitempty"`                                                                        // initial window cols (>=1)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateTerminalRequest) Reset() {
+	*x = CreateTerminalRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateTerminalRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateTerminalRequest) ProtoMessage() {}
+
+func (x *CreateTerminalRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateTerminalRequest.ProtoReflect.Descriptor instead.
+func (*CreateTerminalRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *CreateTerminalRequest) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
+}
+
+func (x *CreateTerminalRequest) GetArgv() []string {
+	if x != nil {
+		return x.Argv
+	}
+	return nil
+}
+
+func (x *CreateTerminalRequest) GetWorkdir() string {
+	if x != nil {
+		return x.Workdir
+	}
+	return ""
+}
+
+func (x *CreateTerminalRequest) GetEnv() map[string]string {
+	if x != nil {
+		return x.Env
+	}
+	return nil
+}
+
+func (x *CreateTerminalRequest) GetRows() int32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
+func (x *CreateTerminalRequest) GetCols() int32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+type CreateTerminalResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"` // opaque branded handle for all terminal RPCs
+	Pid           int32                  `protobuf:"varint,2,opt,name=pid,proto3" json:"pid,omitempty"`                                // session-leader pid in the sandbox pid space
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateTerminalResponse) Reset() {
+	*x = CreateTerminalResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateTerminalResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateTerminalResponse) ProtoMessage() {}
+
+func (x *CreateTerminalResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateTerminalResponse.ProtoReflect.Descriptor instead.
+func (*CreateTerminalResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *CreateTerminalResponse) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+func (x *CreateTerminalResponse) GetPid() int32 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+type TerminalStreamRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalStreamRequest) Reset() {
+	*x = TerminalStreamRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalStreamRequest) ProtoMessage() {}
+
+func (x *TerminalStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalStreamRequest.ProtoReflect.Descriptor instead.
+func (*TerminalStreamRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *TerminalStreamRequest) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+type TerminalStreamResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Frame:
+	//
+	//	*TerminalStreamResponse_Data
+	//	*TerminalStreamResponse_Exit
+	Frame         isTerminalStreamResponse_Frame `protobuf_oneof:"frame"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalStreamResponse) Reset() {
+	*x = TerminalStreamResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalStreamResponse) ProtoMessage() {}
+
+func (x *TerminalStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalStreamResponse.ProtoReflect.Descriptor instead.
+func (*TerminalStreamResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *TerminalStreamResponse) GetFrame() isTerminalStreamResponse_Frame {
+	if x != nil {
+		return x.Frame
+	}
+	return nil
+}
+
+func (x *TerminalStreamResponse) GetData() []byte {
+	if x != nil {
+		if x, ok := x.Frame.(*TerminalStreamResponse_Data); ok {
+			return x.Data
+		}
+	}
+	return nil
+}
+
+func (x *TerminalStreamResponse) GetExit() *TerminalExit {
+	if x != nil {
+		if x, ok := x.Frame.(*TerminalStreamResponse_Exit); ok {
+			return x.Exit
+		}
+	}
+	return nil
+}
+
+type isTerminalStreamResponse_Frame interface {
+	isTerminalStreamResponse_Frame()
+}
+
+type TerminalStreamResponse_Data struct {
+	Data []byte `protobuf:"bytes,1,opt,name=data,proto3,oneof"` // terminal output bytes in delivery order
+}
+
+type TerminalStreamResponse_Exit struct {
+	Exit *TerminalExit `protobuf:"bytes,2,opt,name=exit,proto3,oneof"` // final frame: top-level process closed
+}
+
+func (*TerminalStreamResponse_Data) isTerminalStreamResponse_Frame() {}
+
+func (*TerminalStreamResponse_Exit) isTerminalStreamResponse_Frame() {}
+
+type TerminalExit struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ExitCode      int32                  `protobuf:"varint,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"` // process exit code; 0 = clean
+	Signal        string                 `protobuf:"bytes,2,opt,name=signal,proto3" json:"signal,omitempty"`                      // terminating signal name; empty = normal exit
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalExit) Reset() {
+	*x = TerminalExit{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalExit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalExit) ProtoMessage() {}
+
+func (x *TerminalExit) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalExit.ProtoReflect.Descriptor instead.
+func (*TerminalExit) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *TerminalExit) GetExitCode() int32 {
+	if x != nil {
+		return x.ExitCode
+	}
+	return 0
+}
+
+func (x *TerminalExit) GetSignal() string {
+	if x != nil {
+		return x.Signal
+	}
+	return ""
+}
+
+type TerminalWriteRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"`
+	Data          []byte                 `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"` // raw bytes, no implicit newline
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalWriteRequest) Reset() {
+	*x = TerminalWriteRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalWriteRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalWriteRequest) ProtoMessage() {}
+
+func (x *TerminalWriteRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalWriteRequest.ProtoReflect.Descriptor instead.
+func (*TerminalWriteRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *TerminalWriteRequest) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+func (x *TerminalWriteRequest) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+type TerminalWriteResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalWriteResponse) Reset() {
+	*x = TerminalWriteResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalWriteResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalWriteResponse) ProtoMessage() {}
+
+func (x *TerminalWriteResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalWriteResponse.ProtoReflect.Descriptor instead.
+func (*TerminalWriteResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *TerminalWriteResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+type TerminalResizeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"`
+	Rows          int32                  `protobuf:"varint,2,opt,name=rows,proto3" json:"rows,omitempty"`
+	Cols          int32                  `protobuf:"varint,3,opt,name=cols,proto3" json:"cols,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalResizeRequest) Reset() {
+	*x = TerminalResizeRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalResizeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalResizeRequest) ProtoMessage() {}
+
+func (x *TerminalResizeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalResizeRequest.ProtoReflect.Descriptor instead.
+func (*TerminalResizeRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *TerminalResizeRequest) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+func (x *TerminalResizeRequest) GetRows() int32 {
+	if x != nil {
+		return x.Rows
+	}
+	return 0
+}
+
+func (x *TerminalResizeRequest) GetCols() int32 {
+	if x != nil {
+		return x.Cols
+	}
+	return 0
+}
+
+type TerminalResizeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalResizeResponse) Reset() {
+	*x = TerminalResizeResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalResizeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalResizeResponse) ProtoMessage() {}
+
+func (x *TerminalResizeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalResizeResponse.ProtoReflect.Descriptor instead.
+func (*TerminalResizeResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *TerminalResizeResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+type TerminalForegroundRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalForegroundRequest) Reset() {
+	*x = TerminalForegroundRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalForegroundRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalForegroundRequest) ProtoMessage() {}
+
+func (x *TerminalForegroundRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalForegroundRequest.ProtoReflect.Descriptor instead.
+func (*TerminalForegroundRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *TerminalForegroundRequest) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+type TerminalForegroundResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ProcessGroupId int32                  `protobuf:"varint,1,opt,name=process_group_id,json=processGroupId,proto3" json:"process_group_id,omitempty"` // current foreground pgid; -1 when unresolvable
+	InputWaiting   bool                   `protobuf:"varint,2,opt,name=input_waiting,json=inputWaiting,proto3" json:"input_waiting,omitempty"`         // best-effort; false means "not provable" (KIP-19)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *TerminalForegroundResponse) Reset() {
+	*x = TerminalForegroundResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalForegroundResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalForegroundResponse) ProtoMessage() {}
+
+func (x *TerminalForegroundResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalForegroundResponse.ProtoReflect.Descriptor instead.
+func (*TerminalForegroundResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{58}
+}
+
+func (x *TerminalForegroundResponse) GetProcessGroupId() int32 {
+	if x != nil {
+		return x.ProcessGroupId
+	}
+	return 0
+}
+
+func (x *TerminalForegroundResponse) GetInputWaiting() bool {
+	if x != nil {
+		return x.InputWaiting
+	}
+	return false
+}
+
+type TerminalSignalRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"`
+	Signal        TerminalSignal         `protobuf:"varint,2,opt,name=signal,proto3,enum=sandbox.v1.TerminalSignal" json:"signal,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalSignalRequest) Reset() {
+	*x = TerminalSignalRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalSignalRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalSignalRequest) ProtoMessage() {}
+
+func (x *TerminalSignalRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalSignalRequest.ProtoReflect.Descriptor instead.
+func (*TerminalSignalRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{59}
+}
+
+func (x *TerminalSignalRequest) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+func (x *TerminalSignalRequest) GetSignal() TerminalSignal {
+	if x != nil {
+		return x.Signal
+	}
+	return TerminalSignal_TERMINAL_SIGNAL_UNSPECIFIED
+}
+
+type TerminalSignalResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ProcessGroupId int32                  `protobuf:"varint,1,opt,name=process_group_id,json=processGroupId,proto3" json:"process_group_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *TerminalSignalResponse) Reset() {
+	*x = TerminalSignalResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalSignalResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalSignalResponse) ProtoMessage() {}
+
+func (x *TerminalSignalResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalSignalResponse.ProtoReflect.Descriptor instead.
+func (*TerminalSignalResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *TerminalSignalResponse) GetProcessGroupId() int32 {
+	if x != nil {
+		return x.ProcessGroupId
+	}
+	return 0
+}
+
+type TerminalDestroyRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TerminalId    string                 `protobuf:"bytes,1,opt,name=terminal_id,json=terminalId,proto3" json:"terminal_id,omitempty"`
+	GraceMs       int32                  `protobuf:"varint,2,opt,name=grace_ms,json=graceMs,proto3" json:"grace_ms,omitempty"` // TERM -> grace -> KILL escalation bound
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalDestroyRequest) Reset() {
+	*x = TerminalDestroyRequest{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalDestroyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalDestroyRequest) ProtoMessage() {}
+
+func (x *TerminalDestroyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalDestroyRequest.ProtoReflect.Descriptor instead.
+func (*TerminalDestroyRequest) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *TerminalDestroyRequest) GetTerminalId() string {
+	if x != nil {
+		return x.TerminalId
+	}
+	return ""
+}
+
+func (x *TerminalDestroyRequest) GetGraceMs() int32 {
+	if x != nil {
+		return x.GraceMs
+	}
+	return 0
+}
+
+type TerminalDestroyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ok            bool                   `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TerminalDestroyResponse) Reset() {
+	*x = TerminalDestroyResponse{}
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TerminalDestroyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TerminalDestroyResponse) ProtoMessage() {}
+
+func (x *TerminalDestroyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_sandbox_v1_sandbox_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TerminalDestroyResponse.ProtoReflect.Descriptor instead.
+func (*TerminalDestroyResponse) Descriptor() ([]byte, []int) {
+	return file_sandbox_v1_sandbox_proto_rawDescGZIP(), []int{62}
+}
+
+func (x *TerminalDestroyResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
 var File_sandbox_v1_sandbox_proto protoreflect.FileDescriptor
 
 const file_sandbox_v1_sandbox_proto_rawDesc = "" +
@@ -2899,7 +3759,70 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\x04comm\x18\x02 \x01(\tR\x04comm\x12\x14\n" +
 	"\x05state\x18\x03 \x01(\tR\x05state\"M\n" +
 	"\x14GetProcessesResponse\x125\n" +
-	"\tprocesses\x18\x01 \x03(\v2\x17.sandbox.v1.ProcessInfoR\tprocesses2\x98\x0e\n" +
+	"\tprocesses\x18\x01 \x03(\v2\x17.sandbox.v1.ProcessInfoR\tprocesses\"\x82\x02\n" +
+	"\x15CreateTerminalRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
+	"\x04argv\x18\x02 \x03(\tR\x04argv\x12\x18\n" +
+	"\aworkdir\x18\x03 \x01(\tR\aworkdir\x12<\n" +
+	"\x03env\x18\x04 \x03(\v2*.sandbox.v1.CreateTerminalRequest.EnvEntryR\x03env\x12\x12\n" +
+	"\x04rows\x18\x05 \x01(\x05R\x04rows\x12\x12\n" +
+	"\x04cols\x18\x06 \x01(\x05R\x04cols\x1a6\n" +
+	"\bEnvEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"K\n" +
+	"\x16CreateTerminalResponse\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\x12\x10\n" +
+	"\x03pid\x18\x02 \x01(\x05R\x03pid\"8\n" +
+	"\x15TerminalStreamRequest\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\"g\n" +
+	"\x16TerminalStreamResponse\x12\x14\n" +
+	"\x04data\x18\x01 \x01(\fH\x00R\x04data\x12.\n" +
+	"\x04exit\x18\x02 \x01(\v2\x18.sandbox.v1.TerminalExitH\x00R\x04exitB\a\n" +
+	"\x05frame\"C\n" +
+	"\fTerminalExit\x12\x1b\n" +
+	"\texit_code\x18\x01 \x01(\x05R\bexitCode\x12\x16\n" +
+	"\x06signal\x18\x02 \x01(\tR\x06signal\"K\n" +
+	"\x14TerminalWriteRequest\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\x12\x12\n" +
+	"\x04data\x18\x02 \x01(\fR\x04data\"'\n" +
+	"\x15TerminalWriteResponse\x12\x0e\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\"`\n" +
+	"\x15TerminalResizeRequest\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\x12\x12\n" +
+	"\x04rows\x18\x02 \x01(\x05R\x04rows\x12\x12\n" +
+	"\x04cols\x18\x03 \x01(\x05R\x04cols\"(\n" +
+	"\x16TerminalResizeResponse\x12\x0e\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok\"<\n" +
+	"\x19TerminalForegroundRequest\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\"k\n" +
+	"\x1aTerminalForegroundResponse\x12(\n" +
+	"\x10process_group_id\x18\x01 \x01(\x05R\x0eprocessGroupId\x12#\n" +
+	"\rinput_waiting\x18\x02 \x01(\bR\finputWaiting\"l\n" +
+	"\x15TerminalSignalRequest\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\x122\n" +
+	"\x06signal\x18\x02 \x01(\x0e2\x1a.sandbox.v1.TerminalSignalR\x06signal\"B\n" +
+	"\x16TerminalSignalResponse\x12(\n" +
+	"\x10process_group_id\x18\x01 \x01(\x05R\x0eprocessGroupId\"T\n" +
+	"\x16TerminalDestroyRequest\x12\x1f\n" +
+	"\vterminal_id\x18\x01 \x01(\tR\n" +
+	"terminalId\x12\x19\n" +
+	"\bgrace_ms\x18\x02 \x01(\x05R\agraceMs\")\n" +
+	"\x17TerminalDestroyResponse\x12\x0e\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok*\xb1\x01\n" +
+	"\x0eTerminalSignal\x12\x1f\n" +
+	"\x1bTERMINAL_SIGNAL_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13TERMINAL_SIGNAL_INT\x10\x01\x12\x18\n" +
+	"\x14TERMINAL_SIGNAL_TERM\x10\x02\x12\x18\n" +
+	"\x14TERMINAL_SIGNAL_KILL\x10\x03\x12\x18\n" +
+	"\x14TERMINAL_SIGNAL_TSTP\x10\x04\x12\x17\n" +
+	"\x13TERMINAL_SIGNAL_HUP\x10\x052\x95\x13\n" +
 	"\x0eSandboxService\x12T\n" +
 	"\rCreateSession\x12 .sandbox.v1.CreateSessionRequest\x1a!.sandbox.v1.CreateSessionResponse\x12K\n" +
 	"\n" +
@@ -2926,7 +3849,14 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"\vSnapshotPut\x12\x1e.sandbox.v1.SnapshotPutRequest\x1a\x1f.sandbox.v1.SnapshotPutResponse\x12N\n" +
 	"\vSnapshotGet\x12\x1e.sandbox.v1.SnapshotGetRequest\x1a\x1f.sandbox.v1.SnapshotGetResponse\x12Q\n" +
 	"\fSnapshotList\x12\x1f.sandbox.v1.SnapshotListRequest\x1a .sandbox.v1.SnapshotListResponse\x12Q\n" +
-	"\fGetProcesses\x12\x1f.sandbox.v1.GetProcessesRequest\x1a .sandbox.v1.GetProcessesResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
+	"\fGetProcesses\x12\x1f.sandbox.v1.GetProcessesRequest\x1a .sandbox.v1.GetProcessesResponse\x12W\n" +
+	"\x0eCreateTerminal\x12!.sandbox.v1.CreateTerminalRequest\x1a\".sandbox.v1.CreateTerminalResponse\x12Y\n" +
+	"\x0eTerminalStream\x12!.sandbox.v1.TerminalStreamRequest\x1a\".sandbox.v1.TerminalStreamResponse0\x01\x12T\n" +
+	"\rTerminalWrite\x12 .sandbox.v1.TerminalWriteRequest\x1a!.sandbox.v1.TerminalWriteResponse\x12W\n" +
+	"\x0eTerminalResize\x12!.sandbox.v1.TerminalResizeRequest\x1a\".sandbox.v1.TerminalResizeResponse\x12c\n" +
+	"\x12TerminalForeground\x12%.sandbox.v1.TerminalForegroundRequest\x1a&.sandbox.v1.TerminalForegroundResponse\x12W\n" +
+	"\x0eTerminalSignal\x12!.sandbox.v1.TerminalSignalRequest\x1a\".sandbox.v1.TerminalSignalResponse\x12Z\n" +
+	"\x0fTerminalDestroy\x12\".sandbox.v1.TerminalDestroyRequest\x1a#.sandbox.v1.TerminalDestroyResponseB?Z=github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pbb\x06proto3"
 
 var (
 	file_sandbox_v1_sandbox_proto_rawDescOnce sync.Once
@@ -2940,115 +3870,150 @@ func file_sandbox_v1_sandbox_proto_rawDescGZIP() []byte {
 	return file_sandbox_v1_sandbox_proto_rawDescData
 }
 
-var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_sandbox_v1_sandbox_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_sandbox_v1_sandbox_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
 var file_sandbox_v1_sandbox_proto_goTypes = []any{
-	(*SecretRef)(nil),              // 0: sandbox.v1.SecretRef
-	(*CreateSessionRequest)(nil),   // 1: sandbox.v1.CreateSessionRequest
-	(*CreateSessionResponse)(nil),  // 2: sandbox.v1.CreateSessionResponse
-	(*GetSessionRequest)(nil),      // 3: sandbox.v1.GetSessionRequest
-	(*GetSessionResponse)(nil),     // 4: sandbox.v1.GetSessionResponse
-	(*ListSessionsRequest)(nil),    // 5: sandbox.v1.ListSessionsRequest
-	(*ListSessionsResponse)(nil),   // 6: sandbox.v1.ListSessionsResponse
-	(*DestroySessionRequest)(nil),  // 7: sandbox.v1.DestroySessionRequest
-	(*DestroySessionResponse)(nil), // 8: sandbox.v1.DestroySessionResponse
-	(*PauseSessionRequest)(nil),    // 9: sandbox.v1.PauseSessionRequest
-	(*PauseSessionResponse)(nil),   // 10: sandbox.v1.PauseSessionResponse
-	(*ResumeSessionRequest)(nil),   // 11: sandbox.v1.ResumeSessionRequest
-	(*ResumeSessionResponse)(nil),  // 12: sandbox.v1.ResumeSessionResponse
-	(*ExecRequest)(nil),            // 13: sandbox.v1.ExecRequest
-	(*ExecResponse)(nil),           // 14: sandbox.v1.ExecResponse
-	(*ExecStreamResponse)(nil),     // 15: sandbox.v1.ExecStreamResponse
-	(*WriteFileRequest)(nil),       // 16: sandbox.v1.WriteFileRequest
-	(*WriteFileResponse)(nil),      // 17: sandbox.v1.WriteFileResponse
-	(*ReadFileRequest)(nil),        // 18: sandbox.v1.ReadFileRequest
-	(*ReadFileResponse)(nil),       // 19: sandbox.v1.ReadFileResponse
-	(*ListFilesRequest)(nil),       // 20: sandbox.v1.ListFilesRequest
-	(*ListFilesResponse)(nil),      // 21: sandbox.v1.ListFilesResponse
-	(*FileEntry)(nil),              // 22: sandbox.v1.FileEntry
-	(*PipInstallRequest)(nil),      // 23: sandbox.v1.PipInstallRequest
-	(*PipInstallResponse)(nil),     // 24: sandbox.v1.PipInstallResponse
-	(*RunSubAgentRequest)(nil),     // 25: sandbox.v1.RunSubAgentRequest
-	(*RunSubAgentResponse)(nil),    // 26: sandbox.v1.RunSubAgentResponse
-	(*ConfirmActionRequest)(nil),   // 27: sandbox.v1.ConfirmActionRequest
-	(*ConfirmActionResponse)(nil),  // 28: sandbox.v1.ConfirmActionResponse
-	(*ApproveActionRequest)(nil),   // 29: sandbox.v1.ApproveActionRequest
-	(*ApproveActionResponse)(nil),  // 30: sandbox.v1.ApproveActionResponse
-	(*LoginRequest)(nil),           // 31: sandbox.v1.LoginRequest
-	(*LoginResponse)(nil),          // 32: sandbox.v1.LoginResponse
-	(*PollRunRequest)(nil),         // 33: sandbox.v1.PollRunRequest
-	(*PollRunResponse)(nil),        // 34: sandbox.v1.PollRunResponse
-	(*GetTranscriptRequest)(nil),   // 35: sandbox.v1.GetTranscriptRequest
-	(*GetTranscriptResponse)(nil),  // 36: sandbox.v1.GetTranscriptResponse
-	(*GetEventsRequest)(nil),       // 37: sandbox.v1.GetEventsRequest
-	(*GetEventsResponse)(nil),      // 38: sandbox.v1.GetEventsResponse
-	(*SnapshotPutRequest)(nil),     // 39: sandbox.v1.SnapshotPutRequest
-	(*SnapshotPutResponse)(nil),    // 40: sandbox.v1.SnapshotPutResponse
-	(*SnapshotGetRequest)(nil),     // 41: sandbox.v1.SnapshotGetRequest
-	(*SnapshotGetResponse)(nil),    // 42: sandbox.v1.SnapshotGetResponse
-	(*SnapshotListRequest)(nil),    // 43: sandbox.v1.SnapshotListRequest
-	(*SnapshotListResponse)(nil),   // 44: sandbox.v1.SnapshotListResponse
-	(*GetProcessesRequest)(nil),    // 45: sandbox.v1.GetProcessesRequest
-	(*ProcessInfo)(nil),            // 46: sandbox.v1.ProcessInfo
-	(*GetProcessesResponse)(nil),   // 47: sandbox.v1.GetProcessesResponse
-	nil,                            // 48: sandbox.v1.CreateSessionRequest.EnvEntry
+	(TerminalSignal)(0),                // 0: sandbox.v1.TerminalSignal
+	(*SecretRef)(nil),                  // 1: sandbox.v1.SecretRef
+	(*CreateSessionRequest)(nil),       // 2: sandbox.v1.CreateSessionRequest
+	(*CreateSessionResponse)(nil),      // 3: sandbox.v1.CreateSessionResponse
+	(*GetSessionRequest)(nil),          // 4: sandbox.v1.GetSessionRequest
+	(*GetSessionResponse)(nil),         // 5: sandbox.v1.GetSessionResponse
+	(*ListSessionsRequest)(nil),        // 6: sandbox.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),       // 7: sandbox.v1.ListSessionsResponse
+	(*DestroySessionRequest)(nil),      // 8: sandbox.v1.DestroySessionRequest
+	(*DestroySessionResponse)(nil),     // 9: sandbox.v1.DestroySessionResponse
+	(*PauseSessionRequest)(nil),        // 10: sandbox.v1.PauseSessionRequest
+	(*PauseSessionResponse)(nil),       // 11: sandbox.v1.PauseSessionResponse
+	(*ResumeSessionRequest)(nil),       // 12: sandbox.v1.ResumeSessionRequest
+	(*ResumeSessionResponse)(nil),      // 13: sandbox.v1.ResumeSessionResponse
+	(*ExecRequest)(nil),                // 14: sandbox.v1.ExecRequest
+	(*ExecResponse)(nil),               // 15: sandbox.v1.ExecResponse
+	(*ExecStreamResponse)(nil),         // 16: sandbox.v1.ExecStreamResponse
+	(*WriteFileRequest)(nil),           // 17: sandbox.v1.WriteFileRequest
+	(*WriteFileResponse)(nil),          // 18: sandbox.v1.WriteFileResponse
+	(*ReadFileRequest)(nil),            // 19: sandbox.v1.ReadFileRequest
+	(*ReadFileResponse)(nil),           // 20: sandbox.v1.ReadFileResponse
+	(*ListFilesRequest)(nil),           // 21: sandbox.v1.ListFilesRequest
+	(*ListFilesResponse)(nil),          // 22: sandbox.v1.ListFilesResponse
+	(*FileEntry)(nil),                  // 23: sandbox.v1.FileEntry
+	(*PipInstallRequest)(nil),          // 24: sandbox.v1.PipInstallRequest
+	(*PipInstallResponse)(nil),         // 25: sandbox.v1.PipInstallResponse
+	(*RunSubAgentRequest)(nil),         // 26: sandbox.v1.RunSubAgentRequest
+	(*RunSubAgentResponse)(nil),        // 27: sandbox.v1.RunSubAgentResponse
+	(*ConfirmActionRequest)(nil),       // 28: sandbox.v1.ConfirmActionRequest
+	(*ConfirmActionResponse)(nil),      // 29: sandbox.v1.ConfirmActionResponse
+	(*ApproveActionRequest)(nil),       // 30: sandbox.v1.ApproveActionRequest
+	(*ApproveActionResponse)(nil),      // 31: sandbox.v1.ApproveActionResponse
+	(*LoginRequest)(nil),               // 32: sandbox.v1.LoginRequest
+	(*LoginResponse)(nil),              // 33: sandbox.v1.LoginResponse
+	(*PollRunRequest)(nil),             // 34: sandbox.v1.PollRunRequest
+	(*PollRunResponse)(nil),            // 35: sandbox.v1.PollRunResponse
+	(*GetTranscriptRequest)(nil),       // 36: sandbox.v1.GetTranscriptRequest
+	(*GetTranscriptResponse)(nil),      // 37: sandbox.v1.GetTranscriptResponse
+	(*GetEventsRequest)(nil),           // 38: sandbox.v1.GetEventsRequest
+	(*GetEventsResponse)(nil),          // 39: sandbox.v1.GetEventsResponse
+	(*SnapshotPutRequest)(nil),         // 40: sandbox.v1.SnapshotPutRequest
+	(*SnapshotPutResponse)(nil),        // 41: sandbox.v1.SnapshotPutResponse
+	(*SnapshotGetRequest)(nil),         // 42: sandbox.v1.SnapshotGetRequest
+	(*SnapshotGetResponse)(nil),        // 43: sandbox.v1.SnapshotGetResponse
+	(*SnapshotListRequest)(nil),        // 44: sandbox.v1.SnapshotListRequest
+	(*SnapshotListResponse)(nil),       // 45: sandbox.v1.SnapshotListResponse
+	(*GetProcessesRequest)(nil),        // 46: sandbox.v1.GetProcessesRequest
+	(*ProcessInfo)(nil),                // 47: sandbox.v1.ProcessInfo
+	(*GetProcessesResponse)(nil),       // 48: sandbox.v1.GetProcessesResponse
+	(*CreateTerminalRequest)(nil),      // 49: sandbox.v1.CreateTerminalRequest
+	(*CreateTerminalResponse)(nil),     // 50: sandbox.v1.CreateTerminalResponse
+	(*TerminalStreamRequest)(nil),      // 51: sandbox.v1.TerminalStreamRequest
+	(*TerminalStreamResponse)(nil),     // 52: sandbox.v1.TerminalStreamResponse
+	(*TerminalExit)(nil),               // 53: sandbox.v1.TerminalExit
+	(*TerminalWriteRequest)(nil),       // 54: sandbox.v1.TerminalWriteRequest
+	(*TerminalWriteResponse)(nil),      // 55: sandbox.v1.TerminalWriteResponse
+	(*TerminalResizeRequest)(nil),      // 56: sandbox.v1.TerminalResizeRequest
+	(*TerminalResizeResponse)(nil),     // 57: sandbox.v1.TerminalResizeResponse
+	(*TerminalForegroundRequest)(nil),  // 58: sandbox.v1.TerminalForegroundRequest
+	(*TerminalForegroundResponse)(nil), // 59: sandbox.v1.TerminalForegroundResponse
+	(*TerminalSignalRequest)(nil),      // 60: sandbox.v1.TerminalSignalRequest
+	(*TerminalSignalResponse)(nil),     // 61: sandbox.v1.TerminalSignalResponse
+	(*TerminalDestroyRequest)(nil),     // 62: sandbox.v1.TerminalDestroyRequest
+	(*TerminalDestroyResponse)(nil),    // 63: sandbox.v1.TerminalDestroyResponse
+	nil,                                // 64: sandbox.v1.CreateSessionRequest.EnvEntry
+	nil,                                // 65: sandbox.v1.CreateTerminalRequest.EnvEntry
 }
 var file_sandbox_v1_sandbox_proto_depIdxs = []int32{
-	48, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
-	0,  // 1: sandbox.v1.CreateSessionRequest.secret_refs:type_name -> sandbox.v1.SecretRef
-	4,  // 2: sandbox.v1.ListSessionsResponse.sessions:type_name -> sandbox.v1.GetSessionResponse
-	22, // 3: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
-	46, // 4: sandbox.v1.GetProcessesResponse.processes:type_name -> sandbox.v1.ProcessInfo
-	1,  // 5: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
-	3,  // 6: sandbox.v1.SandboxService.GetSession:input_type -> sandbox.v1.GetSessionRequest
-	5,  // 7: sandbox.v1.SandboxService.ListSessions:input_type -> sandbox.v1.ListSessionsRequest
-	7,  // 8: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
-	9,  // 9: sandbox.v1.SandboxService.PauseSession:input_type -> sandbox.v1.PauseSessionRequest
-	11, // 10: sandbox.v1.SandboxService.ResumeSession:input_type -> sandbox.v1.ResumeSessionRequest
-	13, // 11: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
-	13, // 12: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
-	16, // 13: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
-	18, // 14: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
-	20, // 15: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
-	23, // 16: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
-	25, // 17: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
-	27, // 18: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
-	29, // 19: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
-	31, // 20: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
-	33, // 21: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
-	35, // 22: sandbox.v1.SandboxService.GetTranscript:input_type -> sandbox.v1.GetTranscriptRequest
-	37, // 23: sandbox.v1.SandboxService.GetEvents:input_type -> sandbox.v1.GetEventsRequest
-	39, // 24: sandbox.v1.SandboxService.SnapshotPut:input_type -> sandbox.v1.SnapshotPutRequest
-	41, // 25: sandbox.v1.SandboxService.SnapshotGet:input_type -> sandbox.v1.SnapshotGetRequest
-	43, // 26: sandbox.v1.SandboxService.SnapshotList:input_type -> sandbox.v1.SnapshotListRequest
-	45, // 27: sandbox.v1.SandboxService.GetProcesses:input_type -> sandbox.v1.GetProcessesRequest
-	2,  // 28: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
-	4,  // 29: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
-	6,  // 30: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
-	8,  // 31: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
-	10, // 32: sandbox.v1.SandboxService.PauseSession:output_type -> sandbox.v1.PauseSessionResponse
-	12, // 33: sandbox.v1.SandboxService.ResumeSession:output_type -> sandbox.v1.ResumeSessionResponse
-	14, // 34: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
-	15, // 35: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
-	17, // 36: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
-	19, // 37: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
-	21, // 38: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
-	24, // 39: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
-	26, // 40: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
-	28, // 41: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
-	30, // 42: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
-	32, // 43: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
-	34, // 44: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
-	36, // 45: sandbox.v1.SandboxService.GetTranscript:output_type -> sandbox.v1.GetTranscriptResponse
-	38, // 46: sandbox.v1.SandboxService.GetEvents:output_type -> sandbox.v1.GetEventsResponse
-	40, // 47: sandbox.v1.SandboxService.SnapshotPut:output_type -> sandbox.v1.SnapshotPutResponse
-	42, // 48: sandbox.v1.SandboxService.SnapshotGet:output_type -> sandbox.v1.SnapshotGetResponse
-	44, // 49: sandbox.v1.SandboxService.SnapshotList:output_type -> sandbox.v1.SnapshotListResponse
-	47, // 50: sandbox.v1.SandboxService.GetProcesses:output_type -> sandbox.v1.GetProcessesResponse
-	28, // [28:51] is the sub-list for method output_type
-	5,  // [5:28] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	64, // 0: sandbox.v1.CreateSessionRequest.env:type_name -> sandbox.v1.CreateSessionRequest.EnvEntry
+	1,  // 1: sandbox.v1.CreateSessionRequest.secret_refs:type_name -> sandbox.v1.SecretRef
+	5,  // 2: sandbox.v1.ListSessionsResponse.sessions:type_name -> sandbox.v1.GetSessionResponse
+	23, // 3: sandbox.v1.ListFilesResponse.files:type_name -> sandbox.v1.FileEntry
+	47, // 4: sandbox.v1.GetProcessesResponse.processes:type_name -> sandbox.v1.ProcessInfo
+	65, // 5: sandbox.v1.CreateTerminalRequest.env:type_name -> sandbox.v1.CreateTerminalRequest.EnvEntry
+	53, // 6: sandbox.v1.TerminalStreamResponse.exit:type_name -> sandbox.v1.TerminalExit
+	0,  // 7: sandbox.v1.TerminalSignalRequest.signal:type_name -> sandbox.v1.TerminalSignal
+	2,  // 8: sandbox.v1.SandboxService.CreateSession:input_type -> sandbox.v1.CreateSessionRequest
+	4,  // 9: sandbox.v1.SandboxService.GetSession:input_type -> sandbox.v1.GetSessionRequest
+	6,  // 10: sandbox.v1.SandboxService.ListSessions:input_type -> sandbox.v1.ListSessionsRequest
+	8,  // 11: sandbox.v1.SandboxService.DestroySession:input_type -> sandbox.v1.DestroySessionRequest
+	10, // 12: sandbox.v1.SandboxService.PauseSession:input_type -> sandbox.v1.PauseSessionRequest
+	12, // 13: sandbox.v1.SandboxService.ResumeSession:input_type -> sandbox.v1.ResumeSessionRequest
+	14, // 14: sandbox.v1.SandboxService.Exec:input_type -> sandbox.v1.ExecRequest
+	14, // 15: sandbox.v1.SandboxService.ExecStream:input_type -> sandbox.v1.ExecRequest
+	17, // 16: sandbox.v1.SandboxService.WriteFile:input_type -> sandbox.v1.WriteFileRequest
+	19, // 17: sandbox.v1.SandboxService.ReadFile:input_type -> sandbox.v1.ReadFileRequest
+	21, // 18: sandbox.v1.SandboxService.ListFiles:input_type -> sandbox.v1.ListFilesRequest
+	24, // 19: sandbox.v1.SandboxService.PipInstall:input_type -> sandbox.v1.PipInstallRequest
+	26, // 20: sandbox.v1.SandboxService.RunSubAgent:input_type -> sandbox.v1.RunSubAgentRequest
+	28, // 21: sandbox.v1.SandboxService.ConfirmAction:input_type -> sandbox.v1.ConfirmActionRequest
+	30, // 22: sandbox.v1.SandboxService.ApproveAction:input_type -> sandbox.v1.ApproveActionRequest
+	32, // 23: sandbox.v1.SandboxService.Login:input_type -> sandbox.v1.LoginRequest
+	34, // 24: sandbox.v1.SandboxService.PollRun:input_type -> sandbox.v1.PollRunRequest
+	36, // 25: sandbox.v1.SandboxService.GetTranscript:input_type -> sandbox.v1.GetTranscriptRequest
+	38, // 26: sandbox.v1.SandboxService.GetEvents:input_type -> sandbox.v1.GetEventsRequest
+	40, // 27: sandbox.v1.SandboxService.SnapshotPut:input_type -> sandbox.v1.SnapshotPutRequest
+	42, // 28: sandbox.v1.SandboxService.SnapshotGet:input_type -> sandbox.v1.SnapshotGetRequest
+	44, // 29: sandbox.v1.SandboxService.SnapshotList:input_type -> sandbox.v1.SnapshotListRequest
+	46, // 30: sandbox.v1.SandboxService.GetProcesses:input_type -> sandbox.v1.GetProcessesRequest
+	49, // 31: sandbox.v1.SandboxService.CreateTerminal:input_type -> sandbox.v1.CreateTerminalRequest
+	51, // 32: sandbox.v1.SandboxService.TerminalStream:input_type -> sandbox.v1.TerminalStreamRequest
+	54, // 33: sandbox.v1.SandboxService.TerminalWrite:input_type -> sandbox.v1.TerminalWriteRequest
+	56, // 34: sandbox.v1.SandboxService.TerminalResize:input_type -> sandbox.v1.TerminalResizeRequest
+	58, // 35: sandbox.v1.SandboxService.TerminalForeground:input_type -> sandbox.v1.TerminalForegroundRequest
+	60, // 36: sandbox.v1.SandboxService.TerminalSignal:input_type -> sandbox.v1.TerminalSignalRequest
+	62, // 37: sandbox.v1.SandboxService.TerminalDestroy:input_type -> sandbox.v1.TerminalDestroyRequest
+	3,  // 38: sandbox.v1.SandboxService.CreateSession:output_type -> sandbox.v1.CreateSessionResponse
+	5,  // 39: sandbox.v1.SandboxService.GetSession:output_type -> sandbox.v1.GetSessionResponse
+	7,  // 40: sandbox.v1.SandboxService.ListSessions:output_type -> sandbox.v1.ListSessionsResponse
+	9,  // 41: sandbox.v1.SandboxService.DestroySession:output_type -> sandbox.v1.DestroySessionResponse
+	11, // 42: sandbox.v1.SandboxService.PauseSession:output_type -> sandbox.v1.PauseSessionResponse
+	13, // 43: sandbox.v1.SandboxService.ResumeSession:output_type -> sandbox.v1.ResumeSessionResponse
+	15, // 44: sandbox.v1.SandboxService.Exec:output_type -> sandbox.v1.ExecResponse
+	16, // 45: sandbox.v1.SandboxService.ExecStream:output_type -> sandbox.v1.ExecStreamResponse
+	18, // 46: sandbox.v1.SandboxService.WriteFile:output_type -> sandbox.v1.WriteFileResponse
+	20, // 47: sandbox.v1.SandboxService.ReadFile:output_type -> sandbox.v1.ReadFileResponse
+	22, // 48: sandbox.v1.SandboxService.ListFiles:output_type -> sandbox.v1.ListFilesResponse
+	25, // 49: sandbox.v1.SandboxService.PipInstall:output_type -> sandbox.v1.PipInstallResponse
+	27, // 50: sandbox.v1.SandboxService.RunSubAgent:output_type -> sandbox.v1.RunSubAgentResponse
+	29, // 51: sandbox.v1.SandboxService.ConfirmAction:output_type -> sandbox.v1.ConfirmActionResponse
+	31, // 52: sandbox.v1.SandboxService.ApproveAction:output_type -> sandbox.v1.ApproveActionResponse
+	33, // 53: sandbox.v1.SandboxService.Login:output_type -> sandbox.v1.LoginResponse
+	35, // 54: sandbox.v1.SandboxService.PollRun:output_type -> sandbox.v1.PollRunResponse
+	37, // 55: sandbox.v1.SandboxService.GetTranscript:output_type -> sandbox.v1.GetTranscriptResponse
+	39, // 56: sandbox.v1.SandboxService.GetEvents:output_type -> sandbox.v1.GetEventsResponse
+	41, // 57: sandbox.v1.SandboxService.SnapshotPut:output_type -> sandbox.v1.SnapshotPutResponse
+	43, // 58: sandbox.v1.SandboxService.SnapshotGet:output_type -> sandbox.v1.SnapshotGetResponse
+	45, // 59: sandbox.v1.SandboxService.SnapshotList:output_type -> sandbox.v1.SnapshotListResponse
+	48, // 60: sandbox.v1.SandboxService.GetProcesses:output_type -> sandbox.v1.GetProcessesResponse
+	50, // 61: sandbox.v1.SandboxService.CreateTerminal:output_type -> sandbox.v1.CreateTerminalResponse
+	52, // 62: sandbox.v1.SandboxService.TerminalStream:output_type -> sandbox.v1.TerminalStreamResponse
+	55, // 63: sandbox.v1.SandboxService.TerminalWrite:output_type -> sandbox.v1.TerminalWriteResponse
+	57, // 64: sandbox.v1.SandboxService.TerminalResize:output_type -> sandbox.v1.TerminalResizeResponse
+	59, // 65: sandbox.v1.SandboxService.TerminalForeground:output_type -> sandbox.v1.TerminalForegroundResponse
+	61, // 66: sandbox.v1.SandboxService.TerminalSignal:output_type -> sandbox.v1.TerminalSignalResponse
+	63, // 67: sandbox.v1.SandboxService.TerminalDestroy:output_type -> sandbox.v1.TerminalDestroyResponse
+	38, // [38:68] is the sub-list for method output_type
+	8,  // [8:38] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_sandbox_v1_sandbox_proto_init() }
@@ -3056,18 +4021,23 @@ func file_sandbox_v1_sandbox_proto_init() {
 	if File_sandbox_v1_sandbox_proto != nil {
 		return
 	}
+	file_sandbox_v1_sandbox_proto_msgTypes[51].OneofWrappers = []any{
+		(*TerminalStreamResponse_Data)(nil),
+		(*TerminalStreamResponse_Exit)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_sandbox_v1_sandbox_proto_rawDesc), len(file_sandbox_v1_sandbox_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   49,
+			NumEnums:      1,
+			NumMessages:   65,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_sandbox_v1_sandbox_proto_goTypes,
 		DependencyIndexes: file_sandbox_v1_sandbox_proto_depIdxs,
+		EnumInfos:         file_sandbox_v1_sandbox_proto_enumTypes,
 		MessageInfos:      file_sandbox_v1_sandbox_proto_msgTypes,
 	}.Build()
 	File_sandbox_v1_sandbox_proto = out.File

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox_grpc.pb.go
@@ -19,29 +19,36 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SandboxService_CreateSession_FullMethodName  = "/sandbox.v1.SandboxService/CreateSession"
-	SandboxService_GetSession_FullMethodName     = "/sandbox.v1.SandboxService/GetSession"
-	SandboxService_ListSessions_FullMethodName   = "/sandbox.v1.SandboxService/ListSessions"
-	SandboxService_DestroySession_FullMethodName = "/sandbox.v1.SandboxService/DestroySession"
-	SandboxService_PauseSession_FullMethodName   = "/sandbox.v1.SandboxService/PauseSession"
-	SandboxService_ResumeSession_FullMethodName  = "/sandbox.v1.SandboxService/ResumeSession"
-	SandboxService_Exec_FullMethodName           = "/sandbox.v1.SandboxService/Exec"
-	SandboxService_ExecStream_FullMethodName     = "/sandbox.v1.SandboxService/ExecStream"
-	SandboxService_WriteFile_FullMethodName      = "/sandbox.v1.SandboxService/WriteFile"
-	SandboxService_ReadFile_FullMethodName       = "/sandbox.v1.SandboxService/ReadFile"
-	SandboxService_ListFiles_FullMethodName      = "/sandbox.v1.SandboxService/ListFiles"
-	SandboxService_PipInstall_FullMethodName     = "/sandbox.v1.SandboxService/PipInstall"
-	SandboxService_RunSubAgent_FullMethodName    = "/sandbox.v1.SandboxService/RunSubAgent"
-	SandboxService_ConfirmAction_FullMethodName  = "/sandbox.v1.SandboxService/ConfirmAction"
-	SandboxService_ApproveAction_FullMethodName  = "/sandbox.v1.SandboxService/ApproveAction"
-	SandboxService_Login_FullMethodName          = "/sandbox.v1.SandboxService/Login"
-	SandboxService_PollRun_FullMethodName        = "/sandbox.v1.SandboxService/PollRun"
-	SandboxService_GetTranscript_FullMethodName  = "/sandbox.v1.SandboxService/GetTranscript"
-	SandboxService_GetEvents_FullMethodName      = "/sandbox.v1.SandboxService/GetEvents"
-	SandboxService_SnapshotPut_FullMethodName    = "/sandbox.v1.SandboxService/SnapshotPut"
-	SandboxService_SnapshotGet_FullMethodName    = "/sandbox.v1.SandboxService/SnapshotGet"
-	SandboxService_SnapshotList_FullMethodName   = "/sandbox.v1.SandboxService/SnapshotList"
-	SandboxService_GetProcesses_FullMethodName   = "/sandbox.v1.SandboxService/GetProcesses"
+	SandboxService_CreateSession_FullMethodName      = "/sandbox.v1.SandboxService/CreateSession"
+	SandboxService_GetSession_FullMethodName         = "/sandbox.v1.SandboxService/GetSession"
+	SandboxService_ListSessions_FullMethodName       = "/sandbox.v1.SandboxService/ListSessions"
+	SandboxService_DestroySession_FullMethodName     = "/sandbox.v1.SandboxService/DestroySession"
+	SandboxService_PauseSession_FullMethodName       = "/sandbox.v1.SandboxService/PauseSession"
+	SandboxService_ResumeSession_FullMethodName      = "/sandbox.v1.SandboxService/ResumeSession"
+	SandboxService_Exec_FullMethodName               = "/sandbox.v1.SandboxService/Exec"
+	SandboxService_ExecStream_FullMethodName         = "/sandbox.v1.SandboxService/ExecStream"
+	SandboxService_WriteFile_FullMethodName          = "/sandbox.v1.SandboxService/WriteFile"
+	SandboxService_ReadFile_FullMethodName           = "/sandbox.v1.SandboxService/ReadFile"
+	SandboxService_ListFiles_FullMethodName          = "/sandbox.v1.SandboxService/ListFiles"
+	SandboxService_PipInstall_FullMethodName         = "/sandbox.v1.SandboxService/PipInstall"
+	SandboxService_RunSubAgent_FullMethodName        = "/sandbox.v1.SandboxService/RunSubAgent"
+	SandboxService_ConfirmAction_FullMethodName      = "/sandbox.v1.SandboxService/ConfirmAction"
+	SandboxService_ApproveAction_FullMethodName      = "/sandbox.v1.SandboxService/ApproveAction"
+	SandboxService_Login_FullMethodName              = "/sandbox.v1.SandboxService/Login"
+	SandboxService_PollRun_FullMethodName            = "/sandbox.v1.SandboxService/PollRun"
+	SandboxService_GetTranscript_FullMethodName      = "/sandbox.v1.SandboxService/GetTranscript"
+	SandboxService_GetEvents_FullMethodName          = "/sandbox.v1.SandboxService/GetEvents"
+	SandboxService_SnapshotPut_FullMethodName        = "/sandbox.v1.SandboxService/SnapshotPut"
+	SandboxService_SnapshotGet_FullMethodName        = "/sandbox.v1.SandboxService/SnapshotGet"
+	SandboxService_SnapshotList_FullMethodName       = "/sandbox.v1.SandboxService/SnapshotList"
+	SandboxService_GetProcesses_FullMethodName       = "/sandbox.v1.SandboxService/GetProcesses"
+	SandboxService_CreateTerminal_FullMethodName     = "/sandbox.v1.SandboxService/CreateTerminal"
+	SandboxService_TerminalStream_FullMethodName     = "/sandbox.v1.SandboxService/TerminalStream"
+	SandboxService_TerminalWrite_FullMethodName      = "/sandbox.v1.SandboxService/TerminalWrite"
+	SandboxService_TerminalResize_FullMethodName     = "/sandbox.v1.SandboxService/TerminalResize"
+	SandboxService_TerminalForeground_FullMethodName = "/sandbox.v1.SandboxService/TerminalForeground"
+	SandboxService_TerminalSignal_FullMethodName     = "/sandbox.v1.SandboxService/TerminalSignal"
+	SandboxService_TerminalDestroy_FullMethodName    = "/sandbox.v1.SandboxService/TerminalDestroy"
 )
 
 // SandboxServiceClient is the client API for SandboxService service.
@@ -85,6 +92,18 @@ type SandboxServiceClient interface {
 	SnapshotList(ctx context.Context, in *SnapshotListRequest, opts ...grpc.CallOption) (*SnapshotListResponse, error)
 	// GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
 	GetProcesses(ctx context.Context, in *GetProcessesRequest, opts ...grpc.CallOption) (*GetProcessesResponse, error)
+	// ── PTY terminal primitive (KIP-19) ───────────────────────────────────────
+	// CreateTerminal allocates a PTY and starts argv as a controlling-terminal
+	// session leader (argv is NOT shell-interpreted).
+	CreateTerminal(ctx context.Context, in *CreateTerminalRequest, opts ...grpc.CallOption) (*CreateTerminalResponse, error)
+	// TerminalStream streams terminal output bytes; the final frame carries
+	// TerminalExit (exit code / signal) when the top-level process closes.
+	TerminalStream(ctx context.Context, in *TerminalStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[TerminalStreamResponse], error)
+	TerminalWrite(ctx context.Context, in *TerminalWriteRequest, opts ...grpc.CallOption) (*TerminalWriteResponse, error)
+	TerminalResize(ctx context.Context, in *TerminalResizeRequest, opts ...grpc.CallOption) (*TerminalResizeResponse, error)
+	TerminalForeground(ctx context.Context, in *TerminalForegroundRequest, opts ...grpc.CallOption) (*TerminalForegroundResponse, error)
+	TerminalSignal(ctx context.Context, in *TerminalSignalRequest, opts ...grpc.CallOption) (*TerminalSignalResponse, error)
+	TerminalDestroy(ctx context.Context, in *TerminalDestroyRequest, opts ...grpc.CallOption) (*TerminalDestroyResponse, error)
 }
 
 type sandboxServiceClient struct {
@@ -334,6 +353,85 @@ func (c *sandboxServiceClient) GetProcesses(ctx context.Context, in *GetProcesse
 	return out, nil
 }
 
+func (c *sandboxServiceClient) CreateTerminal(ctx context.Context, in *CreateTerminalRequest, opts ...grpc.CallOption) (*CreateTerminalResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateTerminalResponse)
+	err := c.cc.Invoke(ctx, SandboxService_CreateTerminal_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) TerminalStream(ctx context.Context, in *TerminalStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[TerminalStreamResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &SandboxService_ServiceDesc.Streams[1], SandboxService_TerminalStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[TerminalStreamRequest, TerminalStreamResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type SandboxService_TerminalStreamClient = grpc.ServerStreamingClient[TerminalStreamResponse]
+
+func (c *sandboxServiceClient) TerminalWrite(ctx context.Context, in *TerminalWriteRequest, opts ...grpc.CallOption) (*TerminalWriteResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminalWriteResponse)
+	err := c.cc.Invoke(ctx, SandboxService_TerminalWrite_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) TerminalResize(ctx context.Context, in *TerminalResizeRequest, opts ...grpc.CallOption) (*TerminalResizeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminalResizeResponse)
+	err := c.cc.Invoke(ctx, SandboxService_TerminalResize_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) TerminalForeground(ctx context.Context, in *TerminalForegroundRequest, opts ...grpc.CallOption) (*TerminalForegroundResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminalForegroundResponse)
+	err := c.cc.Invoke(ctx, SandboxService_TerminalForeground_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) TerminalSignal(ctx context.Context, in *TerminalSignalRequest, opts ...grpc.CallOption) (*TerminalSignalResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminalSignalResponse)
+	err := c.cc.Invoke(ctx, SandboxService_TerminalSignal_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *sandboxServiceClient) TerminalDestroy(ctx context.Context, in *TerminalDestroyRequest, opts ...grpc.CallOption) (*TerminalDestroyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TerminalDestroyResponse)
+	err := c.cc.Invoke(ctx, SandboxService_TerminalDestroy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SandboxServiceServer is the server API for SandboxService service.
 // All implementations must embed UnimplementedSandboxServiceServer
 // for forward compatibility.
@@ -375,6 +473,18 @@ type SandboxServiceServer interface {
 	SnapshotList(context.Context, *SnapshotListRequest) (*SnapshotListResponse, error)
 	// GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
 	GetProcesses(context.Context, *GetProcessesRequest) (*GetProcessesResponse, error)
+	// ── PTY terminal primitive (KIP-19) ───────────────────────────────────────
+	// CreateTerminal allocates a PTY and starts argv as a controlling-terminal
+	// session leader (argv is NOT shell-interpreted).
+	CreateTerminal(context.Context, *CreateTerminalRequest) (*CreateTerminalResponse, error)
+	// TerminalStream streams terminal output bytes; the final frame carries
+	// TerminalExit (exit code / signal) when the top-level process closes.
+	TerminalStream(*TerminalStreamRequest, grpc.ServerStreamingServer[TerminalStreamResponse]) error
+	TerminalWrite(context.Context, *TerminalWriteRequest) (*TerminalWriteResponse, error)
+	TerminalResize(context.Context, *TerminalResizeRequest) (*TerminalResizeResponse, error)
+	TerminalForeground(context.Context, *TerminalForegroundRequest) (*TerminalForegroundResponse, error)
+	TerminalSignal(context.Context, *TerminalSignalRequest) (*TerminalSignalResponse, error)
+	TerminalDestroy(context.Context, *TerminalDestroyRequest) (*TerminalDestroyResponse, error)
 	mustEmbedUnimplementedSandboxServiceServer()
 }
 
@@ -453,6 +563,27 @@ func (UnimplementedSandboxServiceServer) SnapshotList(context.Context, *Snapshot
 }
 func (UnimplementedSandboxServiceServer) GetProcesses(context.Context, *GetProcessesRequest) (*GetProcessesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetProcesses not implemented")
+}
+func (UnimplementedSandboxServiceServer) CreateTerminal(context.Context, *CreateTerminalRequest) (*CreateTerminalResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateTerminal not implemented")
+}
+func (UnimplementedSandboxServiceServer) TerminalStream(*TerminalStreamRequest, grpc.ServerStreamingServer[TerminalStreamResponse]) error {
+	return status.Error(codes.Unimplemented, "method TerminalStream not implemented")
+}
+func (UnimplementedSandboxServiceServer) TerminalWrite(context.Context, *TerminalWriteRequest) (*TerminalWriteResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TerminalWrite not implemented")
+}
+func (UnimplementedSandboxServiceServer) TerminalResize(context.Context, *TerminalResizeRequest) (*TerminalResizeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TerminalResize not implemented")
+}
+func (UnimplementedSandboxServiceServer) TerminalForeground(context.Context, *TerminalForegroundRequest) (*TerminalForegroundResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TerminalForeground not implemented")
+}
+func (UnimplementedSandboxServiceServer) TerminalSignal(context.Context, *TerminalSignalRequest) (*TerminalSignalResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TerminalSignal not implemented")
+}
+func (UnimplementedSandboxServiceServer) TerminalDestroy(context.Context, *TerminalDestroyRequest) (*TerminalDestroyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TerminalDestroy not implemented")
 }
 func (UnimplementedSandboxServiceServer) mustEmbedUnimplementedSandboxServiceServer() {}
 func (UnimplementedSandboxServiceServer) testEmbeddedByValue()                        {}
@@ -882,6 +1013,125 @@ func _SandboxService_GetProcesses_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SandboxService_CreateTerminal_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateTerminalRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).CreateTerminal(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_CreateTerminal_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).CreateTerminal(ctx, req.(*CreateTerminalRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_TerminalStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(TerminalStreamRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(SandboxServiceServer).TerminalStream(m, &grpc.GenericServerStream[TerminalStreamRequest, TerminalStreamResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type SandboxService_TerminalStreamServer = grpc.ServerStreamingServer[TerminalStreamResponse]
+
+func _SandboxService_TerminalWrite_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminalWriteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).TerminalWrite(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_TerminalWrite_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).TerminalWrite(ctx, req.(*TerminalWriteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_TerminalResize_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminalResizeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).TerminalResize(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_TerminalResize_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).TerminalResize(ctx, req.(*TerminalResizeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_TerminalForeground_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminalForegroundRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).TerminalForeground(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_TerminalForeground_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).TerminalForeground(ctx, req.(*TerminalForegroundRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_TerminalSignal_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminalSignalRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).TerminalSignal(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_TerminalSignal_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).TerminalSignal(ctx, req.(*TerminalSignalRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SandboxService_TerminalDestroy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TerminalDestroyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxServiceServer).TerminalDestroy(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxService_TerminalDestroy_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxServiceServer).TerminalDestroy(ctx, req.(*TerminalDestroyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SandboxService_ServiceDesc is the grpc.ServiceDesc for SandboxService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -977,11 +1227,40 @@ var SandboxService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "GetProcesses",
 			Handler:    _SandboxService_GetProcesses_Handler,
 		},
+		{
+			MethodName: "CreateTerminal",
+			Handler:    _SandboxService_CreateTerminal_Handler,
+		},
+		{
+			MethodName: "TerminalWrite",
+			Handler:    _SandboxService_TerminalWrite_Handler,
+		},
+		{
+			MethodName: "TerminalResize",
+			Handler:    _SandboxService_TerminalResize_Handler,
+		},
+		{
+			MethodName: "TerminalForeground",
+			Handler:    _SandboxService_TerminalForeground_Handler,
+		},
+		{
+			MethodName: "TerminalSignal",
+			Handler:    _SandboxService_TerminalSignal_Handler,
+		},
+		{
+			MethodName: "TerminalDestroy",
+			Handler:    _SandboxService_TerminalDestroy_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
 			StreamName:    "ExecStream",
 			Handler:       _SandboxService_ExecStream_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "TerminalStream",
+			Handler:       _SandboxService_TerminalStream_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -142,6 +142,10 @@ type Server struct {
 	localAuth     bool
 	rateLimiter   *ratelimit.Limiter
 	layerStore    *sandboxlayer.Store
+	// terminal registry (KIP-19): branded terminal_id → sandboxd terminal.
+	terminalsMu sync.RWMutex
+	terminals   map[string]terminalEntry
+	terminalSeq uint64
 }
 
 func NewServer(cfg ServerConfig) *Server {
@@ -159,6 +163,7 @@ func NewServer(cfg ServerConfig) *Server {
 		serverKeyFile:  cfg.ServerKeyFile,
 		localAuth:      cfg.LocalAuth,
 		rateLimiter:    ratelimit.NewLimiter(ratelimit.DefaultRateConfig()),
+		terminals:      make(map[string]terminalEntry),
 	}
 	s.orch = NewOrchestrator(cfg.K8s, cfg.Dyn)
 	if cfg.FQDNEnabled {

--- a/pkg/sandboxmatrix/grpc/terminal.go
+++ b/pkg/sandboxmatrix/grpc/terminal.go
@@ -1,0 +1,290 @@
+package grpc
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// maxTerminals bounds the gateway-side terminal registry so a runaway client
+// cannot grow it without bound. Entries are removed on TerminalDestroy and on
+// lazy cleanup when their session no longer resolves.
+const maxTerminals = 10000
+
+// terminalEntry maps a gateway-owned branded terminal_id to the sandboxd
+// terminal it proxies. The branded id is opaque; the sandboxd id is a
+// pod-local numeric handle.
+type terminalEntry struct {
+	sessionID  string
+	sandboxdID uint32
+}
+
+// terminalSignalName maps the proto enum to the signal names sandboxd accepts.
+func terminalSignalName(sig pb.TerminalSignal) (string, error) {
+	switch sig {
+	case pb.TerminalSignal_TERMINAL_SIGNAL_INT:
+		return "SIGINT", nil
+	case pb.TerminalSignal_TERMINAL_SIGNAL_TERM:
+		return "SIGTERM", nil
+	case pb.TerminalSignal_TERMINAL_SIGNAL_KILL:
+		return "SIGKILL", nil
+	case pb.TerminalSignal_TERMINAL_SIGNAL_TSTP:
+		return "SIGTSTP", nil
+	case pb.TerminalSignal_TERMINAL_SIGNAL_HUP:
+		return "SIGHUP", nil
+	default:
+		return "", status.Errorf(codes.InvalidArgument, "unsupported terminal signal %v", sig)
+	}
+}
+
+// resolveTerminal returns the pod IP and sandboxd terminal id for a branded
+// terminal_id. A terminal whose session no longer resolves is dropped lazily.
+func (s *Server) resolveTerminal(ctx context.Context, terminalID string) (string, uint32, error) {
+	s.terminalsMu.RLock()
+	e, ok := s.terminals[terminalID]
+	s.terminalsMu.RUnlock()
+	if !ok {
+		return "", 0, status.Error(codes.NotFound, "terminal not found")
+	}
+	podIP, err := s.getPodIP(ctx, e.sessionID)
+	if err != nil {
+		s.terminalsMu.Lock()
+		delete(s.terminals, terminalID)
+		s.terminalsMu.Unlock()
+		return "", 0, err
+	}
+	return podIP, e.sandboxdID, nil
+}
+
+func (s *Server) dropTerminal(terminalID string) {
+	s.terminalsMu.Lock()
+	delete(s.terminals, terminalID)
+	s.terminalsMu.Unlock()
+}
+
+// CreateTerminal allocates a sandbox PTY and starts argv as a controlling-
+// terminal session leader, then records a branded terminal_id for routing.
+func (s *Server) CreateTerminal(ctx context.Context, req *pb.CreateTerminalRequest) (*pb.CreateTerminalResponse, error) {
+	if req.SessionId == "" {
+		return nil, status.Error(codes.InvalidArgument, "session_id required")
+	}
+	if len(req.Argv) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "argv must be non-empty")
+	}
+	podIP, err := s.getPodIP(ctx, req.SessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := req.Rows
+	cols := req.Cols
+	if rows <= 0 {
+		rows = 24
+	}
+	if cols <= 0 {
+		cols = 80
+	}
+	body := map[string]any{
+		"argv":    req.Argv,
+		"workdir": req.Workdir,
+		"env":     req.Env,
+		"rows":    rows,
+		"cols":    cols,
+	}
+	resp, err := sandboxdPost(ctx, podIP, "/pty/create", body)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd pty create: %v", err)
+	}
+	defer resp.Body.Close()
+	var created struct {
+		TerminalID uint32 `json:"terminal_id"`
+		PID        int32  `json:"pid"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return nil, status.Errorf(codes.Internal, "sandboxd pty create decode: %v", err)
+	}
+
+	s.terminalsMu.Lock()
+	if len(s.terminals) >= maxTerminals {
+		s.terminalsMu.Unlock()
+		return nil, status.Error(codes.ResourceExhausted, "terminal registry full")
+	}
+	s.terminalSeq++
+	terminalID := fmt.Sprintf("term-%d", s.terminalSeq)
+	s.terminals[terminalID] = terminalEntry{sessionID: req.SessionId, sandboxdID: created.TerminalID}
+	s.terminalsMu.Unlock()
+
+	return &pb.CreateTerminalResponse{TerminalId: terminalID, Pid: created.PID}, nil
+}
+
+// TerminalWrite delivers raw bytes to the terminal input (no implicit newline).
+func (s *Server) TerminalWrite(ctx context.Context, req *pb.TerminalWriteRequest) (*pb.TerminalWriteResponse, error) {
+	podIP, sandboxdID, err := s.resolveTerminal(ctx, req.TerminalId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sandboxdPost(ctx, podIP, "/pty/input", map[string]any{
+		"terminal_id": sandboxdID,
+		"data":        string(req.Data),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd pty input: %v", err)
+	}
+	defer resp.Body.Close()
+	return &pb.TerminalWriteResponse{Ok: resp.StatusCode == http.StatusOK}, nil
+}
+
+// TerminalResize applies a new window size to the terminal.
+func (s *Server) TerminalResize(ctx context.Context, req *pb.TerminalResizeRequest) (*pb.TerminalResizeResponse, error) {
+	podIP, sandboxdID, err := s.resolveTerminal(ctx, req.TerminalId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sandboxdPost(ctx, podIP, "/pty/resize", map[string]any{
+		"terminal_id": sandboxdID,
+		"rows":        req.Rows,
+		"cols":        req.Cols,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd pty resize: %v", err)
+	}
+	defer resp.Body.Close()
+	return &pb.TerminalResizeResponse{Ok: resp.StatusCode == http.StatusOK}, nil
+}
+
+// TerminalForeground reports the current foreground process group.
+func (s *Server) TerminalForeground(ctx context.Context, req *pb.TerminalForegroundRequest) (*pb.TerminalForegroundResponse, error) {
+	podIP, sandboxdID, err := s.resolveTerminal(ctx, req.TerminalId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sandboxdGet(ctx, podIP, fmt.Sprintf("/pty/foreground?terminal_id=%d", sandboxdID))
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd pty foreground: %v", err)
+	}
+	defer resp.Body.Close()
+	var fg struct {
+		ProcessGroupID int32 `json:"process_group_id"`
+		InputWaiting   bool  `json:"input_waiting"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&fg); err != nil {
+		return nil, status.Errorf(codes.Internal, "sandboxd pty foreground decode: %v", err)
+	}
+	return &pb.TerminalForegroundResponse{ProcessGroupId: fg.ProcessGroupID, InputWaiting: fg.InputWaiting}, nil
+}
+
+// TerminalSignal delivers a signal to the terminal's foreground process group.
+func (s *Server) TerminalSignal(ctx context.Context, req *pb.TerminalSignalRequest) (*pb.TerminalSignalResponse, error) {
+	name, err := terminalSignalName(req.Signal)
+	if err != nil {
+		return nil, err
+	}
+	podIP, sandboxdID, err := s.resolveTerminal(ctx, req.TerminalId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sandboxdPost(ctx, podIP, "/pty/signal", map[string]any{
+		"terminal_id": sandboxdID,
+		"signal":      name,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd pty signal: %v", err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		ProcessGroupID int32 `json:"process_group_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, status.Errorf(codes.Internal, "sandboxd pty signal decode: %v", err)
+	}
+	return &pb.TerminalSignalResponse{ProcessGroupId: out.ProcessGroupID}, nil
+}
+
+// TerminalDestroy terminates the terminal session tree and drops its registry entry.
+func (s *Server) TerminalDestroy(ctx context.Context, req *pb.TerminalDestroyRequest) (*pb.TerminalDestroyResponse, error) {
+	podIP, sandboxdID, err := s.resolveTerminal(ctx, req.TerminalId)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sandboxdPost(ctx, podIP, "/pty/destroy", map[string]any{
+		"terminal_id": sandboxdID,
+		"grace_ms":    req.GraceMs,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "sandboxd pty destroy: %v", err)
+	}
+	defer resp.Body.Close()
+	s.dropTerminal(req.TerminalId)
+	return &pb.TerminalDestroyResponse{Ok: resp.StatusCode == http.StatusOK}, nil
+}
+
+// TerminalStream streams terminal output as data frames and closes with one
+// exit frame. sandboxd emits SSE: a pid frame, base64 data frames, then a JSON
+// exit frame.
+func (s *Server) TerminalStream(req *pb.TerminalStreamRequest, stream pb.SandboxService_TerminalStreamServer) error {
+	podIP, sandboxdID, err := s.resolveTerminal(stream.Context(), req.TerminalId)
+	if err != nil {
+		return err
+	}
+	resp, err := sandboxdGet(stream.Context(), podIP, fmt.Sprintf("/pty/stream?terminal_id=%d", sandboxdID))
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "sandboxd pty stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 256*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+
+		if strings.HasPrefix(payload, "{") {
+			var frame struct {
+				PID       *int32 `json:"pid"`
+				Exit      *int32 `json:"exit"`
+				Signal    string `json:"signal"`
+				Truncated bool   `json:"truncated"`
+			}
+			if err := json.Unmarshal([]byte(payload), &frame); err != nil {
+				return status.Errorf(codes.Internal, "pty stream frame decode: %v", err)
+			}
+			if frame.Exit != nil {
+				if err := stream.Send(&pb.TerminalStreamResponse{
+					Frame: &pb.TerminalStreamResponse_Exit{
+						Exit: &pb.TerminalExit{ExitCode: *frame.Exit, Signal: frame.Signal},
+					},
+				}); err != nil {
+					return err
+				}
+				return nil
+			}
+			// pid frame: ignore
+			continue
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			return status.Errorf(codes.Internal, "pty stream base64 decode: %v", err)
+		}
+		if err := stream.Send(&pb.TerminalStreamResponse{
+			Frame: &pb.TerminalStreamResponse_Data{Data: decoded},
+		}); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return status.Errorf(codes.Internal, "pty stream read: %v", err)
+	}
+	return nil
+}

--- a/pkg/sandboxmatrix/grpc/terminal.go
+++ b/pkg/sandboxmatrix/grpc/terminal.go
@@ -249,42 +249,60 @@ func (s *Server) TerminalStream(req *pb.TerminalStreamRequest, stream pb.Sandbox
 		}
 		payload := strings.TrimPrefix(line, "data: ")
 
-		if strings.HasPrefix(payload, "{") {
-			var frame struct {
-				PID       *int32 `json:"pid"`
-				Exit      *int32 `json:"exit"`
-				Signal    string `json:"signal"`
-				Truncated bool   `json:"truncated"`
-			}
-			if err := json.Unmarshal([]byte(payload), &frame); err != nil {
-				return status.Errorf(codes.Internal, "pty stream frame decode: %v", err)
-			}
-			if frame.Exit != nil {
-				if err := stream.Send(&pb.TerminalStreamResponse{
-					Frame: &pb.TerminalStreamResponse_Exit{
-						Exit: &pb.TerminalExit{ExitCode: *frame.Exit, Signal: frame.Signal},
-					},
-				}); err != nil {
-					return err
-				}
-				return nil
-			}
-			// pid frame: ignore
-			continue
-		}
-
-		decoded, err := base64.StdEncoding.DecodeString(payload)
+		frame, err := parsePTYStreamFrame(payload)
 		if err != nil {
-			return status.Errorf(codes.Internal, "pty stream base64 decode: %v", err)
+			return status.Errorf(codes.Internal, "pty stream frame: %v", err)
 		}
-		if err := stream.Send(&pb.TerminalStreamResponse{
-			Frame: &pb.TerminalStreamResponse_Data{Data: decoded},
-		}); err != nil {
-			return err
+		if frame.exit != nil {
+			if err := stream.Send(&pb.TerminalStreamResponse{
+				Frame: &pb.TerminalStreamResponse_Exit{Exit: frame.exit},
+			}); err != nil {
+				return err
+			}
+			return nil
 		}
+		if frame.data != nil {
+			if err := stream.Send(&pb.TerminalStreamResponse{
+				Frame: &pb.TerminalStreamResponse_Data{Data: frame.data},
+			}); err != nil {
+				return err
+			}
+		}
+		// pid frame (both fields nil): nothing to forward
 	}
 	if err := scanner.Err(); err != nil {
 		return status.Errorf(codes.Internal, "pty stream read: %v", err)
 	}
 	return nil
+}
+
+// ptyStreamFrame is one parsed /pty/stream SSE data payload.
+type ptyStreamFrame struct {
+	data []byte           // base64-decoded output (nil for control frames)
+	exit *pb.TerminalExit // terminal exit frame (nil until the final frame)
+}
+
+// parsePTYStreamFrame decodes one sandboxd SSE data payload into a stream
+// frame. JSON payloads carry control facts (pid, then exit); any other payload
+// is a base64-encoded output chunk.
+func parsePTYStreamFrame(payload string) (ptyStreamFrame, error) {
+	if strings.HasPrefix(payload, "{") {
+		var frame struct {
+			PID    *int32 `json:"pid"`
+			Exit   *int32 `json:"exit"`
+			Signal string `json:"signal"`
+		}
+		if err := json.Unmarshal([]byte(payload), &frame); err != nil {
+			return ptyStreamFrame{}, fmt.Errorf("frame decode: %w", err)
+		}
+		if frame.Exit != nil {
+			return ptyStreamFrame{exit: &pb.TerminalExit{ExitCode: *frame.Exit, Signal: frame.Signal}}, nil
+		}
+		return ptyStreamFrame{}, nil // pid frame
+	}
+	decoded, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return ptyStreamFrame{}, fmt.Errorf("base64 decode: %w", err)
+	}
+	return ptyStreamFrame{data: decoded}, nil
 }

--- a/pkg/sandboxmatrix/grpc/terminal_test.go
+++ b/pkg/sandboxmatrix/grpc/terminal_test.go
@@ -1,0 +1,85 @@
+package grpc
+
+import (
+	"encoding/base64"
+	"testing"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+)
+
+func TestTerminalSignalName(t *testing.T) {
+	cases := []struct {
+		sig  pb.TerminalSignal
+		want string
+	}{
+		{pb.TerminalSignal_TERMINAL_SIGNAL_INT, "SIGINT"},
+		{pb.TerminalSignal_TERMINAL_SIGNAL_TERM, "SIGTERM"},
+		{pb.TerminalSignal_TERMINAL_SIGNAL_KILL, "SIGKILL"},
+		{pb.TerminalSignal_TERMINAL_SIGNAL_TSTP, "SIGTSTP"},
+		{pb.TerminalSignal_TERMINAL_SIGNAL_HUP, "SIGHUP"},
+	}
+	for _, c := range cases {
+		got, err := terminalSignalName(c.sig)
+		if err != nil {
+			t.Fatalf("terminalSignalName(%v): unexpected error %v", c.sig, err)
+		}
+		if got != c.want {
+			t.Errorf("terminalSignalName(%v) = %q, want %q", c.sig, got, c.want)
+		}
+	}
+	if _, err := terminalSignalName(pb.TerminalSignal_TERMINAL_SIGNAL_UNSPECIFIED); err == nil {
+		t.Error("terminalSignalName(UNSPECIFIED) should error")
+	}
+}
+
+func TestParsePTYStreamFrame(t *testing.T) {
+	// pid frame: no data, no exit
+	f, err := parsePTYStreamFrame(`{"pid":123}`)
+	if err != nil {
+		t.Fatalf("pid frame: %v", err)
+	}
+	if f.data != nil || f.exit != nil {
+		t.Errorf("pid frame should carry no data/exit, got %+v", f)
+	}
+
+	// data frame: base64-decoded output
+	payload := base64.StdEncoding.EncodeToString([]byte("hello\nworld"))
+	f, err = parsePTYStreamFrame(payload)
+	if err != nil {
+		t.Fatalf("data frame: %v", err)
+	}
+	if string(f.data) != "hello\nworld" {
+		t.Errorf("data frame decoded to %q", f.data)
+	}
+	if f.exit != nil {
+		t.Errorf("data frame should carry no exit, got %+v", f.exit)
+	}
+
+	// exit frame: terminal exit facts
+	f, err = parsePTYStreamFrame(`{"exit":42,"signal":"SIGTERM"}`)
+	if err != nil {
+		t.Fatalf("exit frame: %v", err)
+	}
+	if f.exit == nil || f.exit.ExitCode != 42 || f.exit.Signal != "SIGTERM" {
+		t.Errorf("exit frame = %+v", f.exit)
+	}
+	if f.data != nil {
+		t.Errorf("exit frame should carry no data, got %q", f.data)
+	}
+
+	// invalid base64
+	if _, err := parsePTYStreamFrame("not-base64!!"); err == nil {
+		t.Error("invalid base64 should error")
+	}
+
+	// invalid JSON control frame
+	if _, err := parsePTYStreamFrame(`{"exit":`); err == nil {
+		t.Error("malformed JSON control frame should error")
+	}
+}
+
+func TestTerminalStreamResponseWrapHelpers(t *testing.T) {
+	// Guard the oneof wrapper types we rely on remain constructible.
+	_ = &pb.TerminalStreamResponse{Frame: &pb.TerminalStreamResponse_Data{Data: []byte("x")}}
+	_ = &pb.TerminalStreamResponse{Frame: &pb.TerminalStreamResponse_Exit{Exit: &pb.TerminalExit{ExitCode: 0, Signal: ""}}}
+}

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -40,6 +40,18 @@ service SandboxService {
   rpc SnapshotList(SnapshotListRequest)     returns (SnapshotListResponse);
   // GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
   rpc GetProcesses(GetProcessesRequest)     returns (GetProcessesResponse);
+  // ── PTY terminal primitive (KIP-19) ───────────────────────────────────────
+  // CreateTerminal allocates a PTY and starts argv as a controlling-terminal
+  // session leader (argv is NOT shell-interpreted).
+  rpc CreateTerminal(CreateTerminalRequest) returns (CreateTerminalResponse);
+  // TerminalStream streams terminal output bytes; the final frame carries
+  // TerminalExit (exit code / signal) when the top-level process closes.
+  rpc TerminalStream(TerminalStreamRequest) returns (stream TerminalStreamResponse);
+  rpc TerminalWrite(TerminalWriteRequest)   returns (TerminalWriteResponse);
+  rpc TerminalResize(TerminalResizeRequest) returns (TerminalResizeResponse);
+  rpc TerminalForeground(TerminalForegroundRequest) returns (TerminalForegroundResponse);
+  rpc TerminalSignal(TerminalSignalRequest) returns (TerminalSignalResponse);
+  rpc TerminalDestroy(TerminalDestroyRequest) returns (TerminalDestroyResponse);
 }
 
 // SecretRef references a key in a same-namespace K8s Secret. Values are resolved
@@ -255,3 +267,69 @@ message ProcessInfo {
 message GetProcessesResponse {
   repeated ProcessInfo processes = 1;
 }
+
+// ── PTY terminal primitive (KIP-19) ─────────────────────────────────────────
+
+message CreateTerminalRequest {
+  string session_id = 1;
+  repeated string argv = 2;   // argv[0] is the program; NOT shell-interpreted
+  string workdir = 3;
+  map<string, string> env = 4; // non-sensitive env; secrets stay in CreateSession.secret_refs
+  int32  rows = 5;            // initial window rows (>=1)
+  int32  cols = 6;            // initial window cols (>=1)
+}
+message CreateTerminalResponse {
+  string terminal_id = 1;     // opaque branded handle for all terminal RPCs
+  int32  pid = 2;             // session-leader pid in the sandbox pid space
+}
+
+message TerminalStreamRequest { string terminal_id = 1; }
+message TerminalStreamResponse {
+  oneof frame {
+    bytes data = 1;           // terminal output bytes in delivery order
+    TerminalExit exit = 2;    // final frame: top-level process closed
+  }
+}
+message TerminalExit {
+  int32  exit_code = 1;       // process exit code; 0 = clean
+  string signal    = 2;       // terminating signal name; empty = normal exit
+}
+
+message TerminalWriteRequest {
+  string terminal_id = 1;
+  bytes  data = 2;            // raw bytes, no implicit newline
+}
+message TerminalWriteResponse { bool ok = 1; }
+
+message TerminalResizeRequest {
+  string terminal_id = 1;
+  int32 rows = 2;
+  int32 cols = 3;
+}
+message TerminalResizeResponse { bool ok = 1; }
+
+message TerminalForegroundRequest { string terminal_id = 1; }
+message TerminalForegroundResponse {
+  int32 process_group_id = 1; // current foreground pgid; -1 when unresolvable
+  bool  input_waiting = 2;    // best-effort; false means "not provable" (KIP-19)
+}
+
+enum TerminalSignal {
+  TERMINAL_SIGNAL_UNSPECIFIED = 0;
+  TERMINAL_SIGNAL_INT  = 1;   // SIGINT
+  TERMINAL_SIGNAL_TERM = 2;   // SIGTERM
+  TERMINAL_SIGNAL_KILL = 3;   // SIGKILL
+  TERMINAL_SIGNAL_TSTP = 4;   // SIGTSTP
+  TERMINAL_SIGNAL_HUP  = 5;   // SIGHUP
+}
+message TerminalSignalRequest {
+  string terminal_id = 1;
+  TerminalSignal signal = 2;
+}
+message TerminalSignalResponse { int32 process_group_id = 1; } // pgid that received the signal
+
+message TerminalDestroyRequest {
+  string terminal_id = 1;
+  int32  grace_ms = 2;        // TERM -> grace -> KILL escalation bound
+}
+message TerminalDestroyResponse { bool ok = 1; }

--- a/sandboxd/build.zig
+++ b/sandboxd/build.zig
@@ -48,4 +48,8 @@ pub fn build(b: *std.Build) void {
     const events_mod = b.createModule(.{ .root_source_file = b.path("src/events_test.zig"), .target = native });
     const events_tests = b.addTest(.{ .root_module = events_mod });
     test_step.dependOn(&b.addRunArtifact(events_tests).step);
+
+    const pty_mod = b.createModule(.{ .root_source_file = b.path("src/pty_test.zig"), .target = native });
+    const pty_tests = b.addTest(.{ .root_module = pty_mod });
+    test_step.dependOn(&b.addRunArtifact(pty_tests).step);
 }

--- a/sandboxd/src/main.zig
+++ b/sandboxd/src/main.zig
@@ -9,6 +9,7 @@ const events = @import("events.zig");
 const processes = @import("processes.zig");
 const execctl = @import("execctl.zig");
 const watch = @import("watch.zig");
+const pty = @import("pty.zig");
 
 pub fn main() !void {
     var gpa = std.heap.DebugAllocator(.{}){};
@@ -211,6 +212,21 @@ fn handleRequest(allocator: std.mem.Allocator, client_fd: i32) !void {
     } else if (std.mem.eql(u8, path, "/watch/remove") and std.mem.eql(u8, method, "POST")) {
         // E2B Filesystem/RemoveWatcher.
         try watch.handleRemove(allocator, client_fd, body);
+    } else if (std.mem.eql(u8, path, "/pty/create") and std.mem.eql(u8, method, "POST")) {
+        // PTY terminal primitive (KIP-19): allocate + start controlling-terminal session leader.
+        try pty.handleCreate(allocator, client_fd, body);
+    } else if (std.mem.eql(u8, path, "/pty/input") and std.mem.eql(u8, method, "POST")) {
+        try pty.handleInput(allocator, client_fd, body);
+    } else if (std.mem.eql(u8, path, "/pty/resize") and std.mem.eql(u8, method, "POST")) {
+        try pty.handleResize(allocator, client_fd, body);
+    } else if (std.mem.eql(u8, path, "/pty/foreground") and std.mem.eql(u8, method, "GET")) {
+        try pty.handleForeground(allocator, client_fd, query);
+    } else if (std.mem.eql(u8, path, "/pty/signal") and std.mem.eql(u8, method, "POST")) {
+        try pty.handleSignal(allocator, client_fd, body);
+    } else if (std.mem.eql(u8, path, "/pty/destroy") and std.mem.eql(u8, method, "POST")) {
+        try pty.handleDestroy(allocator, client_fd, body);
+    } else if (std.mem.eql(u8, path, "/pty/stream") and std.mem.eql(u8, method, "GET")) {
+        try pty.handleStream(allocator, client_fd, query);
     } else {
         try writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"not found\"}");
     }

--- a/sandboxd/src/pty.zig
+++ b/sandboxd/src/pty.zig
@@ -1,0 +1,623 @@
+const std = @import("std");
+const main = @import("main.zig");
+const exec = @import("exec.zig");
+
+/// PTY terminal primitive (KIP-19). Allocates a pseudo-terminal, starts an
+/// argv as a controlling-terminal session leader, and keeps a daemon-owned
+/// pump thread draining the master so a disconnected stream never blocks the
+/// foreground process. Terminal sessions are keyed by a monotonic id and are
+/// pod-scoped: they die with the pod (no cross-pod migration).
+
+// ioctl request codes (asm-generic / Linux).
+const TIOCGPTN: u32 = 0x80045430; // get pty number (unsigned int)
+const TIOCSPTLCK: u32 = 0x40045431; // lock/unlock pty (int)
+const TIOCSCTTY: u32 = 0x540E; // make controlling terminal
+const TIOCSWINSZ: u32 = 0x5414; // set window size
+
+const Winsize = extern struct {
+    ws_row: u16 = 0,
+    ws_col: u16 = 0,
+    ws_xpixel: u16 = 0,
+    ws_ypixel: u16 = 0,
+};
+
+const BUFFER_MAX = 64 * 1024; // output ring buffer per terminal (attach/replay)
+const MAX_TERMINALS = 64;
+const POLL_NSEC: isize = 50 * 1_000_000; // 50ms stream poll cadence
+
+const Terminal = struct {
+    id: u32,
+    master_fd: i32,
+    pid: i32, // session leader
+    rows: u16,
+    cols: u16,
+    buf: [BUFFER_MAX]u8 = [_]u8{0} ** BUFFER_MAX,
+    buf_len: usize = 0,
+    buf_head: usize = 0,
+    total_bytes: u64 = 0,
+    exit_code: i32 = 0,
+    done: bool = false,
+};
+
+var terminals: [MAX_TERMINALS]?Terminal = [_]?Terminal{null} ** MAX_TERMINALS;
+var count: usize = 0;
+var next_id: u32 = 1;
+var lock: std.atomic.Value(u32) = .init(0);
+
+fn lockTable() void {
+    while (lock.cmpxchgStrong(0, 1, .acquire, .monotonic) != null) {
+        std.atomic.spinLoopHint();
+    }
+}
+
+fn unlockTable() void {
+    _ = lock.cmpxchgStrong(1, 0, .release, .monotonic);
+}
+
+/// True when a raw Linux syscall return value encodes a negative errno.
+fn isErr(rc: usize) bool {
+    return @as(isize, @bitCast(rc)) < 0;
+}
+
+fn findTerminal(id: u32) ?*Terminal {
+    for (&terminals) |*slot| {
+        if (slot.*) |*t| {
+            if (t.id == id) return t;
+        }
+    }
+    return null;
+}
+
+fn sleepPoll() void {
+    const ts = std.os.linux.timespec{ .sec = 0, .nsec = POLL_NSEC };
+    _ = std.os.linux.nanosleep(&ts, null);
+}
+
+// ── PTY allocation ──────────────────────────────────────────────────────────
+
+const Pty = struct {
+    master: i32,
+    slave: i32,
+};
+
+fn openPty() !Pty {
+    var ptmx_buf: [64]u8 = undefined;
+    const ptmx = std.fmt.bufPrintZ(&ptmx_buf, "/dev/ptmx", .{}) catch return error.PathTooLong;
+    const master_rc = std.os.linux.open(ptmx.ptr, std.os.linux.O{ .ACCMODE = .RDWR, .NOCTTY = true, .CLOEXEC = true }, 0);
+    if (isErr(master_rc)) return error.OpenPtmxFailed;
+    const master: i32 = @intCast(master_rc);
+
+    var ptn: u32 = 0;
+    if (std.os.linux.ioctl(master, TIOCGPTN, @intFromPtr(&ptn)) != 0) {
+        _ = std.os.linux.close(master);
+        return error.IoctlGptnFailed;
+    }
+    var unlock: i32 = 0;
+    if (std.os.linux.ioctl(master, TIOCSPTLCK, @intFromPtr(&unlock)) != 0) {
+        _ = std.os.linux.close(master);
+        return error.IoctlSptlckFailed;
+    }
+
+    var pts_buf: [64]u8 = undefined;
+    const pts = std.fmt.bufPrintZ(&pts_buf, "/dev/pts/{d}", .{ptn}) catch {
+        _ = std.os.linux.close(master);
+        return error.PathTooLong;
+    };
+    const slave_rc = std.os.linux.open(pts.ptr, std.os.linux.O{ .ACCMODE = .RDWR, .NOCTTY = true, .CLOEXEC = true }, 0);
+    if (isErr(slave_rc)) {
+        _ = std.os.linux.close(master);
+        return error.OpenSlaveFailed;
+    }
+    const slave: i32 = @intCast(slave_rc);
+    return .{ .master = master, .slave = slave };
+}
+
+// ── argv extraction ─────────────────────────────────────────────────────────
+
+fn argvStrings(allocator: std.mem.Allocator, value: std.json.Value) ![][]const u8 {
+    if (value != .array or value.array.items.len == 0) return error.InvalidArgv;
+    const out = try allocator.alloc([]const u8, value.array.items.len);
+    for (value.array.items, 0..) |item, i| {
+        if (item != .string) return error.InvalidArgv;
+        out[i] = item.string;
+    }
+    return out;
+}
+
+// ── spawn: fork a controlling-terminal session leader ───────────────────────
+
+fn spawnTerminal(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    workdir: []const u8,
+    env: std.json.Value,
+    rows: u16,
+    cols: u16,
+) !Terminal {
+    if (argv.len == 0) return error.EmptyArgv;
+
+    const pty = try openPty();
+
+    // Build argv/envp before fork; the child inherits the memory via COW.
+    const argv_z = try allocator.alloc([:0]u8, argv.len);
+    const argv_ptrs = try allocator.allocSentinel(?[*:0]const u8, argv.len, null);
+    for (argv, 0..) |arg, i| {
+        argv_z[i] = try allocator.dupeZ(u8, arg);
+        argv_ptrs[i] = argv_z[i].ptr;
+    }
+    var env_build = exec.buildEnvp(allocator, env, &.{}) catch {
+        for (argv_z) |s| allocator.free(s);
+        allocator.free(argv_z);
+        allocator.free(argv_ptrs);
+        _ = std.os.linux.close(pty.master);
+        _ = std.os.linux.close(pty.slave);
+        return error.EnvBuildFailed;
+    };
+
+    var workdir_buf: [4096]u8 = undefined;
+    const workdir_z = std.fmt.bufPrintZ(&workdir_buf, "{s}", .{workdir}) catch return error.PathTooLong;
+
+    const child_pid = std.os.linux.fork();
+    if (isErr(child_pid)) {
+        env_build.deinit();
+        for (argv_z) |s| allocator.free(s);
+        allocator.free(argv_z);
+        allocator.free(argv_ptrs);
+        _ = std.os.linux.close(pty.master);
+        _ = std.os.linux.close(pty.slave);
+        return error.ForkFailed;
+    }
+    if (child_pid == 0) {
+        // Child: become a session leader owning the slave as controlling tty.
+        _ = std.os.linux.setsid();
+        _ = std.os.linux.ioctl(pty.slave, TIOCSCTTY, 0);
+        _ = std.os.linux.dup2(pty.slave, 0);
+        _ = std.os.linux.dup2(pty.slave, 1);
+        _ = std.os.linux.dup2(pty.slave, 2);
+        if (pty.slave > 2) _ = std.os.linux.close(pty.slave);
+        _ = std.os.linux.close(pty.master);
+        _ = std.os.linux.chdir(workdir_z);
+        _ = std.os.linux.execve(argv_ptrs[0].?, argv_ptrs.ptr, env_build.envpPtr());
+        std.os.linux.exit(127);
+    }
+
+    // Parent: free fork-only state, drop slave, apply initial window size.
+    env_build.deinit();
+    for (argv_z) |s| allocator.free(s);
+    allocator.free(argv_z);
+    allocator.free(argv_ptrs);
+    _ = std.os.linux.close(pty.slave);
+    const ws = Winsize{ .ws_row = rows, .ws_col = cols };
+    _ = std.os.linux.ioctl(pty.master, TIOCSWINSZ, @intFromPtr(&ws));
+
+    return .{
+        .id = 0,
+        .master_fd = pty.master,
+        .pid = @intCast(child_pid),
+        .rows = rows,
+        .cols = cols,
+    };
+}
+
+// ── terminal table ──────────────────────────────────────────────────────────
+
+fn register(term: Terminal) ?u32 {
+    lockTable();
+    defer unlockTable();
+    if (count >= terminals.len) {
+        _ = std.os.linux.close(term.master_fd);
+        return null;
+    }
+    const id = next_id;
+    next_id += 1;
+    for (&terminals) |*slot| {
+        if (slot.* == null) {
+            var t = term;
+            t.id = id;
+            slot.* = t;
+            count += 1;
+            return id;
+        }
+    }
+    _ = std.os.linux.close(term.master_fd);
+    return null;
+}
+
+fn unregister(id: u32) void {
+    lockTable();
+    defer unlockTable();
+    for (&terminals) |*slot| {
+        if (slot.*) |t| {
+            if (t.id == id) {
+                _ = std.os.linux.close(t.master_fd);
+                slot.* = null;
+                count -= 1;
+                return;
+            }
+        }
+    }
+}
+
+fn appendOutput(id: u32, data: []const u8) void {
+    lockTable();
+    defer unlockTable();
+    if (findTerminal(id)) |t| {
+        for (data) |b| {
+            t.buf[t.buf_head] = b;
+            t.buf_head = (t.buf_head + 1) % BUFFER_MAX;
+            if (t.buf_len < BUFFER_MAX) t.buf_len += 1;
+        }
+        t.total_bytes += data.len;
+    }
+}
+
+fn markDone(id: u32, exit_code: i32) void {
+    lockTable();
+    defer unlockTable();
+    if (findTerminal(id)) |t| {
+        t.exit_code = exit_code;
+        t.done = true;
+    }
+}
+
+/// Copy the most recent `out.len` buffered bytes (in delivery order) into
+/// `out`; returns the number of bytes written.
+fn readTail(id: u32, out: []u8) usize {
+    lockTable();
+    defer unlockTable();
+    const t = findTerminal(id) orelse return 0;
+    const n = @min(t.buf_len, out.len);
+    const start = (t.buf_head + BUFFER_MAX - t.buf_len) % BUFFER_MAX;
+    for (0..n) |i| {
+        out[i] = t.buf[(start + i) % BUFFER_MAX];
+    }
+    return n;
+}
+
+// ── pump thread ─────────────────────────────────────────────────────────────
+
+fn reapExitCode(pid: i32) i32 {
+    var status: u32 = 0;
+    const rc = std.os.linux.syscall4(
+        .wait4,
+        @as(usize, @bitCast(@as(isize, @intCast(pid)))),
+        @intFromPtr(&status),
+        0,
+        0,
+    );
+    if (isErr(rc)) return 0; // auto-reaped (SA_NOCLDWAIT) → no exit status
+    if (std.posix.W.IFEXITED(status)) return @intCast(std.posix.W.EXITSTATUS(status));
+    return 0;
+}
+
+fn pumpThread(id: u32, master_fd: i32, pid: i32) void {
+    var buf: [4096]u8 = undefined;
+    while (true) {
+        const n = std.os.linux.read(master_fd, &buf, buf.len);
+        if (n == 0) break; // EOF: all slave fds closed
+        if (isErr(n)) break; // EIO/EBADF: slave side gone
+        appendOutput(id, buf[0..@intCast(n)]);
+    }
+    markDone(id, reapExitCode(pid));
+}
+
+// ── request structs ─────────────────────────────────────────────────────────
+
+const CreateRequest = struct {
+    argv: std.json.Value = .{ .null = {} },
+    workdir: []const u8 = "/workspace",
+    env: std.json.Value = .{ .null = {} },
+    rows: u16 = 24,
+    cols: u16 = 80,
+};
+
+const InputRequest = struct {
+    terminal_id: u32 = 0,
+    data: []const u8 = "",
+};
+
+const ResizeRequest = struct {
+    terminal_id: u32 = 0,
+    rows: u16 = 0,
+    cols: u16 = 0,
+};
+
+const SignalRequest = struct {
+    terminal_id: u32 = 0,
+    signal: []const u8 = "",
+};
+
+const DestroyRequest = struct {
+    terminal_id: u32 = 0,
+    grace_ms: u32 = 5000,
+};
+
+// ── POST /pty/create ────────────────────────────────────────────────────────
+
+pub fn handleCreate(allocator: std.mem.Allocator, client_fd: i32, body: []const u8) !void {
+    const parsed = std.json.parseFromSlice(CreateRequest, allocator, body, .{ .ignore_unknown_fields = true, .allocate = .alloc_always }) catch {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
+        return;
+    };
+    defer parsed.deinit();
+    const req = parsed.value;
+
+    const argv = argvStrings(allocator, req.argv) catch {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"argv must be a non-empty array of strings\"}");
+        return;
+    };
+    defer allocator.free(argv);
+
+    const term = spawnTerminal(allocator, argv, req.workdir, req.env, req.rows, req.cols) catch |err| {
+        const msg = try std.fmt.allocPrint(allocator, "{{\"error\":\"{s}\"}}", .{@errorName(err)});
+        defer allocator.free(msg);
+        try main.writeResponse(client_fd, "500 Internal Server Error", "application/json", msg);
+        return;
+    };
+
+    const id = register(term) orelse {
+        try main.writeResponse(client_fd, "503 Service Unavailable", "application/json", "{\"error\":\"terminal table full\"}");
+        return;
+    };
+
+    const spawned = std.Thread.spawn(.{}, pumpThread, .{ id, term.master_fd, term.pid }) catch null;
+    if (spawned) |t| t.detach();
+
+    const resp = try std.fmt.allocPrint(allocator, "{{\"terminal_id\":{d},\"pid\":{d}}}", .{ id, term.pid });
+    defer allocator.free(resp);
+    try main.writeResponse(client_fd, "200 OK", "application/json", resp);
+}
+
+// ── POST /pty/input ─────────────────────────────────────────────────────────
+
+pub fn handleInput(allocator: std.mem.Allocator, client_fd: i32, body: []const u8) !void {
+    const parsed = std.json.parseFromSlice(InputRequest, allocator, body, .{ .ignore_unknown_fields = true, .allocate = .alloc_always }) catch {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
+        return;
+    };
+    defer parsed.deinit();
+    const req = parsed.value;
+
+    lockTable();
+    const t = findTerminal(req.terminal_id);
+    if (t == null) {
+        unlockTable();
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"terminal not found\"}");
+        return;
+    }
+    const master_fd = t.?.master_fd;
+    unlockTable();
+
+    var written: usize = 0;
+    while (written < req.data.len) {
+        const n = std.os.linux.write(master_fd, req.data.ptr + written, req.data.len - written);
+        if (isErr(n) or n == 0) break;
+        written += n;
+    }
+    try main.writeResponse(client_fd, "200 OK", "application/json", "{\"ok\":true}");
+}
+
+// ── POST /pty/resize ────────────────────────────────────────────────────────
+
+pub fn handleResize(allocator: std.mem.Allocator, client_fd: i32, body: []const u8) !void {
+    const parsed = std.json.parseFromSlice(ResizeRequest, allocator, body, .{ .ignore_unknown_fields = true }) catch {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
+        return;
+    };
+    defer parsed.deinit();
+    const req = parsed.value;
+
+    lockTable();
+    const t = findTerminal(req.terminal_id);
+    if (t == null) {
+        unlockTable();
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"terminal not found\"}");
+        return;
+    }
+    const master_fd = t.?.master_fd;
+    unlockTable();
+
+    const ws = Winsize{ .ws_row = req.rows, .ws_col = req.cols };
+    _ = std.os.linux.ioctl(master_fd, TIOCSWINSZ, @intFromPtr(&ws));
+    try main.writeResponse(client_fd, "200 OK", "application/json", "{\"ok\":true}");
+}
+
+// ── GET /pty/foreground ─────────────────────────────────────────────────────
+
+pub fn handleForeground(allocator: std.mem.Allocator, client_fd: i32, query: []const u8) !void {
+    const id = parseIdQuery(query) orelse {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"terminal_id required\"}");
+        return;
+    };
+
+    lockTable();
+    const t = findTerminal(id);
+    if (t == null) {
+        unlockTable();
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"terminal not found\"}");
+        return;
+    }
+    const master_fd = t.?.master_fd;
+    unlockTable();
+
+    const pgrp = std.posix.tcgetpgrp(master_fd) catch {
+        try main.writeResponse(client_fd, "200 OK", "application/json", "{\"process_group_id\":-1,\"input_waiting\":false}");
+        return;
+    };
+    const resp = try std.fmt.allocPrint(allocator, "{{\"process_group_id\":{d},\"input_waiting\":false}}", .{pgrp});
+    defer allocator.free(resp);
+    try main.writeResponse(client_fd, "200 OK", "application/json", resp);
+}
+
+// ── POST /pty/signal ────────────────────────────────────────────────────────
+
+pub fn handleSignal(allocator: std.mem.Allocator, client_fd: i32, body: []const u8) !void {
+    const parsed = std.json.parseFromSlice(SignalRequest, allocator, body, .{ .ignore_unknown_fields = true, .allocate = .alloc_always }) catch {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
+        return;
+    };
+    defer parsed.deinit();
+    const req = parsed.value;
+
+    const sig: std.os.linux.SIG = if (std.mem.eql(u8, req.signal, "SIGINT") or std.mem.eql(u8, req.signal, "INT"))
+        .INT
+    else if (std.mem.eql(u8, req.signal, "SIGTERM") or std.mem.eql(u8, req.signal, "TERM"))
+        .TERM
+    else if (std.mem.eql(u8, req.signal, "SIGKILL") or std.mem.eql(u8, req.signal, "KILL"))
+        .KILL
+    else if (std.mem.eql(u8, req.signal, "SIGTSTP") or std.mem.eql(u8, req.signal, "TSTP"))
+        .TSTP
+    else if (std.mem.eql(u8, req.signal, "SIGHUP") or std.mem.eql(u8, req.signal, "HUP"))
+        .HUP
+    else {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"unsupported signal\"}");
+        return;
+    };
+
+    lockTable();
+    const t = findTerminal(req.terminal_id);
+    if (t == null) {
+        unlockTable();
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"terminal not found\"}");
+        return;
+    }
+    const master_fd = t.?.master_fd;
+    unlockTable();
+
+    const pgrp = std.posix.tcgetpgrp(master_fd) catch {
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"foreground group not resolvable\"}");
+        return;
+    };
+    _ = std.posix.kill(-pgrp, sig) catch {
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"signal delivery failed\"}");
+        return;
+    };
+    const resp = try std.fmt.allocPrint(allocator, "{{\"process_group_id\":{d}}}", .{pgrp});
+    defer allocator.free(resp);
+    try main.writeResponse(client_fd, "200 OK", "application/json", resp);
+}
+
+// ── POST /pty/destroy ───────────────────────────────────────────────────────
+
+fn isGroupAlive(pgid: i32) bool {
+    const pid: std.os.linux.pid_t = -pgid;
+    const probe = std.os.linux.syscall2(.kill, @as(usize, @bitCast(@as(isize, @intCast(pid)))), 0);
+    return probe == 0;
+}
+
+pub fn handleDestroy(allocator: std.mem.Allocator, client_fd: i32, body: []const u8) !void {
+    const parsed = std.json.parseFromSlice(DestroyRequest, allocator, body, .{ .ignore_unknown_fields = true }) catch {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"invalid json\"}");
+        return;
+    };
+    defer parsed.deinit();
+    const req = parsed.value;
+
+    lockTable();
+    const t = findTerminal(req.terminal_id);
+    if (t == null) {
+        unlockTable();
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"terminal not found\"}");
+        return;
+    }
+    const master_fd = t.?.master_fd;
+    const pid = t.?.pid;
+    t.?.master_fd = -1; // unregister must not re-close this fd
+    unlockTable();
+
+    // Closing the master hangs up the foreground process group (SIGHUP);
+    // then TERM -> grace -> KILL the session leader's group.
+    _ = std.os.linux.close(master_fd);
+    _ = std.posix.kill(-pid, .TERM) catch {};
+
+    const iters: u32 = if (req.grace_ms < 50) 1 else req.grace_ms / 50;
+    var i: u32 = 0;
+    while (isGroupAlive(pid) and i < iters) : (i += 1) {
+        sleepPoll();
+    }
+    if (isGroupAlive(pid)) {
+        _ = std.posix.kill(-pid, .KILL) catch {};
+    }
+
+    unregister(req.terminal_id);
+    try main.writeResponse(client_fd, "200 OK", "application/json", "{\"ok\":true}");
+}
+
+// ── GET /pty/stream ─────────────────────────────────────────────────────────
+
+fn parseIdQuery(query: []const u8) ?u32 {
+    const prefix = "terminal_id=";
+    if (std.mem.startsWith(u8, query, prefix)) {
+        return std.fmt.parseInt(u32, query[prefix.len..], 10) catch null;
+    }
+    return null;
+}
+
+fn writeDataFrame(allocator: std.mem.Allocator, client_fd: i32, data: []const u8) !void {
+    const encoded_len = std.base64.standard.Encoder.calcSize(data.len);
+    const encoded = try allocator.alloc(u8, encoded_len);
+    defer allocator.free(encoded);
+    _ = std.base64.standard.Encoder.encode(encoded, data);
+
+    _ = std.os.linux.write(client_fd, "data: ".ptr, "data: ".len);
+    _ = std.os.linux.write(client_fd, encoded.ptr, encoded.len);
+    _ = std.os.linux.write(client_fd, "\n\n".ptr, "\n\n".len);
+}
+
+pub fn handleStream(allocator: std.mem.Allocator, client_fd: i32, query: []const u8) !void {
+    const id = parseIdQuery(query) orelse {
+        try main.writeResponse(client_fd, "400 Bad Request", "application/json", "{\"error\":\"terminal_id required\"}");
+        return;
+    };
+
+    lockTable();
+    const t0 = findTerminal(id) orelse {
+        unlockTable();
+        try main.writeResponse(client_fd, "404 Not Found", "application/json", "{\"error\":\"terminal not found\"}");
+        return;
+    };
+    const pid = t0.pid;
+    unlockTable();
+
+    const header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
+    _ = std.os.linux.write(client_fd, header.ptr, header.len);
+
+    var pid_frame_buf: [64]u8 = undefined;
+    const pid_frame = std.fmt.bufPrint(&pid_frame_buf, "data: {{\"pid\":{d}}}\n\n", .{pid}) catch return;
+    _ = std.os.linux.write(client_fd, pid_frame.ptr, pid_frame.len);
+
+    var sent: u64 = 0;
+    var truncated = false;
+    var exit_code: i32 = 0;
+    while (true) {
+        lockTable();
+        const tt = findTerminal(id) orelse {
+            unlockTable();
+            break;
+        };
+        const total = tt.total_bytes;
+        const done = tt.done;
+        exit_code = tt.exit_code;
+        unlockTable();
+
+        const new_bytes = total - sent;
+        if (new_bytes > 0) {
+            const n: usize = @intCast(@min(new_bytes, BUFFER_MAX));
+            var out: [BUFFER_MAX]u8 = undefined;
+            const got = readTail(id, out[0..n]);
+            if (got > 0) try writeDataFrame(allocator, client_fd, out[0..got]);
+            if (new_bytes > BUFFER_MAX) truncated = true;
+            sent = total;
+        }
+        if (done and sent >= total) break;
+        sleepPoll();
+    }
+
+    const trunc_lit: []const u8 = if (truncated) "true" else "false";
+    var exit_buf: [128]u8 = undefined;
+    const exit_frame = std.fmt.bufPrint(&exit_buf, "data: {{\"exit\":{d},\"signal\":\"\",\"truncated\":{s}}}\n\n", .{ exit_code, trunc_lit }) catch {
+        _ = std.os.linux.write(client_fd, "data: {\"exit\":0,\"signal\":\"\"}\n\n".ptr, 28);
+        return;
+    };
+    _ = std.os.linux.write(client_fd, exit_frame.ptr, exit_frame.len);
+}

--- a/sandboxd/src/pty.zig
+++ b/sandboxd/src/pty.zig
@@ -25,7 +25,7 @@ const BUFFER_MAX = 64 * 1024; // output ring buffer per terminal (attach/replay)
 const MAX_TERMINALS = 64;
 const POLL_NSEC: isize = 50 * 1_000_000; // 50ms stream poll cadence
 
-const Terminal = struct {
+pub const Terminal = struct {
     id: u32,
     master_fd: i32,
     pid: i32, // session leader
@@ -80,7 +80,7 @@ const Pty = struct {
     slave: i32,
 };
 
-fn openPty() !Pty {
+pub fn openPty() !Pty {
     var ptmx_buf: [64]u8 = undefined;
     const ptmx = std.fmt.bufPrintZ(&ptmx_buf, "/dev/ptmx", .{}) catch return error.PathTooLong;
     const master_rc = std.os.linux.open(ptmx.ptr, std.os.linux.O{ .ACCMODE = .RDWR, .NOCTTY = true, .CLOEXEC = true }, 0);
@@ -126,7 +126,7 @@ fn argvStrings(allocator: std.mem.Allocator, value: std.json.Value) ![][]const u
 
 // ── spawn: fork a controlling-terminal session leader ───────────────────────
 
-fn spawnTerminal(
+pub fn spawnTerminal(
     allocator: std.mem.Allocator,
     argv: []const []const u8,
     workdir: []const u8,
@@ -201,7 +201,7 @@ fn spawnTerminal(
 
 // ── terminal table ──────────────────────────────────────────────────────────
 
-fn register(term: Terminal) ?u32 {
+pub fn register(term: Terminal) ?u32 {
     lockTable();
     defer unlockTable();
     if (count >= terminals.len) {
@@ -223,7 +223,7 @@ fn register(term: Terminal) ?u32 {
     return null;
 }
 
-fn unregister(id: u32) void {
+pub fn unregister(id: u32) void {
     lockTable();
     defer unlockTable();
     for (&terminals) |*slot| {
@@ -238,7 +238,7 @@ fn unregister(id: u32) void {
     }
 }
 
-fn appendOutput(id: u32, data: []const u8) void {
+pub fn appendOutput(id: u32, data: []const u8) void {
     lockTable();
     defer unlockTable();
     if (findTerminal(id)) |t| {
@@ -251,7 +251,7 @@ fn appendOutput(id: u32, data: []const u8) void {
     }
 }
 
-fn markDone(id: u32, exit_code: i32) void {
+pub fn markDone(id: u32, exit_code: i32) void {
     lockTable();
     defer unlockTable();
     if (findTerminal(id)) |t| {
@@ -262,7 +262,7 @@ fn markDone(id: u32, exit_code: i32) void {
 
 /// Copy the most recent `out.len` buffered bytes (in delivery order) into
 /// `out`; returns the number of bytes written.
-fn readTail(id: u32, out: []u8) usize {
+pub fn readTail(id: u32, out: []u8) usize {
     lockTable();
     defer unlockTable();
     const t = findTerminal(id) orelse return 0;

--- a/sandboxd/src/pty_test.zig
+++ b/sandboxd/src/pty_test.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const pty = @import("pty.zig");
+
+// PTY primitive tests (KIP-19 M2). These exercise Linux-only syscalls
+// (/dev/ptmx, setsid, TIOCSCTTY), so they must run on a Linux kernel
+// (CI linux/amd64 or an OrbStack Linux container), not macOS.
+
+fn isErr(rc: usize) bool {
+    return @as(isize, @bitCast(rc)) < 0;
+}
+
+test "openPty: allocates a master/slave pair" {
+    const p = try pty.openPty();
+    defer _ = std.os.linux.close(p.master);
+    defer _ = std.os.linux.close(p.slave);
+    try std.testing.expect(p.master > 2);
+    try std.testing.expect(p.slave > 2);
+}
+
+test "spawnTerminal: runs argv as a session leader on the PTY" {
+    const allocator = std.testing.allocator;
+    const argv = [_][]const u8{ "/bin/sh", "-c", "printf pty-ok" };
+    const term = try pty.spawnTerminal(allocator, &argv, "/tmp", .{ .null = {} }, 24, 80);
+    defer _ = std.os.linux.close(term.master_fd);
+    try std.testing.expect(term.pid > 1);
+
+    // Drain the master until EOF and require the child's output (ONLCR maps
+    // '\n' to '\r\n', so only assert on the stable prefix).
+    var buf: [256]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = std.os.linux.read(term.master_fd, buf[total..].ptr, buf.len - total);
+        if (n == 0) break; // EOF: slave side closed
+        if (isErr(n)) break;
+        total += n;
+    }
+    try std.testing.expect(std.mem.indexOf(u8, buf[0..total], "pty-ok") != null);
+}
+
+test "table: register, appendOutput, readTail, markDone, unregister" {
+    const p = try pty.openPty();
+    defer _ = std.os.linux.close(p.slave);
+
+    const term = pty.Terminal{
+        .id = 0,
+        .master_fd = p.master,
+        .pid = 4242,
+        .rows = 24,
+        .cols = 80,
+    };
+    const id = pty.register(term) orelse return error.TableFull;
+    defer pty.unregister(id);
+
+    pty.appendOutput(id, "hello");
+    pty.appendOutput(id, "world");
+
+    var out: [16]u8 = undefined;
+    const n = pty.readTail(id, out[0..]);
+    try std.testing.expectEqualStrings("helloworld", out[0..n]);
+
+    // done is a separate flag from the buffered output.
+    pty.markDone(id, 7);
+    const n2 = pty.readTail(id, out[0..]);
+    try std.testing.expectEqualStrings("helloworld", out[0..n2]);
+}
+
+test "table: readTail returns nothing for an unknown id" {
+    var out: [8]u8 = undefined;
+    const n = pty.readTail(9999, out[0..]);
+    try std.testing.expectEqual(@as(usize, 0), n);
+}


### PR DESCRIPTION
## 概述

实现 **KIP-19（sandbox PTY 终端原语）**，为后续 KIP-20 的 dsh 插件 `spawnTerminal` 与 E2B SDK 的 `pty.*` 兼容面铺路。

关联 issue：#542（DeepSeek Harness 集成，本 PR 是其前置依赖之一）。

## 改动

- **proto**：`SandboxService` 新增 7 个终端 RPC + `TerminalSignal` 枚举 + `oneof` 终端流
- **sandboxd**：`pty.zig` 实现 PTY 分配 / 会话首领 / 输出泵 / 环形缓冲 + `/pty/*` 7 个端点
- **gateway**：7 个 RPC handler + `terminal_id` 注册表 + `TerminalStream` SSE→gRPC 解析
- **单测**：Zig `pty_test.zig` + Go `terminal_test.go`

## 验证

- **Zig 单测**：OrbStack Linux 容器内跑通（openPty / spawnTerminal 会话首领 / 表环形缓冲）— 4/4 ✅
- **Go 单测**：`terminalSignalName` + SSE 帧解析 — 3/3 ✅
- `go vet` / `gofmt` / `zig build`（x86_64 / aarch64 / riscv64-linux-musl）全绿

## 说明

- 新 RPC 在 `Server` 嵌入 `UnimplementedSandboxServiceServer` 下编译不破，直到后续补 handler（本 PR 已补全）。
- `TerminalStream` 的 mTLS 已由现有 `mTLSStreamInterceptor` 覆盖（所有流式 RPC）。
- 终端随 pod 生命周期，pod 回收即消亡（无跨 pod 迁移），与 KIP-19 一致。
