### PR TITLE
test(dsh): fake-ctx runtime tests for fs/subprocess/SSE (KIP-20)

### DIFF
--- a/plugins/deepseek-harness/.gitignore
+++ b/plugins/deepseek-harness/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 lib/
 *.tsbuildinfo
 tsconfig.check.json
+tests/.bundle.mjs

--- a/plugins/deepseek-harness/.gitignore
+++ b/plugins/deepseek-harness/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 lib/
 *.tsbuildinfo
 tsconfig.check.json
-tests/.bundle.mjs
+tests/.bundle-*
+package-lock.json

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -23,11 +23,23 @@ runtime e2e against a live K8E gateway is still pending — the procedure is in
 
 ## Test
 
-`npm test` runs a fake-ctx runtime test (no harness, no gateway): it mounts
-`K8eSubprocessRuntime` on a fake `ctx` with a fake owner + fake gRPC client and
-asserts the `spawnTerminal` / `spawn` mapping (`tests/subprocess.test.mjs`,
-bundled on the fly by `scripts/test.mjs`). It needs the same `@deepseek-ai/*`
-symlinks + `esbuild` + `@grpc/*` deps as the Typecheck step below.
+Fake-ctx runtime tests (no harness, gateway, or cluster): `npm test` mounts the
+fs/subprocess providers on a fake `ctx` with a fake owner + fake client and
+asserts their mapping, and unit-tests the exec SSE decoder
+(`tests/{fs,subprocess,grpc-sse}.test.mjs`, bundled on the fly by
+`scripts/test.mjs`).
+
+One-time setup:
+
+```sh
+npm install               # devDependencies: esbuild + @grpc/grpc-js + @grpc/proto-loader
+scripts/setup-links.sh    # symlink @deepseek-ai/* -> the dsh checkout's lib/
+npm test                  # bundle + run tests/*.test.mjs
+```
+
+`npm install` prunes extraneous `node_modules` symlinks, so re-run
+`scripts/setup-links.sh` after any reinstall. `DSH_CHECKOUT` overrides the dsh
+path (default `../../../deepseek-harness`).
 
 ## Typecheck
 

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -21,6 +21,14 @@ Phase 1 (CLI transport) and Phase 2 (direct gRPC: `spawnTerminal` + streaming
 runtime e2e against a live K8E gateway is still pending — the procedure is in
 [`e2e.md`](e2e.md).
 
+## Test
+
+`npm test` runs a fake-ctx runtime test (no harness, no gateway): it mounts
+`K8eSubprocessRuntime` on a fake `ctx` with a fake owner + fake gRPC client and
+asserts the `spawnTerminal` / `spawn` mapping (`tests/subprocess.test.mjs`,
+bundled on the fly by `scripts/test.mjs`). It needs the same `@deepseek-ai/*`
+symlinks + `esbuild` + `@grpc/*` deps as the Typecheck step below.
+
 ## Typecheck
 
 The TypeScript packages target dsh's in-box types (`@deepseek-ai/dsh-fs`,

--- a/plugins/deepseek-harness/package.json
+++ b/plugins/deepseek-harness/package.json
@@ -2,5 +2,8 @@
   "name": "dsh-k8e-sandbox-workspace",
   "private": true,
   "version": "0.1.0",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test": "node scripts/test.mjs"
+  }
 }

--- a/plugins/deepseek-harness/package.json
+++ b/plugins/deepseek-harness/package.json
@@ -5,5 +5,10 @@
   "type": "module",
   "scripts": {
     "test": "node scripts/test.mjs"
+  },
+  "devDependencies": {
+    "@grpc/grpc-js": "^1.12.0",
+    "@grpc/proto-loader": "^0.7.13",
+    "esbuild": "^0.28.2"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -39,6 +39,42 @@ export interface ExecStreamResult {
   done: Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>
 }
 
+export interface ExecSSEEvent {
+  data?: string
+  exit?: number
+}
+
+/**
+ * Incremental decoder for the gateway's /exec/stream SSE framing
+ * (`data: {"pid":N}`, `data: <raw>`, `data: {"exit":N}`). Chunks may split an
+ * event anywhere; `push` returns only complete events.
+ */
+export class ExecSSEDecoder {
+  private buffer = ''
+
+  /** Feed one chunk; returns the decoded data/exit events in delivery order. */
+  push(chunk: string): ExecSSEEvent[] {
+    this.buffer += chunk
+    const events: ExecSSEEvent[] = []
+    while (true) {
+      const idx = this.buffer.indexOf('\n\n')
+      if (idx < 0) break
+      const event = this.buffer.slice(0, idx)
+      this.buffer = this.buffer.slice(idx + 2)
+      if (!event.startsWith('data: ')) continue
+      const payload = event.slice('data: '.length)
+      if (payload.startsWith('{"pid"')) continue
+      if (payload.startsWith('{"exit"')) {
+        const m = /"exit":(-?\d+)/.exec(payload)
+        events.push({ exit: m === null ? 0 : Number(m[1]) })
+        continue
+      }
+      events.push({ data: payload })
+    }
+    return events
+  }
+}
+
 export interface GrpcK8eClientOptions {
   /** gRPC gateway `host:port`. */
   endpoint: string
@@ -181,7 +217,7 @@ export class GrpcK8eClient {
     const stdout = new PassThrough()
     const stream = this.client.execStream({ session_id: sessionId, command }, this.metadata)
 
-    let buffer = ''
+    const decoder = new ExecSSEDecoder()
     let exitCode: number | null = null
     let settled = false
 
@@ -194,22 +230,14 @@ export class GrpcK8eClient {
         }
       }
       stream.on('data', (chunk: Buffer | string) => {
-        buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
-        while (true) {
-          const idx = buffer.indexOf('\n\n')
-          if (idx < 0) break
-          const event = buffer.slice(0, idx)
-          buffer = buffer.slice(idx + 2)
-          if (!event.startsWith('data: ')) continue
-          const payload = event.slice('data: '.length)
-          if (payload.startsWith('{"pid"')) continue
-          if (payload.startsWith('{"exit"')) {
-            const m = /"exit":(-?\d+)/.exec(payload)
-            exitCode = m === null ? 0 : Number(m[1])
+        const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+        for (const event of decoder.push(text)) {
+          if (event.exit !== undefined) {
+            exitCode = event.exit
             settle(null)
-            continue
+          } else if (event.data !== undefined) {
+            stdout.write(event.data)
           }
-          stdout.write(payload)
         }
       })
       stream.on('error', (err) => {

--- a/plugins/deepseek-harness/scripts/setup-links.sh
+++ b/plugins/deepseek-harness/scripts/setup-links.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Link the DeepSeek Harness runtime packages into node_modules so the tests and
+# esbuild can resolve @deepseek-ai/* (the dsh packages are private/not on npm).
+# Run after `npm install`; `npm install` prunes extraneous symlinks, so re-run
+# this whenever you reinstall.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DSH="$(cd "${DSH_CHECKOUT:-../../../deepseek-harness}" && pwd)"
+mkdir -p node_modules/@deepseek-ai
+link() { ln -sfn "$DSH/$1" "node_modules/@deepseek-ai/$2"; }
+
+link vendor/cordis                        cordis
+link vendor/cosmokit                      cosmokit
+link vendor/schemastery                   schemastery
+link packages/subprocess/subprocess       dsh-subprocess
+link packages/fs/fs                       dsh-fs
+link packages/llm/llm                     dsh-llm
+link packages/util/timeout                dsh-timeout
+link packages/runtime-diagnostics/invariants dsh-invariants
+link packages/util/brand                  dsh-brand
+
+echo "linked dsh runtime packages from $DSH"

--- a/plugins/deepseek-harness/scripts/test.mjs
+++ b/plugins/deepseek-harness/scripts/test.mjs
@@ -1,32 +1,37 @@
-// Test runner: bundles a test entry (which imports the plugin source) with
-// esbuild, resolving @k8e/* to src via alias and @deepseek-ai/* via the
-// node_modules symlinks (see README Typecheck), leaving @grpc/* external, then
-// imports and runs the bundle. Usage: node scripts/test.mjs [tests/<file>]
-import { build } from 'esbuild'
+// Test runner: bundles each tests/*.test.mjs entry (which imports the plugin
+// source) with esbuild, resolving @k8e/* to src via alias and @deepseek-ai/*
+// via the node_modules symlinks (see README), leaving @grpc/* external, then
+// imports and runs each bundle. Usage: node scripts/test.mjs [tests/<file>]
+import { readdir } from 'node:fs/promises'
 import { writeFile } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
-const entry = join(ROOT, process.argv[2] ?? join('tests', 'subprocess.test.mjs'))
+const testsDir = join(ROOT, 'tests')
+const files = process.argv[2]
+  ? [process.argv[2]]
+  : (await readdir(testsDir)).filter((f) => f.endsWith('.test.mjs') && !f.startsWith('.bundle-')).sort()
 
-const result = await build({
-  entryPoints: [entry],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  write: false,
-  sourcemap: false,
-  external: ['@grpc/grpc-js', '@grpc/proto-loader'],
-  alias: {
-    '@k8e/dsh-k8e-sandbox': join(ROOT, 'packages/dsh-k8e-sandbox/src/index.ts'),
-    '@k8e/dsh-k8e-sandbox-client': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/index.ts'),
-    '@k8e/dsh-k8e-sandbox-client/grpc': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/grpc.ts'),
-    '@k8e/dsh-k8e-sandbox-fs': join(ROOT, 'packages/dsh-k8e-sandbox-fs/src/index.ts'),
-    '@k8e/dsh-k8e-sandbox-subprocess': join(ROOT, 'packages/dsh-k8e-sandbox-subprocess/src/index.ts'),
-  },
-})
-
-const outfile = join(ROOT, 'tests', '.bundle.mjs')
-await writeFile(outfile, result.outputFiles[0].text)
-await import(outfile)
+for (const file of files) {
+  const result = await build({
+    entryPoints: [join(testsDir, file)],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    sourcemap: false,
+    external: ['@grpc/grpc-js', '@grpc/proto-loader'],
+    alias: {
+      '@k8e/dsh-k8e-sandbox': join(ROOT, 'packages/dsh-k8e-sandbox/src/index.ts'),
+      '@k8e/dsh-k8e-sandbox-client': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/index.ts'),
+      '@k8e/dsh-k8e-sandbox-client/grpc': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/grpc.ts'),
+      '@k8e/dsh-k8e-sandbox-fs': join(ROOT, 'packages/dsh-k8e-sandbox-fs/src/index.ts'),
+      '@k8e/dsh-k8e-sandbox-subprocess': join(ROOT, 'packages/dsh-k8e-sandbox-subprocess/src/index.ts'),
+    },
+  })
+  const outfile = join(testsDir, `.bundle-${file}`)
+  await writeFile(outfile, result.outputFiles[0].text)
+  await import(outfile)
+}

--- a/plugins/deepseek-harness/scripts/test.mjs
+++ b/plugins/deepseek-harness/scripts/test.mjs
@@ -1,0 +1,32 @@
+// Test runner: bundles a test entry (which imports the plugin source) with
+// esbuild, resolving @k8e/* to src via alias and @deepseek-ai/* via the
+// node_modules symlinks (see README Typecheck), leaving @grpc/* external, then
+// imports and runs the bundle. Usage: node scripts/test.mjs [tests/<file>]
+import { build } from 'esbuild'
+import { writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const entry = join(ROOT, process.argv[2] ?? join('tests', 'subprocess.test.mjs'))
+
+const result = await build({
+  entryPoints: [entry],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  write: false,
+  sourcemap: false,
+  external: ['@grpc/grpc-js', '@grpc/proto-loader'],
+  alias: {
+    '@k8e/dsh-k8e-sandbox': join(ROOT, 'packages/dsh-k8e-sandbox/src/index.ts'),
+    '@k8e/dsh-k8e-sandbox-client': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/index.ts'),
+    '@k8e/dsh-k8e-sandbox-client/grpc': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/grpc.ts'),
+    '@k8e/dsh-k8e-sandbox-fs': join(ROOT, 'packages/dsh-k8e-sandbox-fs/src/index.ts'),
+    '@k8e/dsh-k8e-sandbox-subprocess': join(ROOT, 'packages/dsh-k8e-sandbox-subprocess/src/index.ts'),
+  },
+})
+
+const outfile = join(ROOT, 'tests', '.bundle.mjs')
+await writeFile(outfile, result.outputFiles[0].text)
+await import(outfile)

--- a/plugins/deepseek-harness/tests/fs.test.mjs
+++ b/plugins/deepseek-harness/tests/fs.test.mjs
@@ -1,0 +1,113 @@
+// Fake-ctx runtime test for the filesystem provider: mount K8eFileSystem on a
+// fake ctx with a fake owner + fake CliK8eClient (an in-memory file map), then
+// assert resolve/read/write/edit/list map correctly.
+import assert from 'node:assert/strict'
+import { K8eFileSystem } from '@k8e/dsh-k8e-sandbox-fs'
+
+function makeCliClient(files) {
+  const calls = []
+  return {
+    calls,
+    async read(sid, path) {
+      calls.push(['read', sid, path])
+      if (!files.has(path)) throw new Error(`no such file: ${path}`)
+      return files.get(path)
+    },
+    async write(sid, path, content) {
+      calls.push(['write', sid, path, content])
+      files.set(path, content)
+    },
+    async list(sid) {
+      calls.push(['list', sid])
+      return [...files.keys()].map((path) => ({ path, modified: 0 }))
+    },
+    async run(code, opts) {
+      calls.push(['run', code, opts])
+      // parse: stat -c '%f|%s|%Y' 'PATH' 2>/dev/null || printf 'missing'
+      const m = /stat -c '[^']*' '([^']+)'/.exec(code)
+      if (m) {
+        const path = m[1]
+        if (files.has(path)) {
+          return { stdout: `8000|${files.get(path).length}|123`, stderr: '', exitCode: 0 }
+        }
+        return { stdout: 'missing', stderr: '', exitCode: 0 }
+      }
+      return { stdout: '', stderr: '', exitCode: 0 }
+    },
+  }
+}
+
+function makeCtx(owner) {
+  const ctx = { k8eSandbox: owner, reflect: { provide() { return () => {} } }, effect() { return () => {} } }
+  return ctx
+}
+
+// ---- pure path primitives ------------------------------------------
+{
+  const files = new Map()
+  const owner = { getClient: () => makeCliClient(files), getSession: async () => 's1', cwd: '/workspace' }
+  const fs = new K8eFileSystem(makeCtx(owner))
+
+  const target = await fs.resolve('src/a.txt')
+  assert.equal(target.displayPath, '/workspace/src/a.txt')
+  assert.equal(fs.processPath(target), '/workspace/src/a.txt')
+  assert.equal(fs.fileUrl(target), 'file:///workspace/src/a.txt')
+
+  const parent = await fs.resolve('src')
+  const child = await fs.resolve('src/a.txt')
+  const outside = await fs.resolve('other/b.txt')
+  assert.equal(fs.contains(parent, child), true)
+  assert.equal(fs.contains(parent, outside), false)
+}
+
+// ---- readText / writeText (create + update) / editText / listDir ----
+{
+  const files = new Map([['/workspace/hello.txt', 'hello world']])
+  const client = makeCliClient(files)
+  const owner = { getClient: () => client, getSession: async () => 's1', cwd: '/workspace' }
+  const fs = new K8eFileSystem(makeCtx(owner))
+
+  // readText
+  assert.equal(await fs.readText(await fs.resolve('hello.txt')), 'hello world')
+
+  // writeText create
+  const createOutcome = await fs.writeText(await fs.resolve('new.txt'), 'brand new')
+  assert.equal(createOutcome.operation, 'create')
+  assert.equal(createOutcome.before, null)
+  assert.equal(createOutcome.after, 'brand new')
+  assert.equal(files.get('/workspace/new.txt'), 'brand new')
+
+  // writeText update
+  const updateOutcome = await fs.writeText(await fs.resolve('new.txt'), 'updated')
+  assert.equal(updateOutcome.operation, 'update')
+  assert.equal(updateOutcome.before, 'brand new')
+  assert.equal(updateOutcome.after, 'updated')
+
+  // writeText createIfAbsent rejects an existing file
+  await assert.rejects(
+    fs.writeText(await fs.resolve('new.txt'), 'again', { kind: 'createIfAbsent' }),
+    /overwrite existing/,
+  )
+
+  // editText literal replace
+  const editOutcome = await fs.editText(await fs.resolve('hello.txt'), {
+    oldString: 'world',
+    newString: 'there',
+    replaceAll: false,
+  })
+  assert.equal(editOutcome.before, 'hello world')
+  assert.equal(editOutcome.after, 'hello there')
+  assert.equal(files.get('/workspace/hello.txt'), 'hello there')
+
+  // listDir returns only direct-child files (k8e ListFiles lists files, not dirs)
+  files.set('/workspace/sub/a.txt', 'a')
+  files.set('/workspace/root.txt', 'r')
+  const entries = await fs.listDir(await fs.resolve('.'))
+  const names = entries.map((e) => e.name).sort()
+  assert.deepEqual(names, ['hello.txt', 'new.txt', 'root.txt'])
+  const txt = entries.find((e) => e.name === 'root.txt')
+  assert.equal(txt.type, 'file')
+  assert.equal(txt.size, 1, 'size carried from the stat probe')
+}
+
+console.log('✔ fs fake-ctx test passed (path primitives, read/write/edit/list)')

--- a/plugins/deepseek-harness/tests/grpc-sse.test.mjs
+++ b/plugins/deepseek-harness/tests/grpc-sse.test.mjs
@@ -1,0 +1,44 @@
+// Pure-unit test for the /exec/stream SSE decoder (no harness, no gRPC).
+import assert from 'node:assert/strict'
+import { ExecSSEDecoder } from '@k8e/dsh-k8e-sandbox-client/grpc'
+
+// pid frame is dropped; data + exit are emitted in order.
+{
+  const d = new ExecSSEDecoder()
+  const events = d.push('data: {"pid":123}\n\ndata: hello\n\ndata: {"exit":0}\n\n')
+  assert.deepEqual(events, [{ data: 'hello' }, { exit: 0 }])
+}
+
+// byte-by-byte feeding must reassemble events across arbitrary chunk splits.
+{
+  const d = new ExecSSEDecoder()
+  const full = 'data: {"pid":1}\n\ndata: ab\n\ndata: {"exit":42}\n\n'
+  const events = []
+  for (const ch of full) events.push(...d.push(ch))
+  assert.deepEqual(events, [{ data: 'ab' }, { exit: 42 }])
+}
+
+// a single newline inside the payload survives (the raw framing limitation is
+// only a literal "\n\n" inside data, which would split the frame early).
+{
+  const d = new ExecSSEDecoder()
+  assert.deepEqual(d.push('data: line1\nline2\n\ndata: {"exit":0}\n\n'), [
+    { data: 'line1\nline2' },
+    { exit: 0 },
+  ])
+}
+
+// negative exit (killed by signal) is preserved.
+{
+  const d = new ExecSSEDecoder()
+  assert.deepEqual(d.push('data: {"exit":-1}\n\n'), [{ exit: -1 }])
+}
+
+// a partial event is retained until the rest arrives.
+{
+  const d = new ExecSSEDecoder()
+  assert.deepEqual(d.push('data: hel'), [])
+  assert.deepEqual(d.push('lo\n\n'), [{ data: 'hello' }])
+}
+
+console.log('✔ grpc SSE decoder test passed')

--- a/plugins/deepseek-harness/tests/subprocess.test.mjs
+++ b/plugins/deepseek-harness/tests/subprocess.test.mjs
@@ -1,0 +1,180 @@
+// Fake-ctx runtime test for the subprocess provider (learned from
+// dsh-context's host.test.mjs): mount K8eSubprocessRuntime on a fake ctx with a
+// fake owner + fake gRPC client, then drive spawnTerminal / spawn and assert
+// the handle maps correctly. No harness, no gateway, no cluster.
+import assert from 'node:assert/strict'
+import { PassThrough } from 'node:stream'
+import { K8eSubprocessRuntime } from '@k8e/dsh-k8e-sandbox-subprocess'
+
+function makeGrpcClient() {
+  const calls = []
+  const terminalStream = new PassThrough({ objectMode: true })
+  const client = {
+    calls,
+    terminalStream(id) {
+      calls.push(['terminalStream', id])
+      return terminalStream
+    },
+    async createTerminal(req) {
+      calls.push(['createTerminal', req])
+      return { terminalId: 't1', pid: 42 }
+    },
+    async terminalWrite(terminalId, data) {
+      calls.push(['terminalWrite', terminalId, data])
+    },
+    async terminalForeground(terminalId) {
+      calls.push(['terminalForeground', terminalId])
+      return { processGroupId: 7, inputWaiting: false }
+    },
+    async terminalSignal(terminalId, signal) {
+      calls.push(['terminalSignal', terminalId, signal])
+      return 7
+    },
+    async terminalDestroy(terminalId, graceMs) {
+      calls.push(['terminalDestroy', terminalId, graceMs])
+    },
+    execStream(sessionId, command) {
+      calls.push(['execStream', sessionId, command])
+      return { stdout: new PassThrough(), done: Promise.resolve({ exitCode: 0, signal: null }) }
+    },
+  }
+  client.terminalStreamRef = terminalStream
+  return client
+}
+
+function makeCtx(owner) {
+  const ctx = {
+    k8eSandbox: owner,
+    reflect: { provide() { return () => {} } },
+    effect() { return () => {} },
+  }
+  return ctx
+}
+
+// ---- spawnTerminal: full mapping --------------------------------
+{
+  const client = makeGrpcClient()
+  const owner = { getGrpcClient: () => client, getSession: async () => 's1' }
+  const runtime = new K8eSubprocessRuntime(makeCtx(owner))
+
+  const handle = await runtime.spawnTerminal({
+    argv: ['bash', '-l'],
+    cwd: '/workspace',
+    env: { FOO: 'bar' },
+    rows: 24,
+    cols: 80,
+    graceMs: 5000,
+  })
+
+  // createTerminal received the resolved request (sessionId + argv + env + size).
+  assert.deepEqual(client.calls[0], ['createTerminal', {
+    sessionId: 's1',
+    argv: ['bash', '-l'],
+    workdir: '/workspace',
+    env: { FOO: 'bar' },
+    rows: 24,
+    cols: 80,
+  }])
+  assert.equal(handle.pid, 42)
+
+  // write -> terminalWrite(terminalId, utf8 bytes)
+  await handle.write('echo hi\n')
+  const writeCall = client.calls.find((c) => c[0] === 'terminalWrite')
+  assert.equal(writeCall[1], 't1')
+  assert.equal(Buffer.from(writeCall[2]).toString('utf8'), 'echo hi\n')
+
+  // output stream receives data frames; done resolves on the exit frame.
+  const chunks = []
+  handle.output.on('data', (c) => chunks.push(c))
+  client.terminalStreamRef.write({ data: Buffer.from('hello\n') })
+  client.terminalStreamRef.write({ exit: { exitCode: 3, signal: 'SIGTERM' } })
+  client.terminalStreamRef.end()
+
+  const outcome = await handle.done
+  assert.deepEqual(outcome, { exitCode: 3, signal: 'SIGTERM' })
+  assert.equal(Buffer.concat(chunks).toString('utf8'), 'hello\n')
+
+  // inspectForeground -> terminalForeground
+  const fg = await handle.inspectForeground()
+  assert.deepEqual(fg, { processGroupId: 7, inputWaiting: false })
+
+  // signalForeground -> terminalSignal, returns the pgid
+  assert.equal(await handle.signalForeground('SIGINT'), 7)
+  assert.deepEqual(client.calls.find((c) => c[0] === 'terminalSignal'), ['terminalSignal', 't1', 'SIGINT'])
+
+  // terminate -> terminalDestroy with the spec grace
+  await handle.terminate()
+  assert.deepEqual(client.calls.find((c) => c[0] === 'terminalDestroy'), ['terminalDestroy', 't1', 5000])
+}
+
+// ---- spawnTerminal: unresolvable foreground -> undefined ----------------
+{
+  const client = makeGrpcClient()
+  client.terminalForeground = async (id) => ({ processGroupId: -1, inputWaiting: false })
+  const owner = { getGrpcClient: () => client, getSession: async () => 's1' }
+  const runtime = new K8eSubprocessRuntime(makeCtx(owner))
+  const handle = await runtime.spawnTerminal({ argv: ['sh'], cwd: '/w', rows: 24, cols: 80, graceMs: 1000 })
+  assert.equal(await handle.inspectForeground(), undefined)
+}
+
+// ---- spawn: gRPC streaming path ------------------------------------
+{
+  const client = makeGrpcClient()
+  // Make execStream's done controllable so we can write to its stdout first.
+  let resolveExec
+  const execDone = new Promise((resolve) => { resolveExec = resolve })
+  client.execStream = (sessionId, command) => {
+    client.calls.push(['execStream', sessionId, command])
+    const stdout = new PassThrough()
+    client.execStreamRef = stdout
+    return { stdout, done: execDone }
+  }
+  const owner = { getGrpcClient: () => client, getSession: async () => 's1' }
+  const runtime = new K8eSubprocessRuntime(makeCtx(owner))
+
+  const handle = runtime.spawn({
+    argv: ['echo', 'hi'],
+    cwd: '/workspace',
+    stdio: { stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' },
+    graceMs: 5000,
+  })
+  // Let the async done() reach execStream (await getSession yields a microtask).
+  await new Promise((r) => setImmediate(r))
+  assert.ok(client.execStreamRef, 'execStream was called')
+  assert.ok(client.calls.some((c) => c[0] === 'execStream'), 'gRPC path used when endpoint present')
+
+  const chunks = []
+  handle.stdout.on('data', (c) => chunks.push(c))
+  client.execStreamRef.end('streamed\n')
+  resolveExec({ exitCode: 0, signal: null })
+  const outcome = await handle.done
+  assert.deepEqual(outcome, { exitCode: 0, signal: null })
+  assert.equal(Buffer.concat(chunks).toString('utf8'), 'streamed\n')
+}
+
+// ---- spawn: CLI fallback when no gRPC client --------------------------
+{
+  const cliCalls = []
+  const owner = {
+    getGrpcClient: () => { throw new Error('no endpoint') },
+    getSession: async () => 's1',
+    getClient: () => ({ run: async (code, opts) => { cliCalls.push([code, opts]); return { stdout: 'cli-out\n', stderr: '', exitCode: 7 } } }),
+  }
+  const runtime = new K8eSubprocessRuntime(makeCtx(owner))
+  const handle = runtime.spawn({
+    argv: ['echo', 'hi'],
+    cwd: '/workspace',
+    stdio: { stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' },
+    graceMs: 5000,
+  })
+
+  const chunks = []
+  handle.stdout.on('data', (c) => chunks.push(c))
+  const outcome = await handle.done
+  assert.deepEqual(outcome, { exitCode: 7, signal: null })
+  assert.equal(Buffer.concat(chunks).toString('utf8'), 'cli-out\n')
+  assert.equal(cliCalls.length, 1, 'CLI fallback used exactly once')
+  assert.equal(cliCalls[0][0], "'echo' 'hi'", 'argv is shell-quoted into one command')
+}
+
+console.log('✔ subprocess fake-ctx test passed (spawnTerminal mapping, stream frames, spawn gRPC + CLI fallback)')


### PR DESCRIPTION
## 概述

给 KIP-20 dsh 插件补运行时测试（之前只有 typecheck，没 runtime 跑过）。沿用 dsh-context 的「fake ctx + 捕获 handler」经验——不依赖 harness / 网关 / 集群。

关联 issue：#542。

## 改动

- **`tests/subprocess.test.mjs`**：`K8eSubprocessRuntime` 挂 fake ctx + fake `GrpcK8eClient`，验证 `spawnTerminal` 全映射（createTerminal/write/output 帧/done 结算/inspectForeground/signalForeground/terminate）+ `spawn` 的 gRPC 流式与 CLI 回退。
- **`tests/fs.test.mjs`**：`K8eFileSystem` 挂 fake ctx + fake `CliK8eClient`（内存文件 map + stat 命令解析），验证 resolve/read/write(create/update/createIfAbsent)/edit/listDir。
- **`tests/grpc-sse.test.mjs`**：把 `/exec/stream` 的 SSE 解析抽成纯类 `ExecSSEDecoder`（顺带让 `execStream` 更干净），单测 pid 帧丢弃/逐字节重组/内嵌换行/负 exit/跨 push 缓存。
- **`scripts/test.mjs`**：esbuild 打包并运行所有 `tests/*.test.mjs`；`scripts/setup-links.sh` 把 `@deepseek-ai/*` 软链到 dsh checkout（`npm install` 会剪软链，故固化脚本）。

## 验证

```
✔ fs fake-ctx test passed
✔ grpc SSE decoder test passed
✔ subprocess fake-ctx test passed
```

全部 3 个测试绿（`npm install` → `scripts/setup-links.sh` → `npm test`）。

## 说明

- `esbuild` / `@grpc/grpc-js` / `@grpc/proto-loader` 加进根 `package.json` 的 `devDependencies`。
- `@deepseek-ai/*` 是 dsh 私有/未发布包，测试时靠 `setup-links.sh` 软链到本地 checkout（不提交）。
