### PR TITLE
feat(dsh): k8e-sandbox dsh plugin skeleton (KIP-20 Phase 1)

### DIFF
--- a/plugins/deepseek-harness/.gitignore
+++ b/plugins/deepseek-harness/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+lib/
+*.tsbuildinfo

--- a/plugins/deepseek-harness/.gitignore
+++ b/plugins/deepseek-harness/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 lib/
 *.tsbuildinfo
+tsconfig.check.json

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -1,0 +1,22 @@
+# dsh-k8e-sandbox
+
+Out-of-tree DeepSeek Harness plugin family (KIP-20). These packages let a dsh
+profile route its filesystem and subprocess execution world into k8e-sandbox
+via `dsh plugin --profile <name> add`.
+
+## Packages
+
+| Package | Role | `ctx` key |
+|---|---|---|
+| [`@k8e/dsh-k8e-sandbox`](packages/dsh-k8e-sandbox) | Sandbox owner service (session lifecycle + shared client) | `ctx.k8eSandbox` |
+| [`@k8e/dsh-k8e-sandbox-client`](packages/dsh-k8e-sandbox-client) | Transport abstraction: `CliK8eClient` (Phase 1) | library |
+| [`@k8e/dsh-k8e-sandbox-fs`](packages/dsh-k8e-sandbox-fs) | Filesystem seam provider | `ctx.fs` |
+| [`@k8e/dsh-k8e-sandbox-subprocess`](packages/dsh-k8e-sandbox-subprocess) | Subprocess seam provider | `ctx.subprocess` |
+| [`@k8e/dsh-k8e-sandbox-bundle`](packages/dsh-k8e-sandbox-bundle) | Installable bundle (`dsh.bundle.patch` → `cordis.patch.yml`) | — |
+
+## Status
+
+Phase 1 (CLI transport) under construction. The TypeScript packages target
+dsh's in-box types (`@deepseek-ai/dsh-fs`, `@deepseek-ai/dsh-subprocess`,
+`@deepseek-ai/cordis`), which resolve from the dsh installation at profile boot
+time rather than from this workspace's `node_modules`.

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -18,7 +18,8 @@ via `dsh plugin --profile <name> add`.
 
 Phase 1 (CLI transport) and Phase 2 (direct gRPC: `spawnTerminal` + streaming
 `spawn`) are implemented. The tree typechecks cleanly against the dsh checkout;
-runtime e2e against a live K8E gateway is still pending.
+runtime e2e against a live K8E gateway is still pending — the procedure is in
+[`e2e.md`](e2e.md).
 
 ## Typecheck
 

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -8,15 +8,61 @@ via `dsh plugin --profile <name> add`.
 
 | Package | Role | `ctx` key |
 |---|---|---|
-| [`@k8e/dsh-k8e-sandbox`](packages/dsh-k8e-sandbox) | Sandbox owner service (session lifecycle + shared client) | `ctx.k8eSandbox` |
-| [`@k8e/dsh-k8e-sandbox-client`](packages/dsh-k8e-sandbox-client) | Transport abstraction: `CliK8eClient` (Phase 1) | library |
+| [`@k8e/dsh-k8e-sandbox`](packages/dsh-k8e-sandbox) | Sandbox owner service (session lifecycle + shared CLI/gRPC client) | `ctx.k8eSandbox` |
+| [`@k8e/dsh-k8e-sandbox-client`](packages/dsh-k8e-sandbox-client) | Transport: `CliK8eClient` (Phase 1) + `GrpcK8eClient` (Phase 2) | library |
 | [`@k8e/dsh-k8e-sandbox-fs`](packages/dsh-k8e-sandbox-fs) | Filesystem seam provider | `ctx.fs` |
-| [`@k8e/dsh-k8e-sandbox-subprocess`](packages/dsh-k8e-sandbox-subprocess) | Subprocess seam provider | `ctx.subprocess` |
+| [`@k8e/dsh-k8e-sandbox-subprocess`](packages/dsh-k8e-sandbox-subprocess) | Subprocess seam provider (streaming exec + `spawnTerminal`) | `ctx.subprocess` |
 | [`@k8e/dsh-k8e-sandbox-bundle`](packages/dsh-k8e-sandbox-bundle) | Installable bundle (`dsh.bundle.patch` → `cordis.patch.yml`) | — |
 
 ## Status
 
-Phase 1 (CLI transport) under construction. The TypeScript packages target
-dsh's in-box types (`@deepseek-ai/dsh-fs`, `@deepseek-ai/dsh-subprocess`,
-`@deepseek-ai/cordis`), which resolve from the dsh installation at profile boot
-time rather than from this workspace's `node_modules`.
+Phase 1 (CLI transport) and Phase 2 (direct gRPC: `spawnTerminal` + streaming
+`spawn`) are implemented. The tree typechecks cleanly against the dsh checkout;
+runtime e2e against a live K8E gateway is still pending.
+
+## Typecheck
+
+The TypeScript packages target dsh's in-box types (`@deepseek-ai/dsh-fs`,
+`@deepseek-ai/dsh-subprocess`, `@deepseek-ai/cordis`, `@deepseek-ai/schemastery`),
+which resolve from the dsh installation at profile boot time — not from this
+workspace's `node_modules`. To typecheck against a local dsh checkout:
+
+```sh
+# 1. Install the gRPC runtime deps (only the client package needs them):
+npm install --no-save --cache "$(mktemp -d)" @grpc/grpc-js @grpc/proto-loader
+
+# 2. Generate a paths-mapped check config and run dsh's tsc. The generated
+#    tsconfig.check.json maps @deepseek-ai/* to <dsh>/vendor/*/lib/types/*.d.ts
+#    and packages/<group>/*/lib/types/*.d.ts; it is gitignored.
+python3 - <<'PY'
+import json, os
+DSH = '/path/to/deepseek-harness'
+K8E = os.getcwd()
+groups = ['core','prompt','llm','shell','terminal','subprocess','e2b','code-runtime','fs','lsp','skill',
+          'compaction','context','goal','feedback','schedule','guard','plan','preset','subagent','jobs',
+          'workflow','web','attachment','spill','todo','bundle','extensions','sandbox','hooks','session',
+          'session-query','settings','credentials','acp','storage','workspace','sdk','interaction','boot',
+          'examples','util','mcp','identity','test-support','host','client','runtime-diagnostics','typert','api']
+paths = {
+  '@deepseek-ai/cordis': [os.path.join(DSH,'vendor','cordis','lib','types','index.d.ts')],
+  '@deepseek-ai/cosmokit': [os.path.join(DSH,'vendor','cosmokit','lib','types','index.d.ts')],
+  '@deepseek-ai/schemastery': [os.path.join(DSH,'vendor','schemastery','lib','types','index.d.ts')],
+  '@deepseek-ai/dsh-*': [os.path.join(DSH,'packages',g,'*','lib','types','index.d.ts') for g in groups],
+  '@k8e/dsh-k8e-sandbox': [os.path.join(K8E,'packages','dsh-k8e-sandbox','src')],
+  '@k8e/dsh-k8e-sandbox-client': [os.path.join(K8E,'packages','dsh-k8e-sandbox-client','src')],
+  '@k8e/dsh-k8e-sandbox-client/grpc': [os.path.join(K8E,'packages','dsh-k8e-sandbox-client','src','grpc.ts')],
+  '@k8e/dsh-k8e-sandbox-fs': [os.path.join(K8E,'packages','dsh-k8e-sandbox-fs','src')],
+  '@k8e/dsh-k8e-sandbox-subprocess': [os.path.join(K8E,'packages','dsh-k8e-sandbox-subprocess','src')],
+}
+json.dump({'compilerOptions': {
+  'target': 'es2024', 'module': 'esnext', 'moduleResolution': 'bundler',
+  'allowImportingTsExtensions': True, 'strict': True, 'skipLibCheck': True,
+  'esModuleInterop': True, 'noEmit': True, 'types': ['node'],
+  'typeRoots': [os.path.join(DSH,'node_modules','@types')], 'paths': paths,
+}, 'include': [os.path.join(K8E,'packages','*','src','**','*.ts')]},
+  open('tsconfig.check.json','w'), indent=2)
+PY
+
+# 3. Run dsh's TypeScript:
+/path/to/deepseek-harness/node_modules/.bin/tsc -p tsconfig.check.json
+```

--- a/plugins/deepseek-harness/e2e.md
+++ b/plugins/deepseek-harness/e2e.md
@@ -1,0 +1,141 @@
+# E2E verification — dsh-k8e-sandbox (KIP-20)
+
+How to run the whole chain end-to-end: a K8E sandbox gateway, this plugin
+installed into a dsh profile, and a real filesystem / exec / terminal operation
+landing in a sandbox pod.
+
+The TypeScript tree already typechecks against the dsh checkout (see
+[`README.md`](README.md#typecheck)); this guide verifies the **runtime** path.
+
+## Prerequisites
+
+- A K8E cluster with the sandbox matrix deployed (the `sandbox-matrix` CRDs and
+  controller), and the sandbox gRPC gateway listening on `:50051`.
+- `k8e-sandbox-cli` on PATH (for `connect`, `ps`, `list`, `log` introspection).
+- A dsh installation (`dsh` CLI on PATH).
+- (Phase 2 only) `endpoint` reachable from the dsh host, and mTLS material from
+  `connect`.
+
+## Step 1 — gateway + mTLS
+
+Start the gateway (via the K8E control plane or `k8e sandbox-gateway`) and
+establish mTLS once:
+
+```sh
+# local node
+k8e-sandbox-cli connect
+
+# remote — API key from the server (default TTL 30d)
+k8e sandbox-apikey create my-agent            # -> {"key":"k8e-..."}
+k8e-sandbox-cli connect --endpoint <host>:50051 --apikey k8e-...
+```
+
+`connect` verifies the gateway, puts `k8e-sandbox-cli` on PATH, and writes
+`ca.crt` / `client.crt` / `client.key` under `~/.k8e/sandbox/`. The gRPC client
+reads the same certs, so **no separate credential setup** is needed.
+
+Sanity-check the gateway:
+
+```sh
+k8e-sandbox-cli status          # -> {"available": true, ...}
+k8e-sandbox-cli run 'echo hi'   # -> {"stdout":"hi\n", "exit_code":0, ...}
+```
+
+## Step 2 — install the bundle into a dsh profile
+
+```sh
+# from this workspace's parent (where the package dirs resolve)
+dsh plugin --profile k8e add ./packages/dsh-k8e-sandbox-bundle
+
+# verify the layer, then boot
+dsh --profile k8e --dump-config    # shows a "# == @k8e/dsh-k8e-sandbox-bundle" layer
+dsh --profile k8e
+```
+
+The bundle's `cordis.patch.yml` mounts `@k8e/dsh-k8e-sandbox` (owner),
+`@k8e/dsh-k8e-sandbox-fs`, and `@k8e/dsh-k8e-sandbox-subprocess`.
+
+> The profile's own `cordis.patch.yml` (`$DSH_HOME/profiles/k8e/cordis.patch.yml`)
+> can override the owner row by `id: k8e-sandbox` to set `endpoint` (see below).
+
+## Step 3 — configure endpoint (Phase 2 required)
+
+Phase 1 (filesystem + single-shot exec) works through `k8e-sandbox-cli` with
+no endpoint. Phase 2 (`spawnTerminal` + streaming `spawn`) needs the direct
+gRPC endpoint, because the gRPC client does no local auto-discovery.
+
+Add to the profile patch (restate the fields you keep):
+
+```yaml
+# $DSH_HOME/profiles/k8e/cordis.patch.yml
+- id: k8e-sandbox
+  name: '@k8e/dsh-k8e-sandbox'
+  config:
+    endpoint: 127.0.0.1:50051     # or the remote gateway host:port
+    cwd: /workspace
+    runtimeClass: gvisor
+```
+
+Without `endpoint`, `getGrpcClient()` fails loud when a terminal is requested —
+that is intentional, not a silent fallback.
+
+## Step 4 — verify filesystem (`ctx.fs`)
+
+In a dsh session under the `k8e` profile, ask the agent to read/write/list, or
+drive the tools directly. Confirm the operation landed in the sandbox pod, not
+the host:
+
+```sh
+k8e-sandbox-cli sessions          # an Active session exists
+k8e-sandbox-cli list <sid>        # the written file shows up under /workspace
+k8e-sandbox-cli read <sid> /workspace/hello.txt
+```
+
+## Step 5 — verify exec (`ctx.subprocess` / bash)
+
+Ask the agent to run a shell command (the `bash` tool). It should complete and
+report output. Confirm from the outside:
+
+```sh
+k8e-sandbox-cli log <sid>         # the exec transcript shows the command
+k8e-sandbox-cli ps <sid>          # (during a long command) the process is in the pod
+```
+
+## Step 6 — verify terminal (`spawnTerminal`, Phase 2)
+
+Open a persistent terminal (the `terminal` tool) in the dsh session. It should
+allocate a PTY in the sandbox pod:
+
+```sh
+k8e-sandbox-cli ps <sid>          # the shell (e.g. bash) is the session leader
+```
+
+Inside the terminal, check job control and window size:
+
+```sh
+tty                               # -> /dev/pts/N  (a real PTY, not a pipe)
+stty size                         # reflects rows/cols sent by the harness
+# Ctrl-C should interrupt the foreground job (SIGINT via the PTY)
+```
+
+## What to check
+
+| Capability | Phase | Success signal |
+|---|---|---|
+| filesystem read/write/list/edit | 1 | files appear under `/workspace` in the sandbox |
+| exec (`bash`) | 1 (CLI) / 2 (streaming) | stdout streams back, exit code correct |
+| terminal (`spawnTerminal`) | 2 | `/dev/pts/N`, Ctrl-C / resize / foreground signal work |
+| teardown | 1 | disposing the dsh session destroys the sandbox session (`k8e-sandbox-cli sessions` empties) |
+
+## Known limitations
+
+- The KIP-19 `/exec/stream` sandboxd endpoint frames output as raw `data: <raw>`
+  SSE; output containing `\n\n` can split a frame. `GrpcK8eClient.execStream`
+  inherits this until `/exec/stream` is switched to base64 framing (as
+  `/pty/stream` already does). `/pty/stream` (terminal output) is unaffected.
+- The gRPC client reads static certs from `~/.k8e/sandbox/`; it does not yet do
+  the KIP-14 lazy client-cert renewal. Long-running sessions should re-run
+  `k8e-sandbox-cli connect` before the 90-day cert expires (auto-renew kicks in
+  at <30 days for CLI-managed flows).
+- Terminals are pod-scoped: pausing/resuming or recycling the session pod kills
+  them (KIP-19).

--- a/plugins/deepseek-harness/package.json
+++ b/plugins/deepseek-harness/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dsh-k8e-sandbox-workspace",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module"
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
@@ -1,0 +1,16 @@
+# Mounts the k8e-sandbox execution world: one sandbox owner service plus the
+# filesystem and subprocess providers. Loading order matters — the owner must
+# mount first (fs/subprocess inject `k8eSandbox`), which Cordis dependency
+# injection guarantees regardless of row order.
+- insert:
+    - id: k8e-sandbox
+      name: '@k8e/dsh-k8e-sandbox'
+      config:
+        # endpoint / profile resolve like k8e-sandbox-cli; leave unset for
+        # local auto-discovery via ~/.k8e/sandbox (KIP-17).
+        cwd: /workspace
+        runtimeClass: gvisor
+    - id: k8e-sandbox-fs
+      name: '@k8e/dsh-k8e-sandbox-fs'
+    - id: k8e-sandbox-subprocess
+      name: '@k8e/dsh-k8e-sandbox-subprocess'

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox-bundle",
+  "version": "0.1.0",
+  "description": "Installable dsh bundle mounting the k8e-sandbox execution world (KIP-20).",
+  "type": "module",
+  "files": ["cordis.patch.yml"],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "dependencies": {
+    "@k8e/dsh-k8e-sandbox": "workspace:*",
+    "@k8e/dsh-k8e-sandbox-fs": "workspace:*",
+    "@k8e/dsh-k8e-sandbox-subprocess": "workspace:*"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox-client",
+  "version": "0.1.0",
+  "description": "k8e-sandbox transport: Phase 1 CLI client (wraps k8e-sandbox-cli).",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": ["lib"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@k8e/dsh-k8e-sandbox-client",
   "version": "0.1.0",
-  "description": "k8e-sandbox transport: Phase 1 CLI client (wraps k8e-sandbox-cli).",
+  "description": "k8e-sandbox transport: CLI client (Phase 1) + gRPC terminal client (Phase 2).",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -9,11 +9,19 @@
     ".": {
       "types": "./lib/index.d.ts",
       "default": "./lib/index.js"
+    },
+    "./grpc": {
+      "types": "./lib/grpc.d.ts",
+      "default": "./lib/grpc.js"
     }
   },
-  "files": ["lib"],
+  "files": ["lib", "proto"],
   "scripts": {
     "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.12.0",
+    "@grpc/proto-loader": "^0.7.13"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/proto/sandbox.proto
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/proto/sandbox.proto
@@ -1,0 +1,335 @@
+syntax = "proto3";
+package sandbox.v1;
+option go_package = "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1;pb";
+
+service SandboxService {
+  rpc CreateSession(CreateSessionRequest)   returns (CreateSessionResponse);
+  rpc GetSession(GetSessionRequest)         returns (GetSessionResponse);
+  rpc ListSessions(ListSessionsRequest)     returns (ListSessionsResponse);
+  rpc DestroySession(DestroySessionRequest) returns (DestroySessionResponse);
+  // PauseSession releases the sandbox pod (CPU/memory) while keeping the
+  // workspace PVC and session CRD; a paused sandbox resumes via ResumeSession
+  // with its filesystem intact (E2B pause semantics, KIP-18).
+  rpc PauseSession(PauseSessionRequest)   returns (PauseSessionResponse);
+  rpc ResumeSession(ResumeSessionRequest) returns (ResumeSessionResponse);
+  rpc Exec(ExecRequest)                     returns (ExecResponse);
+  rpc ExecStream(ExecRequest)               returns (stream ExecStreamResponse);
+  rpc WriteFile(WriteFileRequest)           returns (WriteFileResponse);
+  rpc ReadFile(ReadFileRequest)             returns (ReadFileResponse);
+  rpc ListFiles(ListFilesRequest)           returns (ListFilesResponse);
+  rpc PipInstall(PipInstallRequest)         returns (PipInstallResponse);
+  rpc RunSubAgent(RunSubAgentRequest)       returns (RunSubAgentResponse);
+  rpc ConfirmAction(ConfirmActionRequest)   returns (ConfirmActionResponse);
+  rpc ApproveAction(ApproveActionRequest)   returns (ApproveActionResponse);
+  // Login authenticates the client and returns a signed X.509 certificate for mTLS.
+  // First login: pass API key via gRPC metadata (authorization: Bearer <key>).
+  // Renewal: present existing valid client cert via mTLS — no API key needed.
+  rpc Login(LoginRequest) returns (LoginResponse);
+  // PollRun checks the status of a background execution.
+  rpc PollRun(PollRunRequest)               returns (PollRunResponse);
+  // GetTranscript reads a bounded window of a session's exec transcript
+  // (file-backed, offset-resumable; KIP-16 M4 / issue #512).
+  rpc GetTranscript(GetTranscriptRequest)   returns (GetTranscriptResponse);
+  // GetEvents reads the daemon's NDJSON event stream (exec/files/bg events;
+  // KIP-16 M5 / issue #513).
+  rpc GetEvents(GetEventsRequest)           returns (GetEventsResponse);
+  // Snapshot layer registry (server-side, KIP-16 M2 / issue #511):
+  // content-addressed snapshot artifacts hosted by the gateway.
+  rpc SnapshotPut(SnapshotPutRequest)       returns (SnapshotPutResponse);
+  rpc SnapshotGet(SnapshotGetRequest)       returns (SnapshotGetResponse);
+  rpc SnapshotList(SnapshotListRequest)     returns (SnapshotListResponse);
+  // GetProcesses lists processes in the sandbox pod (KIP-16 M5 process topology).
+  rpc GetProcesses(GetProcessesRequest)     returns (GetProcessesResponse);
+  // ── PTY terminal primitive (KIP-19) ───────────────────────────────────────
+  // CreateTerminal allocates a PTY and starts argv as a controlling-terminal
+  // session leader (argv is NOT shell-interpreted).
+  rpc CreateTerminal(CreateTerminalRequest) returns (CreateTerminalResponse);
+  // TerminalStream streams terminal output bytes; the final frame carries
+  // TerminalExit (exit code / signal) when the top-level process closes.
+  rpc TerminalStream(TerminalStreamRequest) returns (stream TerminalStreamResponse);
+  rpc TerminalWrite(TerminalWriteRequest)   returns (TerminalWriteResponse);
+  rpc TerminalResize(TerminalResizeRequest) returns (TerminalResizeResponse);
+  rpc TerminalForeground(TerminalForegroundRequest) returns (TerminalForegroundResponse);
+  rpc TerminalSignal(TerminalSignalRequest) returns (TerminalSignalResponse);
+  rpc TerminalDestroy(TerminalDestroyRequest) returns (TerminalDestroyResponse);
+}
+
+// SecretRef references a key in a same-namespace K8s Secret. Values are resolved
+// at exec time only and never stored on the SandboxSession CRD (#505 / KIP-12 B).
+message SecretRef {
+  string secret_name = 1; // K8s Secret name
+  string key         = 2; // key within Secret.data
+  string env_var     = 3; // environment variable name injected into the process
+}
+
+message CreateSessionRequest {
+  string          session_id     = 1;
+  string          tenant_id      = 2;
+  repeated string allowed_hosts  = 3;
+  string          runtime_class  = 4;
+  // Non-sensitive environment variables persisted on the SandboxSession and
+  // applied at exec time so warm-pool pods stay reusable (KIP-12 Part B / #483).
+  map<string, string> env        = 5;
+  repeated SecretRef  secret_refs = 6;
+}
+message CreateSessionResponse {
+  string session_id = 1;
+  string pod_ip     = 2;
+}
+
+message GetSessionRequest  { string session_id = 1; }
+message GetSessionResponse {
+  string          session_id     = 1;
+  string          phase          = 2;
+  string          runtime_class  = 3;
+  string          pod_ip         = 4;
+  string          tenant_id      = 5;
+  int64           expires_at     = 6; // unix seconds; 0 if none
+  repeated string env_keys       = 7; // keys only, never values
+  repeated string secret_env_vars = 8; // env_var names from secret_refs only
+  int32           background_runs = 9; // active entries known to gateway registry
+}
+
+message ListSessionsRequest {
+  string phase = 1; // empty = Active only; "all" = every phase
+}
+message ListSessionsResponse {
+  repeated GetSessionResponse sessions = 1;
+}
+
+message DestroySessionRequest  { string session_id = 1; }
+message DestroySessionResponse { bool   ok         = 1; }
+
+message PauseSessionRequest  { string session_id = 1; }
+message PauseSessionResponse { bool   ok         = 1; }
+
+message ResumeSessionRequest  { string session_id = 1; }
+message ResumeSessionResponse { bool   ok         = 1; }
+
+message ExecRequest {
+  string session_id = 1;
+  string command    = 2;
+  int32  timeout    = 3;
+  string workdir    = 4;
+  bool   background = 5;  // submit asynchronously, return run_id immediately
+  string language   = 6;  // optional hint: python|bash|node|ts (observability)
+}
+message ExecResponse {
+  string stdout      = 1;
+  string stderr      = 2;
+  int32  exit_code   = 3;
+  string session_id  = 4;
+  string run_id      = 5;  // set when background=true
+  // started|running|completed|timed_out|failed
+  string status      = 6;
+  int64  duration_ms = 7;  // wall-clock ms for this execution (0 if unknown/started)
+  bool   truncated   = 8;  // stdout and/or stderr hit size cap
+  string language    = 9;  // echoed from request when set
+}
+message ExecStreamResponse { string chunk = 1; }
+
+message WriteFileRequest {
+  string session_id = 1;
+  string path       = 2;
+  string content    = 3;
+  string mode       = 4;
+}
+message WriteFileResponse { bool ok = 1; }
+
+message ReadFileRequest  { string session_id = 1; string path = 2; }
+message ReadFileResponse { string content    = 1; }
+
+message ListFilesRequest  {
+  string session_id = 1;
+  // Return only files modified after this unix timestamp (0 = all).
+  int64  since      = 2;
+}
+message ListFilesResponse { repeated FileEntry files = 1; }
+message FileEntry         { string path = 1; int64 modified = 2; }
+
+message PipInstallRequest  { string session_id = 1; repeated string packages = 2; }
+message PipInstallResponse { string output = 1; int32 exit_code = 2; }
+
+message RunSubAgentRequest {
+  string parent_session_id = 1;
+  string agent_type        = 2;
+  string workspace_path    = 3;
+}
+message RunSubAgentResponse { string session_id = 1; }
+
+message ConfirmActionRequest {
+  string session_id  = 1;
+  string action      = 2;
+  string approval_id = 3;
+}
+message ConfirmActionResponse {
+  string approval_id = 1;
+  bool   approved    = 2;
+}
+
+message ApproveActionRequest {
+  string approval_id = 1;
+  bool   approved    = 2;
+  string reason      = 3;
+}
+
+message ApproveActionResponse {
+  bool ok = 1;
+}
+
+message LoginRequest {
+  string csr            = 1;  // PEM-encoded PKCS#10 certificate signing request
+  string device_name    = 2;  // e.g. hostname, for audit logging
+  string client_version = 3;  // k8e version, for audit logging
+}
+message LoginResponse {
+  string cert       = 1;  // PEM-encoded signed client certificate
+  string ca_cert    = 2;  // PEM-encoded sandbox CA certificate (trust anchor)
+  int64  valid_days = 3;  // days the certificate is valid
+}
+
+message PollRunRequest  { string run_id = 1; }
+message PollRunResponse {
+  string run_id      = 1;
+  // started|running|completed|failed|timed_out|not_found
+  string status      = 2;
+  string stdout      = 3;
+  string stderr      = 4;
+  int32  exit_code   = 5;
+  int64  duration_ms = 6;
+  bool   truncated   = 7;
+}
+
+// GetTranscriptRequest reads a file-backed exec transcript window.
+message GetTranscriptRequest {
+  string session_id = 1;
+  // Byte offset to start reading from. 0 = start of transcript.
+  int64  offset     = 2;
+  // Max bytes to return in this window. 0 = server default (64 KiB).
+  int64  limit      = 3;
+}
+message GetTranscriptResponse {
+  string session_id = 1;
+  string output     = 2;      // window content, line-aligned
+  int64  offset     = 3;      // absolute offset this window starts at
+  int64  next_offset = 4;     // offset for the next window; == file size at EOF
+  bool   truncated_before = 5; // true when the window starts mid-file (lines were skipped)
+  bool   eof        = 6;      // true when next_offset reached the end of the transcript
+}
+
+// GetEventsRequest reads the daemon NDJSON event stream (KIP-16 M5).
+message GetEventsRequest {
+  // Empty = all events (daemon-wide). When set, only events for this session.
+  string session_id = 1;
+  // Max events to return in this call (0 = server default 500).
+  int64  limit      = 2;
+}
+message GetEventsResponse {
+  repeated string events = 1; // raw NDJSON lines
+  bool   truncated       = 2; // more events exist beyond the returned window
+  int64  returned        = 3; // number of lines returned
+}
+
+// SnapshotPutRequest stores one content-addressed layer (or a whole chunked
+// manifest) in the server-side registry.
+message SnapshotPutRequest {
+  string name    = 1; // snapshot name (manifest id)
+  repeated string layers = 2; // layer digests to publish as this snapshot's manifest
+}
+message SnapshotPutResponse {
+  string name = 1;
+  int64  layers = 2; // number of layers published
+}
+
+message SnapshotGetRequest {
+  string name = 1; // manifest name
+}
+message SnapshotGetResponse {
+  string name   = 1;
+  repeated string layers = 2; // ordered layer digests of the manifest
+}
+
+message SnapshotListRequest {}
+message SnapshotListResponse {
+  repeated string names = 1; // manifest names
+}
+
+// GetProcessesRequest lists processes visible in the sandbox pod's pid
+// namespace (KIP-16 M5 follow-up: namespace-identity process topology).
+message GetProcessesRequest {
+  string session_id = 1;
+}
+message ProcessInfo {
+  int32  pid    = 1;
+  string comm   = 2;
+  string state  = 3; // single char: R/S/D/Z/...
+}
+message GetProcessesResponse {
+  repeated ProcessInfo processes = 1;
+}
+
+// ── PTY terminal primitive (KIP-19) ─────────────────────────────────────────
+
+message CreateTerminalRequest {
+  string session_id = 1;
+  repeated string argv = 2;   // argv[0] is the program; NOT shell-interpreted
+  string workdir = 3;
+  map<string, string> env = 4; // non-sensitive env; secrets stay in CreateSession.secret_refs
+  int32  rows = 5;            // initial window rows (>=1)
+  int32  cols = 6;            // initial window cols (>=1)
+}
+message CreateTerminalResponse {
+  string terminal_id = 1;     // opaque branded handle for all terminal RPCs
+  int32  pid = 2;             // session-leader pid in the sandbox pid space
+}
+
+message TerminalStreamRequest { string terminal_id = 1; }
+message TerminalStreamResponse {
+  oneof frame {
+    bytes data = 1;           // terminal output bytes in delivery order
+    TerminalExit exit = 2;    // final frame: top-level process closed
+  }
+}
+message TerminalExit {
+  int32  exit_code = 1;       // process exit code; 0 = clean
+  string signal    = 2;       // terminating signal name; empty = normal exit
+}
+
+message TerminalWriteRequest {
+  string terminal_id = 1;
+  bytes  data = 2;            // raw bytes, no implicit newline
+}
+message TerminalWriteResponse { bool ok = 1; }
+
+message TerminalResizeRequest {
+  string terminal_id = 1;
+  int32 rows = 2;
+  int32 cols = 3;
+}
+message TerminalResizeResponse { bool ok = 1; }
+
+message TerminalForegroundRequest { string terminal_id = 1; }
+message TerminalForegroundResponse {
+  int32 process_group_id = 1; // current foreground pgid; -1 when unresolvable
+  bool  input_waiting = 2;    // best-effort; false means "not provable" (KIP-19)
+}
+
+enum TerminalSignal {
+  TERMINAL_SIGNAL_UNSPECIFIED = 0;
+  TERMINAL_SIGNAL_INT  = 1;   // SIGINT
+  TERMINAL_SIGNAL_TERM = 2;   // SIGTERM
+  TERMINAL_SIGNAL_KILL = 3;   // SIGKILL
+  TERMINAL_SIGNAL_TSTP = 4;   // SIGTSTP
+  TERMINAL_SIGNAL_HUP  = 5;   // SIGHUP
+}
+message TerminalSignalRequest {
+  string terminal_id = 1;
+  TerminalSignal signal = 2;
+}
+message TerminalSignalResponse { int32 process_group_id = 1; } // pgid that received the signal
+
+message TerminalDestroyRequest {
+  string terminal_id = 1;
+  int32  grace_ms = 2;        // TERM -> grace -> KILL escalation bound
+}
+message TerminalDestroyResponse { bool ok = 1; }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 2 k8e-sandbox transport: a direct gRPC client (mTLS) for the terminal
+ * primitive. Loads the bundled `sandbox.proto` at runtime via
+ * @grpc/proto-loader; mTLS material comes from the CLI's cert dir
+ * (~/.k8e/sandbox, KIP-14/KIP-17), shared with `k8e-sandbox-cli`.
+ * @module @k8e/dsh-k8e-sandbox-client/grpc
+ */
+
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import * as grpc from '@grpc/grpc-js'
+import { loadPackageDefinition, loadSync } from '@grpc/proto-loader'
+
+/** Terminal signal names shared with sandboxd /pty/signal. */
+export type TerminalSignal = 'SIGINT' | 'SIGTERM' | 'SIGKILL' | 'SIGTSTP' | 'SIGHUP'
+
+export interface CreateTerminalResponse {
+  terminalId: string
+  pid: number
+}
+
+export interface TerminalExit {
+  exitCode: number
+  signal: string
+}
+
+export interface TerminalForegroundResponse {
+  processGroupId: number
+  inputWaiting: boolean
+}
+
+export interface GrpcK8eClientOptions {
+  /** gRPC gateway `host:port`. */
+  endpoint: string
+  /** mTLS material dir holding ca.crt / client.crt / client.key. */
+  certDir?: string
+  /** Path to the bundled sandbox.proto. */
+  protoPath?: string
+}
+
+// Dynamic client surface produced by proto-loader; typed loosely here.
+interface SandboxServiceClient {
+  createTerminal(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalWrite(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalResize(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalForeground(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalSignal(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalDestroy(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalStream(request: unknown, metadata: grpc.Metadata): grpc.ClientReadableStream<any>
+}
+
+function defaultCertDir(): string {
+  return process.env.K8E_SANDBOX_CERT_DIR ?? join(homedir(), '.k8e', 'sandbox')
+}
+
+function createCredentials(certDir: string): grpc.ChannelCredentials {
+  const read = (name: string): Buffer | undefined => {
+    try {
+      return readFileSync(join(certDir, name))
+    } catch {
+      return undefined
+    }
+  }
+  const caCert = read('ca.crt')
+  const clientCert = read('client.crt')
+  const clientKey = read('client.key')
+  if (caCert !== undefined && clientCert !== undefined && clientKey !== undefined) {
+    return grpc.credentials.createSsl(caCert, clientKey, clientCert)
+  }
+  if (caCert !== undefined) {
+    return grpc.credentials.createSsl(caCert)
+  }
+  return grpc.credentials.createSsl()
+}
+
+function terminalSignalEnum(signal: TerminalSignal): number {
+  switch (signal) {
+    case 'SIGINT': return 1
+    case 'SIGTERM': return 2
+    case 'SIGKILL': return 3
+    case 'SIGTSTP': return 4
+    case 'SIGHUP': return 5
+  }
+}
+
+/**
+ * Direct gRPC client for the sandbox gateway's PTY terminal primitive. Phase 2
+ * uses this for `spawnTerminal`; Phase 1 shells out to the CLI for the rest.
+ */
+export class GrpcK8eClient {
+  private readonly client: SandboxServiceClient
+  private readonly metadata = new grpc.Metadata()
+
+  constructor(private readonly opts: GrpcK8eClientOptions) {
+    const protoPath = opts.protoPath ?? join(import.meta.dirname, '..', 'proto', 'sandbox.proto')
+    const definition = loadSync(protoPath, {
+      keepCase: false,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true,
+    })
+    const pkg = loadPackageDefinition(definition) as any
+    const SandboxService = pkg.sandbox.v1.SandboxService
+    this.client = new SandboxService(opts.endpoint, createCredentials(opts.certDir ?? defaultCertDir())) as SandboxServiceClient
+  }
+
+  private call<T>(
+    method: (req: unknown, md: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void) => grpc.ClientUnaryCall,
+    request: unknown,
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      method.call(this.client, request, this.metadata, (err, resp) => {
+        if (err !== null) reject(err)
+        else resolve(resp as T)
+      })
+    })
+  }
+
+  async createTerminal(request: { sessionId: string; argv: string[]; workdir?: string; env?: Record<string, string>; rows: number; cols: number }): Promise<CreateTerminalResponse> {
+    const resp = await this.call<any>(this.client.createTerminal, {
+      session_id: request.sessionId,
+      argv: request.argv,
+      workdir: request.workdir ?? '/workspace',
+      env: request.env ?? {},
+      rows: request.rows,
+      cols: request.cols,
+    })
+    return { terminalId: resp.terminal_id as string, pid: resp.pid as number }
+  }
+
+  async terminalWrite(terminalId: string, data: Uint8Array): Promise<void> {
+    await this.call(this.client.terminalWrite, { terminal_id: terminalId, data })
+  }
+
+  async terminalResize(terminalId: string, rows: number, cols: number): Promise<void> {
+    await this.call(this.client.terminalResize, { terminal_id: terminalId, rows, cols })
+  }
+
+  async terminalForeground(terminalId: string): Promise<TerminalForegroundResponse> {
+    const resp = await this.call<any>(this.client.terminalForeground, { terminal_id: terminalId })
+    return { processGroupId: resp.process_group_id as number, inputWaiting: resp.input_waiting as boolean }
+  }
+
+  async terminalSignal(terminalId: string, signal: TerminalSignal): Promise<number> {
+    const resp = await this.call<any>(this.client.terminalSignal, {
+      terminal_id: terminalId,
+      signal: terminalSignalEnum(signal),
+    })
+    return resp.process_group_id as number
+  }
+
+  async terminalDestroy(terminalId: string, graceMs: number): Promise<void> {
+    await this.call(this.client.terminalDestroy, { terminal_id: terminalId, grace_ms: graceMs })
+  }
+
+  /** Open the terminal output stream; the stream yields data frames then a final exit frame. */
+  terminalStream(terminalId: string): grpc.ClientReadableStream<any> {
+    return this.client.terminalStream({ terminal_id: terminalId }, this.metadata)
+  }
+
+  close(): void {
+    ;(this.client as unknown as grpc.Client).close()
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 import type { Readable } from 'node:stream'
 import * as grpc from '@grpc/grpc-js'
-import { loadPackageDefinition, loadSync } from '@grpc/proto-loader'
+import { loadSync } from '@grpc/proto-loader'
 
 /** Terminal signal names shared with sandboxd /pty/signal. */
 export type TerminalSignal = 'SIGINT' | 'SIGTERM' | 'SIGKILL' | 'SIGTSTP' | 'SIGHUP'
@@ -112,7 +112,7 @@ export class GrpcK8eClient {
       defaults: true,
       oneofs: true,
     })
-    const pkg = loadPackageDefinition(definition) as any
+    const pkg = grpc.loadPackageDefinition(definition) as any
     const SandboxService = pkg.sandbox.v1.SandboxService
     this.client = new SandboxService(opts.endpoint, createCredentials(opts.certDir ?? defaultCertDir())) as SandboxServiceClient
   }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -9,6 +9,8 @@
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import type { Readable } from 'node:stream'
 import * as grpc from '@grpc/grpc-js'
 import { loadPackageDefinition, loadSync } from '@grpc/proto-loader'
 
@@ -30,6 +32,13 @@ export interface TerminalForegroundResponse {
   inputWaiting: boolean
 }
 
+export interface ExecStreamResult {
+  /** Merged stdout+stderr, decoded from the gateway's SSE stream. */
+  stdout: Readable
+  /** Resolves when the process exits (exit frame observed or stream closed). */
+  done: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>
+}
+
 export interface GrpcK8eClientOptions {
   /** gRPC gateway `host:port`. */
   endpoint: string
@@ -48,6 +57,8 @@ interface SandboxServiceClient {
   terminalSignal(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
   terminalDestroy(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
   terminalStream(request: unknown, metadata: grpc.Metadata): grpc.ClientReadableStream<any>
+  execStream(request: unknown, metadata: grpc.Metadata): grpc.ClientReadableStream<any>
+  exec(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
 }
 
 function defaultCertDir(): string {
@@ -158,6 +169,60 @@ export class GrpcK8eClient {
   /** Open the terminal output stream; the stream yields data frames then a final exit frame. */
   terminalStream(terminalId: string): grpc.ClientReadableStream<any> {
     return this.client.terminalStream({ terminal_id: terminalId }, this.metadata)
+  }
+
+  /**
+   * Run one command with streaming merged output. The gateway forwards
+   * sandboxd's SSE (`data: {"pid":N}`, `data: <raw>`, `data: {"exit":N}`) as
+   * raw chunks; this decodes them into a clean stdout stream plus an exit
+   * promise.
+   */
+  execStream(sessionId: string, command: string): ExecStreamResult {
+    const stdout = new PassThrough()
+    const stream = this.client.execStream({ session_id: sessionId, command }, this.metadata)
+
+    let buffer = ''
+    let exitCode: number | null = null
+    let settled = false
+
+    const done = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      const settle = (signal: NodeJS.Signals | null): void => {
+        stdout.end()
+        if (!settled) {
+          settled = true
+          resolve({ exitCode, signal })
+        }
+      }
+      stream.on('data', (chunk: Buffer | string) => {
+        buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+        while (true) {
+          const idx = buffer.indexOf('\n\n')
+          if (idx < 0) break
+          const event = buffer.slice(0, idx)
+          buffer = buffer.slice(idx + 2)
+          if (!event.startsWith('data: ')) continue
+          const payload = event.slice('data: '.length)
+          if (payload.startsWith('{"pid"')) continue
+          if (payload.startsWith('{"exit"')) {
+            const m = /"exit":(-?\d+)/.exec(payload)
+            exitCode = m === null ? 0 : Number(m[1])
+            settle(null)
+            continue
+          }
+          stdout.write(payload)
+        }
+      })
+      stream.on('error', (err) => {
+        stdout.destroy(err instanceof Error ? err : new Error(String(err)))
+        if (!settled) {
+          settled = true
+          reject(err instanceof Error ? err : new Error(String(err)))
+        }
+      })
+      stream.on('end', () => settle(null))
+    })
+
+    return { stdout, done }
   }
 
   close(): void {

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
@@ -1,0 +1,166 @@
+/**
+ * Phase 1 k8e-sandbox transport: shell out to `k8e-sandbox-cli`, reusing its
+ * mTLS, profile, and session-state handling. Each operation is one process
+ * spawn; Phase 2 replaces this with a direct gRPC client for streaming
+ * fidelity (KIP-20).
+ * @module @k8e/dsh-k8e-sandbox-client
+ */
+
+import { spawn } from 'node:child_process'
+
+/** Result of a single-shot sandbox exec (`k8e-sandbox-cli run`). */
+export interface ExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+  sessionId: string
+  status: string
+  durationMs: number
+  truncated: boolean
+  language: string
+}
+
+/** Result of a background submit (`run --background`). */
+export interface BackgroundResult {
+  runId: string
+  status: string
+  sessionId: string
+}
+
+/** Result of a poll (`k8e-sandbox-cli poll <run-id>`). */
+export interface PollResult {
+  runId: string
+  status: string
+  stdout: string
+  stderr: string
+  exitCode: number
+  durationMs: number
+  truncated: boolean
+}
+
+export interface FileEntry {
+  path: string
+  modified: number
+}
+
+export interface CreateSessionOptions {
+  runtimeClass?: string
+  tenant?: string
+  allowedHosts?: string[]
+}
+
+export interface StatusResult {
+  available: boolean
+  sessionId: string
+  tenantId: string
+  error: string
+}
+
+/** Options for the CLI-backed transport. */
+export interface CliK8eClientOptions {
+  /** Path to the k8e-sandbox-cli binary; defaults to `k8e-sandbox-cli` on PATH. */
+  bin?: string
+  /** Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17). */
+  profile?: string
+  /** gRPC gateway endpoint override. */
+  endpoint?: string
+}
+
+interface CliResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+function runCli(args: string[], opts: CliK8eClientOptions, stdin?: string): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const full: string[] = []
+    if (opts.profile) full.push('--profile', opts.profile)
+    if (opts.endpoint) full.push('--endpoint', opts.endpoint)
+    full.push(...args)
+
+    const child = spawn(opts.bin ?? 'k8e-sandbox-cli', full, { stdio: ['pipe', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString() })
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
+    child.on('error', reject)
+    child.on('close', (code) => { resolve({ stdout, stderr, exitCode: code ?? -1 }) })
+    if (stdin !== undefined) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+function parseJSON<T>(result: CliResult, what: string): T {
+  if (result.exitCode !== 0) {
+    throw new Error(`k8e-sandbox-cli ${what} failed (exit ${result.exitCode}): ${result.stderr.trim()}`)
+  }
+  try {
+    return JSON.parse(result.stdout) as T
+  } catch (cause) {
+    throw new Error(`k8e-sandbox-cli ${what} returned invalid JSON: ${result.stdout}`, { cause })
+  }
+}
+
+/** CLI-backed k8e-sandbox client. */
+export class CliK8eClient {
+  constructor(private readonly opts: CliK8eClientOptions = {}) {}
+
+  /** Run one command in the sandbox and collect stdout/stderr/exit code. */
+  async run(code: string, opts: { lang?: string; timeout?: number; sessionId?: string; tenant?: string } = {}): Promise<ExecResult> {
+    const args = ['run', code]
+    if (opts.lang) args.push('--lang', opts.lang)
+    if (opts.timeout !== undefined) args.push('--timeout', String(opts.timeout))
+    if (opts.sessionId) args.push('--session-id', opts.sessionId)
+    if (opts.tenant) args.push('--tenant', opts.tenant)
+    return parseJSON<ExecResult>(await runCli(args, this.opts), 'run')
+  }
+
+  /** Submit asynchronously; returns a run id to poll. */
+  async runBackground(code: string, opts: { lang?: string; sessionId?: string; tenant?: string } = {}): Promise<BackgroundResult> {
+    const args = ['run', code, '--background']
+    if (opts.lang) args.push('--lang', opts.lang)
+    if (opts.sessionId) args.push('--session-id', opts.sessionId)
+    if (opts.tenant) args.push('--tenant', opts.tenant)
+    return parseJSON<BackgroundResult>(await runCli(args, this.opts), 'run --background')
+  }
+
+  async poll(runId: string): Promise<PollResult> {
+    return parseJSON<PollResult>(await runCli(['poll', runId], this.opts), 'poll')
+  }
+
+  async write(sessionId: string, path: string, content: string): Promise<void> {
+    await parseJSON<{ ok: boolean }>(await runCli(['write', sessionId, path], this.opts, content), 'write')
+  }
+
+  async read(sessionId: string, path: string): Promise<string> {
+    const result = await runCli(['read', sessionId, path, '--raw'], this.opts)
+    if (result.exitCode !== 0) {
+      throw new Error(`k8e-sandbox-cli read failed (exit ${result.exitCode}): ${result.stderr.trim()}`)
+    }
+    return result.stdout
+  }
+
+  async list(sessionId: string, since?: number): Promise<FileEntry[]> {
+    const args = ['list', sessionId]
+    if (since !== undefined) args.push('--since', String(since))
+    const out = await parseJSON<{ files: FileEntry[] }>(await runCli(args, this.opts), 'list')
+    return out.files ?? []
+  }
+
+  async createSession(opts: CreateSessionOptions = {}): Promise<{ sessionId: string; podIp: string }> {
+    const args = ['create']
+    if (opts.runtimeClass) args.push('--runtime', opts.runtimeClass)
+    if (opts.tenant) args.push('--tenant', opts.tenant)
+    if (opts.allowedHosts?.length) args.push('--allowed-hosts', opts.allowedHosts.join(','))
+    return parseJSON<{ sessionId: string; podIp: string }>(await runCli(args, this.opts), 'create')
+  }
+
+  async destroySession(sessionId: string): Promise<void> {
+    await parseJSON<{ ok: boolean }>(await runCli(['destroy', sessionId], this.opts), 'destroy')
+  }
+
+  async status(): Promise<StatusResult> {
+    return parseJSON<StatusResult>(await runCli(['status'], this.opts), 'status')
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox-fs",
+  "version": "0.1.0",
+  "description": "k8e-sandbox filesystem seam provider for DeepSeek Harness (ctx.fs).",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": ["lib"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@k8e/dsh-k8e-sandbox": "workspace:*"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-fs": "*"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-fs": "*",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
@@ -165,12 +165,13 @@ export class K8eFileSystem extends FileSystem {
     }
     const client = (await this.runtime()).getClient()
     const sid = await this.session()
-    const before = await this.stat(target, signal).then((info) => info ?? null)
+    const existing = await this.stat(target, signal)
+    const before = existing === undefined ? null : await this.readText(target, signal)
     await client.write(sid, this.processPath(target), content)
-    const after = await this.probe(this.processPath(target))
+    const facts = await this.probe(this.processPath(target))
     return {
-      operation: before === null ? 'create' : 'update',
-      version: after?.version ?? FsVersion('k8e:unknown'),
+      operation: existing === undefined ? 'create' : 'update',
+      version: facts?.version ?? FsVersion('k8e:unknown'),
       before,
       after: content,
     }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
@@ -1,0 +1,209 @@
+/**
+ * k8e-sandbox Service Provider for the filesystem capability seam. Paths and
+ * contents live in the sandbox workspace; operations shell out to
+ * `k8e-sandbox-cli` in Phase 1 (KIP-20).
+ * @module @k8e/dsh-k8e-sandbox-fs
+ */
+
+import { Buffer } from 'node:buffer'
+import { posix } from 'node:path'
+import { Context } from '@deepseek-ai/cordis'
+import { FileSystem, FsError, FsTargetKey, FsVersion } from '@deepseek-ai/dsh-fs'
+import type {
+  FsDirEntry,
+  FsEditOutcome,
+  FsEditRequest,
+  FsInfo,
+  FsPathInfo,
+  FsTarget,
+  FsWriteIntent,
+  FsWriteOutcome,
+} from '@deepseek-ai/dsh-fs'
+import type { K8eSandboxRuntime } from '@k8e/dsh-k8e-sandbox'
+
+/** Stat facts returned by the single `stat -c` probe. */
+interface StatFacts {
+  type: FsInfo['type']
+  size: number
+  version: ReturnType<typeof FsVersion>
+}
+
+/** Remote filesystem backend sharing the session owned by `ctx.k8eSandbox`. */
+export class K8eFileSystem extends FileSystem {
+  static inject = ['k8eSandbox']
+
+  private async runtime(): Promise<K8eSandboxRuntime> {
+    return this.ctx.k8eSandbox
+  }
+
+  private async session(): Promise<string> {
+    return (await this.runtime()).getSession()
+  }
+
+  private display(path: string, cwd?: string): string {
+    return posix.resolve(cwd ?? this.ctx.k8eSandbox.cwd, path)
+  }
+
+  private shellQuote(value: string): string {
+    return `'${value.replaceAll('\'', `'"'"'`)}'`
+  }
+
+  override async resolve(path: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<FsTarget> {
+    if (path.trim().length === 0) throw new FsError('file_path must be a non-empty string', 'FS_NOT_FOUND')
+    const displayPath = this.display(path, opts?.cwd)
+    // Phase 1: no realpath round-trip; the canonical path is the resolved path.
+    return { targetKey: FsTargetKey(displayPath), displayPath }
+  }
+
+  override processPath(target: FsTarget): string {
+    return String(target.targetKey)
+  }
+
+  override fileUrl(target: FsTarget): string {
+    const path = this.processPath(target)
+    return `file://${path.split('/').map((segment) => encodeURIComponent(segment)).join('/')}`
+  }
+
+  override contains(parent: FsTarget, child: FsTarget): boolean {
+    const relative = posix.relative(this.processPath(parent), this.processPath(child))
+    return relative === '' || (relative !== '..' && !relative.startsWith('../') && !posix.isAbsolute(relative))
+  }
+
+  private async probe(path: string): Promise<StatFacts | undefined> {
+    const client = (await this.runtime()).getClient()
+    const sid = await this.session()
+    const code = `stat -c '%f|%s|%Y' ${this.shellQuote(path)} 2>/dev/null || printf 'missing'`
+    const result = await client.run(code, { sessionId: sid, timeout: 10 })
+    if (result.exitCode !== 0) throw new FsError(`cannot stat "${path}": ${result.stderr}`, 'FS_IO_ERROR')
+    const raw = result.stdout.trim()
+    if (raw === 'missing') return undefined
+    const parts = raw.split('|')
+    if (parts.length !== 3) return undefined
+    const typeHex = Number.parseInt(parts[0] ?? '', 16)
+    const size = Number.parseInt(parts[1] ?? '0', 10)
+    const type: FsInfo['type'] = typeHex === 0x4000 ? 'directory' : typeHex === 0x8000 ? 'file' : 'other'
+    const version = FsVersion(`k8e:${parts[2] ?? '0'}:${parts[1] ?? '0'}`)
+    return { type, size: Number.isFinite(size) ? size : 0, version }
+  }
+
+  override async stat(target: FsTarget, signal?: AbortSignal): Promise<FsInfo | undefined> {
+    const facts = await this.probe(this.processPath(target))
+    if (facts === undefined) return undefined
+    return { version: facts.version, type: facts.type, ...(facts.type === 'file' ? { size: facts.size } : {}) }
+  }
+
+  override async lstat(path: string, opts?: { cwd?: string }, signal?: AbortSignal): Promise<FsPathInfo | undefined> {
+    const displayPath = this.display(path, opts?.cwd)
+    const info = await this.stat({ targetKey: FsTargetKey(displayPath), displayPath }, signal)
+    if (info === undefined) return undefined
+    return info
+  }
+
+  override async readText(target: FsTarget, signal?: AbortSignal): Promise<string> {
+    const client = (await this.runtime()).getClient()
+    const sid = await this.session()
+    try {
+      return await client.read(sid, this.processPath(target))
+    } catch (cause) {
+      throw new FsError(`cannot read "${target.displayPath}": ${String(cause)}`, 'FS_IO_ERROR', { cause })
+    }
+  }
+
+  override async streamText(target: FsTarget, signal?: AbortSignal): Promise<AsyncIterable<string>> {
+    const content = await this.readText(target, signal)
+    return {
+      async *[Symbol.asyncIterator](): AsyncGenerator<string> {
+        if (content.length > 0) yield content
+      },
+    }
+  }
+
+  override async readBytes(target: FsTarget, signal: AbortSignal | undefined, maxBytes: number): Promise<Uint8Array> {
+    const content = await this.readText(target, signal)
+    const bytes = new TextEncoder().encode(content)
+    if (bytes.byteLength > maxBytes) {
+      throw new FsError(`cannot read "${target.displayPath}": ${bytes.byteLength} bytes exceeds the ${maxBytes}-byte limit`, 'FS_TOO_LARGE')
+    }
+    return bytes
+  }
+
+  override async listDir(target: FsTarget, signal?: AbortSignal): Promise<FsDirEntry[]> {
+    const client = (await this.runtime()).getClient()
+    const sid = await this.session()
+    const parent = this.processPath(target)
+    const files = await client.list(sid)
+    const prefix = parent === '/' ? '/' : `${parent}/`
+    const entries: FsDirEntry[] = []
+    for (const file of files) {
+      if (!file.path.startsWith(prefix)) continue
+      const rest = file.path.slice(prefix.length)
+      if (rest.length === 0 || rest.includes('/')) continue // only direct children
+      const childPath = file.path
+      const facts = await this.probe(childPath)
+      entries.push({
+        name: rest,
+        type: facts?.type ?? 'other',
+        target: { targetKey: FsTargetKey(childPath), displayPath: childPath },
+        ...(facts?.type === 'file' ? { size: facts.size } : {}),
+        ...(facts !== undefined ? { version: facts.version } : {}),
+      })
+    }
+    return entries.sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  override async writeText(
+    target: FsTarget,
+    content: string,
+    expected?: FsWriteIntent,
+    signal?: AbortSignal,
+  ): Promise<FsWriteOutcome> {
+    if (expected?.kind === 'createIfAbsent') {
+      const existing = await this.stat(target, signal)
+      if (existing !== undefined) {
+        throw new FsError(`cannot overwrite existing "${target.displayPath}" without reading it first`, 'FS_NOT_OBSERVED')
+      }
+    }
+    const client = (await this.runtime()).getClient()
+    const sid = await this.session()
+    const before = await this.stat(target, signal).then((info) => info ?? null)
+    await client.write(sid, this.processPath(target), content)
+    const after = await this.probe(this.processPath(target))
+    return {
+      operation: before === null ? 'create' : 'update',
+      version: after?.version ?? FsVersion('k8e:unknown'),
+      before,
+      after: content,
+    }
+  }
+
+  override async editText(
+    target: FsTarget,
+    edit: FsEditRequest,
+    expected?: { version: ReturnType<typeof FsVersion> },
+    signal?: AbortSignal,
+  ): Promise<FsEditOutcome> {
+    const before = await this.readText(target, signal)
+    const oldString = edit.oldString
+    if (oldString.length === 0) {
+      throw new FsError(`cannot edit "${target.displayPath}": old_string must be non-empty`, 'FS_EDIT_NOT_FOUND')
+    }
+    let matches = 0
+    let offset = 0
+    while (true) {
+      const found = before.indexOf(oldString, offset)
+      if (found < 0) break
+      matches += 1
+      offset = found + oldString.length
+    }
+    if (matches === 0) throw new FsError(`cannot edit "${target.displayPath}": old_string was not found`, 'FS_EDIT_NOT_FOUND')
+    if (!edit.replaceAll && matches !== 1) {
+      throw new FsError(`cannot edit "${target.displayPath}": old_string matched ${matches} times`, 'FS_AMBIGUOUS_EDIT')
+    }
+    const after = edit.replaceAll ? before.split(oldString).join(edit.newString) : before.replace(oldString, edit.newString)
+    await this.writeText(target, after, undefined, signal)
+    const version = (await this.probe(this.processPath(target)))?.version ?? FsVersion('k8e:unknown')
+    return { version, before, after }
+  }
+}
+
+export default K8eFileSystem

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox-subprocess",
+  "version": "0.1.0",
+  "description": "k8e-sandbox subprocess seam provider for DeepSeek Harness (ctx.subprocess).",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": ["lib"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@k8e/dsh-k8e-sandbox": "workspace:*"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-subprocess": "*"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-subprocess": "*",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -14,6 +14,7 @@ import type {
   SubprocessOutcome,
   SubprocessSpawnSpec,
   SubprocessTerminalHandle,
+  SubprocessTerminalSignal,
   SubprocessTerminalSpawnSpec,
 } from '@deepseek-ai/dsh-subprocess'
 
@@ -101,8 +102,72 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
   }
 
   override async spawnTerminal(spec: SubprocessTerminalSpawnSpec): Promise<SubprocessTerminalHandle> {
-    // Phase 2 (depends on KIP-19 sandbox PTY primitive).
-    throw new Error('k8e-sandbox subprocess: spawnTerminal is not implemented in Phase 1')
+    const runtime = this.ctx.k8eSandbox
+    const grpcClient = runtime.getGrpcClient()
+    const sessionId = await runtime.getSession()
+
+    const created = await grpcClient.createTerminal({
+      sessionId,
+      argv: [...spec.argv],
+      workdir: spec.cwd,
+      env: spec.env,
+      rows: spec.rows,
+      cols: spec.cols,
+    })
+
+    const output = new PassThrough()
+    let exitCode: number | null = null
+    let termSignal: NodeJS.Signals | null = null
+    let settled = false
+
+    const done: Promise<SubprocessOutcome> = new Promise((resolve, reject) => {
+      const stream = grpcClient.terminalStream(created.terminalId)
+      stream.on('data', (frame: any) => {
+        if (frame.data !== undefined) {
+          output.write(frame.data)
+        } else if (frame.exit !== undefined) {
+          exitCode = frame.exit.exitCode ?? null
+          termSignal = frame.exit.signal ? (frame.exit.signal as NodeJS.Signals) : null
+          output.end()
+          settled = true
+          resolve({ exitCode, signal: termSignal })
+        }
+      })
+      stream.on('error', (err) => {
+        output.destroy(err instanceof Error ? err : new Error(String(err)))
+        if (!settled) {
+          settled = true
+          reject(err instanceof Error ? err : new Error(String(err)))
+        }
+      })
+      stream.on('end', () => {
+        output.end()
+        if (!settled) {
+          settled = true
+          resolve({ exitCode: exitCode ?? 0, signal: termSignal })
+        }
+      })
+    })
+
+    return {
+      pid: created.pid,
+      output,
+      done,
+      async write(data: string): Promise<void> {
+        await grpcClient.terminalWrite(created.terminalId, new TextEncoder().encode(data))
+      },
+      async inspectForeground() {
+        const fg = await grpcClient.terminalForeground(created.terminalId)
+        if (fg.processGroupId < 0) return undefined
+        return { processGroupId: fg.processGroupId, inputWaiting: fg.inputWaiting }
+      },
+      async signalForeground(signal: SubprocessTerminalSignal): Promise<number> {
+        return grpcClient.terminalSignal(created.terminalId, signal)
+      },
+      async terminate(): Promise<void> {
+        await grpcClient.terminalDestroy(created.terminalId, spec.graceMs)
+      },
+    }
   }
 }
 

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -17,6 +17,7 @@ import type {
   SubprocessTerminalSignal,
   SubprocessTerminalSpawnSpec,
 } from '@deepseek-ai/dsh-subprocess'
+import type { GrpcK8eClient } from '@k8e/dsh-k8e-sandbox-client/grpc'
 
 /** Quote one opaque argument for the CLI's `/bin/sh -c` layer. */
 function shellQuote(value: string): string {
@@ -53,15 +54,35 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
   }
 
   override spawn(spec: SubprocessSpawnSpec): SubprocessHandle {
-    // Phase 1: argv is re-quoted into a single shell command; the CLI executes
-    // it and returns only after completion, so the handle is already settled.
     const command = spec.argv.map(shellQuote).join(' ')
-    const client = this.ctx.k8eSandbox.getClient()
     const stdout = new PassThrough()
     const stderr = new PassThrough()
+    let grpcClient: GrpcK8eClient | undefined
+    try {
+      grpcClient = this.ctx.k8eSandbox.getGrpcClient()
+    } catch {
+      grpcClient = undefined
+    }
     let settled = false
 
     const done: Promise<SubprocessOutcome> = (async () => {
+      if (grpcClient !== undefined) {
+        // Phase 2: streaming exec via gRPC (sandboxd merges stderr into stdout).
+        try {
+          const sid = await this.ctx.k8eSandbox.getSession()
+          const result = grpcClient.execStream(sid, command)
+          result.stdout.pipe(stdout)
+          return await result.done
+        } catch (cause) {
+          const error = cause instanceof Error ? cause : new Error(String(cause))
+          stdout.destroy(error)
+          return { exitCode: 1, signal: null }
+        } finally {
+          settled = true
+        }
+      }
+      // Phase 1 fallback: single-shot CLI run.
+      const client = this.ctx.k8eSandbox.getClient()
       try {
         const sid = await this.ctx.k8eSandbox.getSession()
         const result = await client.run(command, { sessionId: sid, timeout: Math.ceil(spec.graceMs / 1000) })

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -1,0 +1,109 @@
+/**
+ * k8e-sandbox Service Provider for the subprocess capability seam. Phase 1
+ * maps `spawn` to a single-shot `k8e-sandbox-cli run`; streaming stdio and
+ * `spawnTerminal` arrive in Phase 2 (direct gRPC + KIP-19 PTY).
+ * @module @k8e/dsh-k8e-sandbox-subprocess
+ */
+
+import { posix } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { Context } from '@deepseek-ai/cordis'
+import { SubprocessRuntime } from '@deepseek-ai/dsh-subprocess'
+import type {
+  SubprocessHandle,
+  SubprocessOutcome,
+  SubprocessSpawnSpec,
+  SubprocessTerminalHandle,
+  SubprocessTerminalSpawnSpec,
+} from '@deepseek-ai/dsh-subprocess'
+
+/** Quote one opaque argument for the CLI's `/bin/sh -c` layer. */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll('\'', `'"'"'`)}'`
+}
+
+/** k8e-sandbox command manager registered as `ctx.subprocess`. */
+export class K8eSubprocessRuntime extends SubprocessRuntime {
+  static inject = ['k8eSandbox']
+
+  override async resolveExecutable(
+    command: string,
+    env?: Readonly<Record<string, string>>,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    if (command.length === 0) throw new Error('k8e-sandbox subprocess: executable name must be non-empty')
+    signal?.throwIfAborted()
+    const client = this.ctx.k8eSandbox.getClient()
+    const sid = await this.ctx.k8eSandbox.getSession()
+    if (posix.isAbsolute(command)) {
+      const result = await client.run(`test -f ${shellQuote(command)} -a -x ${shellQuote(command)}`, { sessionId: sid, timeout: 10 })
+      if (result.exitCode !== 0) throw new Error(`k8e-sandbox subprocess: ${command} is not an executable file`)
+      return command
+    }
+    if (command.includes('/')) {
+      throw new Error(`k8e-sandbox subprocess: command ${JSON.stringify(command)} is a relative path; use an absolute path or a bare PATH name`)
+    }
+    const result = await client.run(`command -v -- ${shellQuote(command)}`, { sessionId: sid, timeout: 10 })
+    const executable = result.stdout.trim()
+    if (executable.length === 0 || executable.includes('\n') || !posix.isAbsolute(executable)) {
+      throw new Error(`k8e-sandbox subprocess: executable ${JSON.stringify(command)} did not resolve to one absolute path`)
+    }
+    return executable
+  }
+
+  override spawn(spec: SubprocessSpawnSpec): SubprocessHandle {
+    // Phase 1: argv is re-quoted into a single shell command; the CLI executes
+    // it and returns only after completion, so the handle is already settled.
+    const command = spec.argv.map(shellQuote).join(' ')
+    const client = this.ctx.k8eSandbox.getClient()
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let settled = false
+
+    const done: Promise<SubprocessOutcome> = (async () => {
+      try {
+        const sid = await this.ctx.k8eSandbox.getSession()
+        const result = await client.run(command, { sessionId: sid, timeout: Math.ceil(spec.graceMs / 1000) })
+        stdout.end(result.stdout)
+        stderr.end(result.stderr)
+        return { exitCode: result.exitCode, signal: null }
+      } catch (cause) {
+        const error = cause instanceof Error ? cause : new Error(String(cause))
+        stdout.destroy(error)
+        stderr.destroy(error)
+        return { exitCode: 1, signal: null }
+      } finally {
+        settled = true
+      }
+    })()
+
+    return {
+      pid: -1,
+      stdin: undefined,
+      stdout,
+      stderr,
+      collected: {},
+      done,
+      terminate() {
+        if (settled) return
+        stdout.destroy()
+        stderr.destroy()
+      },
+      async waitForExit(signal?: AbortSignal): Promise<boolean> {
+        if (signal !== undefined) {
+          await Promise.race([done, new Promise((_, reject) => signal.addEventListener('abort', () => reject(signal.reason), { once: true }))])
+          return !signal.aborted
+        }
+        await done
+        return true
+      },
+    }
+  }
+
+  override async spawnTerminal(spec: SubprocessTerminalSpawnSpec): Promise<SubprocessTerminalHandle> {
+    // Phase 2 (depends on KIP-19 sandbox PTY primitive).
+    throw new Error('k8e-sandbox subprocess: spawnTerminal is not implemented in Phase 1')
+  }
+}
+
+export default K8eSubprocessRuntime

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox",
+  "version": "0.1.0",
+  "description": "k8e-sandbox owner service for DeepSeek Harness (ctx.k8eSandbox).",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": ["lib"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@k8e/dsh-k8e-sandbox-client": "workspace:*"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/schemastery": "*"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/schemastery": "*",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -8,6 +8,7 @@
 import { Context, Service } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
 import { CliK8eClient } from '@k8e/dsh-k8e-sandbox-client'
+import { GrpcK8eClient } from '@k8e/dsh-k8e-sandbox-client/grpc'
 
 /** Configuration for the shared k8e-sandbox owner. */
 export interface Config {
@@ -15,6 +16,8 @@ export interface Config {
   endpoint?: string
   /** Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17). */
   profile?: string
+  /** mTLS material dir for the direct gRPC terminal client. */
+  certDir?: string
   /** Remote working directory shared by provider adapters. */
   cwd?: string
   /** RuntimeClass for the session pod. */
@@ -52,6 +55,7 @@ export class K8eSandboxRuntime extends Service {
   static Config: z<Config> = z.object({
     endpoint: z.string(),
     profile: z.string(),
+    certDir: z.string(),
     cwd: z.string().default('/workspace'),
     runtimeClass: z.string().default('gvisor'),
     tenant: z.string(),
@@ -64,6 +68,7 @@ export class K8eSandboxRuntime extends Service {
 
   private readonly config: ResolvedConfig
   private readonly client: CliK8eClient
+  private readonly grpcClient: GrpcK8eClient | undefined
   private sessionId: string | undefined
   private disposed = false
 
@@ -84,6 +89,9 @@ export class K8eSandboxRuntime extends Service {
       profile: config.profile,
       endpoint: config.endpoint,
     })
+    this.grpcClient = config.endpoint !== undefined
+      ? new GrpcK8eClient({ endpoint: config.endpoint, certDir: config.certDir })
+      : undefined
 
     ctx.effect(() => async () => {
       this.disposed = true
@@ -119,6 +127,18 @@ export class K8eSandboxRuntime extends Service {
   /** Return the shared transport client. */
   getClient(): CliK8eClient {
     return this.client
+  }
+
+  /**
+   * Return the direct gRPC client for the terminal primitive. Requires an
+   * explicit `endpoint` (the gRPC client does no local auto-discovery).
+   * @throws when no endpoint is configured.
+   */
+  getGrpcClient(): GrpcK8eClient {
+    if (this.grpcClient === undefined) {
+      throw new Error('k8e sandbox: gRPC terminal requires an explicit `endpoint` config')
+    }
+    return this.grpcClient
   }
 }
 

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Shared ownership of one k8e-sandbox session. Capability adapters await the
+ * same session handle, so filesystem and process operations inhabit one remote
+ * Linux world (mirrors the E2B POC's `ctx.e2b` owner).
+ * @module @k8e/dsh-k8e-sandbox
+ */
+
+import { Context, Service } from '@deepseek-ai/cordis'
+import z from '@deepseek-ai/schemastery'
+import { CliK8eClient } from '@k8e/dsh-k8e-sandbox-client'
+
+/** Configuration for the shared k8e-sandbox owner. */
+export interface Config {
+  /** gRPC gateway endpoint; omission uses the CLI's local auto-discovery. */
+  endpoint?: string
+  /** Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17). */
+  profile?: string
+  /** Remote working directory shared by provider adapters. */
+  cwd?: string
+  /** RuntimeClass for the session pod. */
+  runtimeClass?: string
+  /** Explicit cross-process session reuse tenant; unset = one session per dsh session. */
+  tenant?: string
+  /** Egress allowlist (only applied when the owner creates the session). */
+  allowedHosts?: string[]
+  /** Dispose by pausing instead of destroying (PVC retained); Phase 1 destroy-only. */
+  pauseOnDispose?: boolean
+}
+
+interface ResolvedConfig {
+  cwd: string
+  runtimeClass: string
+  tenant?: string
+  allowedHosts?: string[]
+  pauseOnDispose: boolean
+}
+
+interface SchemaResolvedConfig extends Config {
+  cwd: string
+  runtimeClass: string
+  pauseOnDispose: boolean
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    k8eSandbox: K8eSandboxRuntime
+  }
+}
+
+/** Creates one lazily consumable k8e-sandbox session and destroys it on disposal. */
+export class K8eSandboxRuntime extends Service {
+  static Config: z<Config> = z.object({
+    endpoint: z.string(),
+    profile: z.string(),
+    cwd: z.string().default('/workspace'),
+    runtimeClass: z.string().default('gvisor'),
+    tenant: z.string(),
+    allowedHosts: z.array(z.string()),
+    pauseOnDispose: z.boolean().default(false),
+  })
+
+  /** Validated remote working directory shared by provider adapters. */
+  readonly cwd: string
+
+  private readonly config: ResolvedConfig
+  private readonly client: CliK8eClient
+  private sessionId: string | undefined
+  private disposed = false
+
+  constructor(ctx: Context, config: Config) {
+    super(ctx, 'k8eSandbox')
+    // Schemastery fills defaulted fields before construction; the type does not encode that step.
+    const resolved = config as SchemaResolvedConfig
+    this.config = {
+      cwd: resolved.cwd,
+      runtimeClass: resolved.runtimeClass,
+      tenant: config.tenant,
+      allowedHosts: config.allowedHosts,
+      pauseOnDispose: resolved.pauseOnDispose,
+    }
+    this.cwd = this.config.cwd
+    this.client = new CliK8eClient({
+      bin: process.env.K8E_SANDBOX_CLI_BIN,
+      profile: config.profile,
+      endpoint: config.endpoint,
+    })
+
+    ctx.effect(() => async () => {
+      this.disposed = true
+      if (this.sessionId === undefined) return
+      try {
+        await this.client.destroySession(this.sessionId)
+      } catch (_destroyFailure) {
+        // Best-effort: the session pod is also reclaimed by the warm-pool GC.
+      }
+    }, 'k8e sandbox teardown')
+  }
+
+  /**
+   * Return the live session id, creating the sandbox session on first use.
+   * @throws when the service is disposing.
+   */
+  async getSession(): Promise<string> {
+    if (this.disposed) throw new Error('k8e sandbox service is disposing')
+    if (this.sessionId !== undefined) return this.sessionId
+    const created = await this.client.createSession({
+      runtimeClass: this.config.runtimeClass,
+      tenant: this.config.tenant,
+      allowedHosts: this.config.allowedHosts,
+    })
+    if (this.disposed) {
+      await this.client.destroySession(created.sessionId).catch(() => undefined)
+      throw new Error('k8e sandbox service is disposing')
+    }
+    this.sessionId = created.sessionId
+    return this.sessionId
+  }
+
+  /** Return the shared transport client. */
+  getClient(): CliK8eClient {
+    return this.client
+  }
+}
+
+export default K8eSandboxRuntime

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/pnpm-workspace.yaml
+++ b/plugins/deepseek-harness/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/plugins/deepseek-harness/tsconfig.base.json
+++ b/plugins/deepseek-harness/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## 概述

KIP-20 Phase 1：DeepSeek Harness 的树外插件骨架，让 dsh 通过 `dsh plugin add` 把执行世界路由到 k8e-sandbox，**不侵入 dsh 源码**。

关联 issue：#542（DeepSeek Harness 集成）。

## 改动

`plugins/deepseek-harness/`（pnpm workspace）：

- `@k8e/dsh-k8e-sandbox-client`：`CliK8eClient` 包装 `k8e-sandbox-cli`（Phase 1 传输，复用 mTLS/profile/state）
- `@k8e/dsh-k8e-sandbox`：owner 服务 `ctx.k8eSandbox`（懒创建 session + dispose 销毁）
- `@k8e/dsh-k8e-sandbox-fs`：`K8eFileSystem extends FileSystem`
- `@k8e/dsh-k8e-sandbox-subprocess`：`K8eSubprocessRuntime extends SubprocessRuntime`（单次 exec；`spawnTerminal` 留到 Phase 2）
- `@k8e/dsh-k8e-sandbox-bundle`：`dsh.bundle` 的 `cordis.patch.yml`

## 验证

- 整套 TS 已对照 dsh checkout（`@deepseek-ai/dsh-fs` / `dsh-subprocess` / `cordis` 的 `.d.ts`）跑过 `tsc --noEmit`，**0 错误**（期间修掉了 `writeText` 的 `before` diff-basis 类型错误）。

## 说明 / WIP 边界

- Phase 1 传输是 CLI（每操作一次进程 spawn）；Phase 2 换直连 gRPC（依赖 KIP-19 PR #544）。
- `spawnTerminal` 目前明确抛「未实现」，需 KIP-19 PTY 先合入。
- 未做真机 e2e；CI 上无法 typecheck（dsh 是 private 未发布包，需本地链 dsh checkout）。

/cc 待评审。
