### PR TITLE
feat(dsh): k8e-sandbox client half — settings page, terminal panel, live monitoring, better-sidebar tab

### DIFF
--- a/plugins/deepseek-harness/.gitignore
+++ b/plugins/deepseek-harness/.gitignore
@@ -4,3 +4,4 @@ lib/
 tsconfig.check.json
 tests/.bundle-*
 package-lock.json
+.npm-cache/

--- a/plugins/deepseek-harness/docs/ui-design.md
+++ b/plugins/deepseek-harness/docs/ui-design.md
@@ -1,0 +1,167 @@
+# dsh-k8e-sandbox 客户端半身设计：配置页 + 沙盒终端页
+
+> 参考实现：[DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（v0.12.x）。
+> 目标：给 `@k8e/dsh-k8e-sandbox` 补上 **client 半身**——① 一个配置页面；② 一个调用 sandbox 时出现的终端页，实时显示运行命令与输出。对应 issue #542 的「侧边栏集成」。
+
+## 0. 现状与差距
+
+KIP-20 目前只有 **host 半身**（`ctx.fs` / `ctx.subprocess` / `ctx.k8eSandbox`），没有浏览器侧 UI。`package.json` 只有 `dsh.bundle`，没有 `dsh.client`。
+
+## 1. 从 DSH-better-sidebar 学到的可借鉴点
+
+| 机制 | better-sidebar 怎么做 | 我们照搬/适配 |
+|---|---|---|
+| **双半身 manifest** | `package.json#dsh` 同时有 `bundle.patch`（host）+ `client: { inject, platform }`（浏览器） | 给 bundle 包加 `dsh.client` |
+| **client inject** | `['@deepseek-ai/dsh-client-runtime','-locale','-ui-slots','-ui-conversation','-ui-settings','-ui-primitives','-web-react']` | 同款（按需裁剪） |
+| **本地 type-only 契约** | `context-types.ts` 里用 `declare module 'cordis'` 重述 `ctx.webServer/slots/settings/...` 的结构面，避开 npm 断裂依赖 | 我们照做（`ctx.k8eSandbox` + webServer/slots/settings/connection） |
+| **host HTTP/WS 路由** | `ctx.webServer.register({kind:'prefix', path, handler})` + `ctx.webServer.registerUpgrade({path, handler})` | 照做：`/k8e-sandbox/api/*` + `/k8e-sandbox/ws/terminal` |
+| **配置页（设置 seam）** | host: `ctx.inject(['settings'], s => s.settings.register(ns, PrefsSchema))`；client: `ctx.slots.inject('settings.section', () => ctx.slots.register({name:'settings.section', id, order, label, inject}, Section))` | 照做，Section 渲染 endpoint/certDir/runtimeClass/rows/cols |
+| **终端页** | host 用 node-pty + WebSocket；client 用 xterm.js + `@xterm/addon-fit`，WS 协议 = 裸文本输入 + `{type:'resize'}` JSON | 照做 WS 协议，但 pty 后端换成**我们的 KIP-19 远程 PTY（gRPC spawnTerminal）**，不是 node-pty |
+| **构建** | tsdown：host → ESM `lib/index.js`；client → CJS closure factory `window.__ModuleLoader__.load({id, factory})`，react 等平台模块 external | 照做（或先 esbuild 等价实现） |
+| **纯度门** | client bundle 禁止 value-import `@deepseek-ai/*`（跨插件只走 cordis 服务） | 照做：client 不 import dsh 服务包 |
+
+关键结论：**我们的终端不是「本机 node-pty」，而是「远端沙盒 PTY」**——这是与 better-sidebar 最大的不同。其余（配置页、WS 桥、xterm 渲染、dsh.client 打包）可以几乎原样借鉴。
+
+## 2. 总体架构
+
+```
+浏览器（client half，@k8e/dsh-k8e-sandbox/client）
+  ├── 设置页 section（配置页）：endpoint / certDir / runtimeClass / rows / cols
+  ├── 沙盒终端面板：xterm.js，实时渲染命令输出 + 可交互 PTY
+  │     │ WebSocket (/k8e-sandbox/ws/terminal)
+  ▼     │
+host half（新增 k8e-sandbox-host-ui 插件）
+  ├── ctx.webServer.register('/k8e-sandbox/api/*')   # status / session / prefs
+  ├── ctx.webServer.registerUpgrade('/k8e-sandbox/ws/terminal')
+  │     ├── 交互式终端：GrpcK8eClient.spawnTerminal → 把 PTY 流桥成 WS
+  │     └── 实时监控：订阅 ctx.subprocess 的 spawn 输出 → 推到 WS
+  └── ctx.settings.register(ns, PrefsSchema)          # 用户偏好
+        └── ctx.k8eSandbox（已有 owner 服务，读 endpoint/certDir）
+```
+
+## 3. 配置页面（两个层次）
+
+### 3.1 部署级 Config（cordis.patch.yml 已能配）
+
+已有：`endpoint / profile / certDir / cwd / runtimeClass / tenant / allowedHosts / pauseOnDispose`。这是「管理员在 profile 里写」的层，不改。
+
+### 3.2 用户级 Prefs（设置页 section，新增）
+
+用设置 seam 暴露一份**用户可在 UI 改**的偏好：
+
+```ts
+export const PrefsSchema = z.object({
+  endpoint: z.string().default(''),        // 空 = 用 CLI 本地自动发现
+  certDir: z.string().default(''),
+  runtimeClass: z.string().default('gvisor'),
+  rows: z.number().min(1).max(200).default(24),
+  cols: z.number().min(1).max(400).default(80),
+  autoOpenTerminal: z.boolean().default(true),  // 调用 sandbox 时自动弹终端
+})
+```
+
+- **host**：`ctx.inject(['settings'], s => s.settings.register('k8e-sandbox', PrefsSchema))`，并把 endpoint/certDir 喂给 `ctx.k8eSandbox`（owner 的 `getGrpcClient()` 优先读运行时设置，其次读 Config）。
+- **client**：`ctx.slots.inject('settings.section', () => ctx.slots.register({ name:'settings.section', id:'k8e-sandbox', order, label, inject }, K8eSettingsSection))`。Section 渲染上面几个字段（text/number 控件，学 better-sidebar §8 的声明式设置）。
+
+## 4. 沙盒终端页
+
+两个能力合成一个终端面板：
+
+### 4.1 交互式 PTY（用户自己敲命令）
+
+```
+client xterm.js  ──WS──▶  host /k8e-sandbox/ws/terminal
+                            │  GrpcK8eClient.createTerminal({argv:['bash','-l'], rows, cols})
+                            │  GrpcK8eClient.terminalStream(terminalId)  → 喂 WS
+                            │  WS input → GrpcK8eClient.terminalWrite
+                            │  WS resize → GrpcK8eClient.terminalResize
+                            │  WS close → GrpcK8eClient.terminalDestroy
+```
+
+WS 协议照搬 better-sidebar：裸文本 = 输入；`{type:'resize',cols,rows}` = 尺寸；`{type:'close'}` = 关闭；host 侧 `terminalStream` 的 data 帧逐段 `ws.send`，exit 帧发 `\r\n[process exited with code N]\r\n`。
+
+### 4.2 实时命令监控（agent 跑命令时自动显示）
+
+这是「调用 sandbox 时出来一个终端页、实时显示运行命令」的核心：
+
+- host 在 `ctx.subprocess`（我们的 `K8eSubprocessRuntime`）每次 `spawn` 时，把命令 + stdout/stderr 流**旁路一份**到监控总线（一个进程内 EventEmitter/广播）。
+- WS 连接附带 `?watch=1`（监控模式）时，host 把这股流转发过去；client 在一个只读的「命令回放/实时」区域渲染（`$ echo hello` → 输出 → exit code）。
+- `autoOpenTerminal` 偏好开启时，client 侦听到「sandbox 有活动」就自动展开/聚焦终端面板。
+
+> 实现落点：要么在 `K8eSubprocessRuntime.spawn/spawnTerminal` 里发一个 `ctx.on('k8e-sandbox/exec', ...)` 事件（把输出流桥出来），要么让 host-ui 插件包一层。优先前者——provider 自己发事件，最小侵入。
+
+## 5. 包结构变化
+
+新增一个 client/UI 包（或塞进现有 bundle）：
+
+```
+plugins/deepseek-harness/packages/
+├── dsh-k8e-sandbox-bundle/       # 已有：dsh.bundle.patch（挂 host 行）
+│   └── cordis.patch.yml          # 增加一行：k8e-sandbox-host-ui
+├── dsh-k8e-sandbox-host-ui/      # 新增：host 半身的 UI 桥（HTTP/WS/settings）
+│   └── src/index.ts
+└── dsh-k8e-sandbox-client-ui/    # 新增：client 半身（dsh.client 的 ./client 入口）
+    └── src/index.tsx             # 设置 section + 终端面板（xterm.js）
+```
+
+`dsh-k8e-sandbox-bundle/package.json` 增加：
+
+```jsonc
+"dsh": {
+  "bundle": { "patch": "./cordis.patch.yml" },
+  "client": {
+    "inject": [
+      "@deepseek-ai/dsh-client-runtime",
+      "@deepseek-ai/dsh-client-locale",
+      "@deepseek-ai/dsh-client-ui-slots",
+      "@deepseek-ai/dsh-client-ui-conversation",
+      "@deepseek-ai/dsh-client-ui-settings",
+      "@deepseek-ai/dsh-client-ui-primitives",
+      "@deepseek-ai/dsh-client-web-react"
+    ],
+    "platform": "web"
+  }
+}
+```
+
+## 6. 构建与按需加载（核心 ~325KB + 懒 chunk）
+
+**目标：启动只拉核心 bundle（~325KB）；终端（xterm）等重依赖首次用到才按需拉。** 照搬 better-sidebar 的懒 chunk 机制（`chunk-loader.ts` + `bundle-route.ts` + tsdown `chunkBundle`）：
+
+### 产物拆分
+
+| 产物 | 内容 | 加载时机 |
+|---|---|---|
+| `lib/index.js`（host，ESM） | host-ui 桥（HTTP/WS/settings），`@deepseek-ai/*` peer | profile 启动 |
+| `lib/client.js`（client 核心，CJS closure `window.__ModuleLoader__.load({id, factory})`） | 设置 section + 终端**外壳**（占位 + 懒加载触发）；`react`/平台模块 external；**不内联 xterm** | 页面启动（~325KB） |
+| `lib/client-terminal.js`（懒 chunk） | xterm + `@xterm/addon-fit` 打包成独立脚本，`globalThis.__dshChunks__["terminal"] = (require) => {...}` | 终端首次打开 |
+
+### 懒加载流程（client `chunk-loader`）
+
+1. 终端 tab 首次打开 → `loadChunk('terminal')`；
+2. inject `<script src="/k8e-sandbox/bundle/terminal.js">`（同源经典 script）；
+3. 从 `globalThis.__dshChunks__["terminal"]` 取 factory，用 `window.__DSH_MODULES__.import(spec)` 构造 require（平台模块走 seed 表）调用之；
+4. 缓存三层：in-flight promise 记忆化 / 失败清缓存重试 / 每次激活 `resetChunks()`（HMR 安全）。
+
+### chunk 服务（host 路由 `/k8e-sandbox/bundle/<name>.js`）
+
+- allowlist 名字（`terminal`），防路径穿越；
+- `cache-control: no-cache` + ETag（mtime/size 记忆化哈希），304 复用——刷新/HMR 不重复下载多 MB chunk；
+- 走与 `/api` 相同的 trust fence。
+
+### 构建工具
+
+Phase 1 用 esbuild 等价实现：核心 bundle + `terminal` chunk 各打一个（`__ModuleLoader__` / `__dshChunks__` 手交格式，`codeSplitting: false`）；摸清官方 `tsdown.client.ts` preset 后再切 tsdown。
+
+## 7. 落地顺序
+
+1. **M1**：`dsh-k8e-sandbox-host-ui`（`/k8e-sandbox/api/status` + settings namespace + 终端 WS 桥，先把 `spawnTerminal` 的 gRPC 流桥成 WS）。
+2. **M2**：`dsh-k8e-sandbox-client-ui`（设置 section + xterm 终端面板 + `__ModuleLoader__` 打包）。
+3. **M3**：实时命令监控（`spawn` 输出旁路 + `autoOpenTerminal` 自动展开）。
+4. **M4**：可选 better-sidebar 集成（若装了 better-sidebar，用 `ctx.betterSidebar.registerTab` 挂我们的终端 tab）。
+
+## 8. 已知风险
+
+- **dsh.client 打包格式**（`__ModuleLoader__.load` 的 closure factory + 纯度门 + 平台模块 external 清单）是最容易踩坑的地方，需要对着 dsh 官方 `packages/client/tsdown.client.ts` preset 逐项核对。
+- **xterm.js 体积**：已由懒 chunk 解决（见 §6）——核心 bundle 不内联 xterm，终端首次打开才拉 `client-terminal.js`。
+- **终端 WS 的 mTLS**：WS 走 dsh webServer 的 trust fence（better-sidebar 同款），不直接暴露 gRPC mTLS；host 侧持 gRPC client 证书。

--- a/plugins/deepseek-harness/package.json
+++ b/plugins/deepseek-harness/package.json
@@ -9,6 +9,16 @@
   "devDependencies": {
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.13",
-    "esbuild": "^0.28.2"
+    "@types/node": "^22.0.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@types/ws": "^8.5.10",
+    "@xterm/addon-fit": "^0.10.0",
+    "esbuild": "^0.28.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.6.0",
+    "ws": "^8.18.0",
+    "xterm": "^5.3.0"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
@@ -14,3 +14,10 @@
       name: '@k8e/dsh-k8e-sandbox-fs'
     - id: k8e-sandbox-subprocess
       name: '@k8e/dsh-k8e-sandbox-subprocess'
+    - id: k8e-sandbox-host-ui
+      name: '@k8e/dsh-k8e-sandbox-host-ui'
+    # Browser half: registers the settings page + terminal panel. The modules
+    # node half scans this row's `dsh.client` declaration into __DSH_BOOT__ and
+    # serves /plugins/@k8e/dsh-k8e-sandbox-client-ui/client.js.
+    - id: k8e-sandbox-client-ui
+      name: '@k8e/dsh-k8e-sandbox-client-ui'

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@k8e/dsh-k8e-sandbox": "workspace:*",
     "@k8e/dsh-k8e-sandbox-fs": "workspace:*",
-    "@k8e/dsh-k8e-sandbox-subprocess": "workspace:*"
+    "@k8e/dsh-k8e-sandbox-subprocess": "workspace:*",
+    "@k8e/dsh-k8e-sandbox-host-ui": "workspace:*",
+    "@k8e/dsh-k8e-sandbox-client-ui": "workspace:*"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox-client-ui",
+  "version": "0.1.0",
+  "description": "k8e-sandbox client half: settings section + terminal panel (KIP-20 M2).",
+  "type": "module",
+  "files": ["lib"],
+  "exports": {
+    "./client": "./lib/client.js",
+    "./client-terminal": "./lib/client-terminal.js",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "node ../../scripts/build-client.mjs"
+  },
+  "dsh": {
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-runtime",
+        "@deepseek-ai/dsh-client-locale",
+        "@deepseek-ai/dsh-client-ui-slots"
+      ],
+      "platform": "web"
+    }
+  },
+  "dependencies": {
+    "@xterm/addon-fit": "^0.10.0",
+    "xterm": "^5.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@deepseek-ai/cordis": "*"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/activity.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/activity.ts
@@ -1,0 +1,37 @@
+/**
+ * Core-bundle activity watcher (KIP-20 M3): subscribes to the sandbox activity
+ * SSE and, when `autoOpenTerminal` is on, lazily loads the terminal chunk and
+ * opens the panel on the first sandbox execution. Keeps the xterm dependency
+ * out of the core bundle — only the SSE (a DOM EventSource) runs at startup.
+ */
+
+import { loadPrefs } from './prefs.ts'
+import { loadChunk } from './chunk-loader.ts'
+
+export function watchSandboxActivity(): () => void {
+  // The SSE stays open regardless of the current preference so a user who
+  // toggles autoOpenTerminal in settings mid-session is honoured without a
+  // reload; the pref is re-read on every activity rather than captured here.
+  const es = new EventSource('/k8e-sandbox/activity')
+
+  const onExec = (event: Event): void => {
+    let phase: unknown
+    try {
+      phase = (JSON.parse((event as MessageEvent).data as string) as { phase?: unknown }).phase
+    } catch {
+      return
+    }
+    if (phase !== 'start') return
+    if (!loadPrefs().autoOpenTerminal) return
+    void loadChunk('terminal')
+      .then((chunk) => { (chunk as { openTerminalPanel: () => void }).openTerminalPanel() })
+      .catch(() => undefined)
+  }
+
+  es.addEventListener('exec', onExec)
+
+  return () => {
+    es.removeEventListener('exec', onExec)
+    es.close()
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/better-sidebar.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/better-sidebar.ts
@@ -1,0 +1,46 @@
+/**
+ * Optional DSH-better-sidebar integration (KIP-20 M4): when better-sidebar is
+ * installed (its client half provides `ctx.betterSidebar`), register a
+ * `k8e-sandbox:terminal` tab that renders the same terminal panel as the
+ * floating window. The terminal content lives in the lazy chunk, so this tab
+ * costs the core bundle nothing until opened.
+ */
+
+import { createElement, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { Context } from './context-types.ts'
+import { loadChunk } from './chunk-loader.ts'
+
+/** Tab content: lazily load the terminal chunk on first mount. */
+function K8eTerminalTab(): ReactNode {
+  const [component, setComponent] = useState<((props: { rows?: number; cols?: number }) => ReactNode) | undefined>(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadChunk('terminal')
+      .then((chunk) => {
+        if (cancelled) return
+        setComponent(() => (chunk as { SandboxTerminalTab: (props: { rows?: number; cols?: number }) => ReactNode }).SandboxTerminalTab)
+      })
+      .catch(() => undefined)
+    return () => { cancelled = true }
+  }, [])
+
+  if (component === undefined) {
+    return createElement('div', { style: { padding: '12px', color: '#999', fontSize: '13px' } }, 'Loading terminal…')
+  }
+  return createElement(component, {})
+}
+
+/** Register the terminal tab; a no-op when better-sidebar is absent. */
+export function registerBetterSidebarTab(ctx: Context): void {
+  const betterSidebar = ctx.get('betterSidebar')
+  if (betterSidebar === undefined) return
+  ctx.effect(() => betterSidebar.registerTab({
+    id: 'k8e-sandbox:terminal',
+    title: 'K8E Terminal',
+    order: 45,
+    single: true,
+    component: () => createElement(K8eTerminalTab, {}),
+  }), 'k8e-sandbox-ui: better-sidebar terminal tab')
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/chunk-loader.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/chunk-loader.ts
@@ -1,0 +1,68 @@
+/**
+ * Lazy chunk loader (mirror of DSH-better-sidebar's chunk-loader): the heavy
+ * xterm stack lives in `lib/client-terminal.js`, fetched on first terminal open
+ * so startup parses only the core bundle.
+ */
+
+export type ChunkName = 'terminal'
+
+interface ChunkModuleSystem {
+  import(specifier: string): Promise<unknown>
+}
+
+function moduleSystem(): ChunkModuleSystem | undefined {
+  return (globalThis as { __DSH_MODULES__?: ChunkModuleSystem }).__DSH_MODULES__
+}
+
+interface ChunkRegistry {
+  [name: string]: ((require: (spec: string) => unknown) => Record<string, unknown>) | undefined
+}
+
+function chunkRegistry(): ChunkRegistry {
+  const g = globalThis as { __dshChunks__?: ChunkRegistry }
+  g.__dshChunks__ ??= {}
+  return g.__dshChunks__
+}
+
+const CHUNK_URL = (name: ChunkName): string => `/k8e-sandbox/bundle/${name}.js`
+
+const cache = new Map<ChunkName, Promise<Record<string, unknown>>>()
+
+function scriptLoader(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const el = document.createElement('script')
+    el.async = true
+    el.src = src
+    el.addEventListener('load', () => { el.remove(); resolve() }, { once: true })
+    el.addEventListener('error', () => { el.remove(); reject(new Error(`chunk script ${src} failed to load`)) }, { once: true })
+    document.head.append(el)
+  })
+}
+
+export function loadChunk(name: ChunkName): Promise<Record<string, unknown>> {
+  const cached = cache.get(name)
+  if (cached !== undefined) return cached
+  const task = (async (): Promise<Record<string, unknown>> => {
+    const modules = moduleSystem()
+    if (modules === undefined) throw new Error(`chunk "${name}": client module system unavailable`)
+    await scriptLoader(CHUNK_URL(name))
+    const factory = chunkRegistry()[name]
+    if (typeof factory !== 'function') throw new Error(`chunk "${name}" script did not register its factory`)
+    const externals = new Map<string, unknown>()
+    await Promise.all(['react', 'react/jsx-runtime', 'react-dom/client'].map(async (spec) => {
+      try { externals.set(spec, await modules.import(spec)) } catch { externals.set(spec, undefined) }
+    }))
+    const require = (spec: string): unknown => {
+      if (!externals.has(spec)) throw new Error(`chunk require('${spec}') missed the module table`)
+      return externals.get(spec)
+    }
+    return factory(require)
+  })()
+  cache.set(name, task)
+  void task.catch(() => { cache.delete(name) })
+  return task
+}
+
+export function resetChunks(): void {
+  cache.clear()
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/context-types.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/context-types.ts
@@ -1,0 +1,62 @@
+/**
+ * Local structural contracts for the client half (mirror of DSH-better-sidebar's
+ * context-types.ts): the `@deepseek-ai/*` client service type packages are not
+ * resolvable from a third-party workspace, so the faces this plugin touches are
+ * restated structurally. Drift is contained to this file.
+ */
+
+export type { Context } from '@deepseek-ai/cordis'
+
+/** The client slots service face (register + inject). */
+export interface SandboxClientSlots {
+  register(options: {
+    name: string
+    id?: string
+    key?: string
+    order?: number
+    label?: string | (() => string)
+    locale?: string
+    inject?: (...args: any[]) => Record<string, unknown>
+    children?: Record<string, unknown>
+    [k: string]: unknown
+  }, component: unknown): () => void
+  inject(key: string, callback: () => () => void): () => void
+}
+
+/** The client locale service face (bind + getSnapshot/subscribe + register). */
+export interface SandboxClientLocale {
+  getSnapshot(): { active: string; revision?: number }
+  subscribe(fn: () => void): () => void
+  /** Register one namespace's dictionaries: `{ zh: {...}, en: {...} }`. */
+  register(ns: string, dicts: Record<string, Record<string, string>>): () => void
+  /** Namespace-bound translate; repeat binds return the same function. */
+  bind(ns: string): (key: string, params?: Record<string, string>) => string
+}
+
+/**
+ * Minimal structural contract of DSH-better-sidebar's `ctx.betterSidebar`
+ * service (registerTab only). Declared locally so this plugin stays an
+ * optional soft dependency: `ctx.get('betterSidebar')` returns `undefined`
+ * when better-sidebar is not installed, and registration is skipped.
+ */
+export interface BetterSidebarService {
+  registerTab(descriptor: {
+    id: string
+    title: string | (() => string)
+    icon?: unknown
+    order?: number
+    hidden?: boolean
+    single?: boolean
+    component: (props: { visible: boolean; [k: string]: unknown }) => unknown
+    [k: string]: unknown
+  }): () => void
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    slots: SandboxClientSlots
+    locale: SandboxClientLocale
+    betterSidebar?: BetterSidebarService
+    effect(fn: () => void | (() => void), label?: string): void
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/exec-types.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/exec-types.ts
@@ -1,0 +1,24 @@
+/**
+ * Wire shapes shared by the core (auto-open watcher) and the terminal chunk
+ * (command log) for the sandbox activity SSE. Type-only — esbuild erases these,
+ * so the core and chunk stay separate bundles.
+ */
+
+/** One sandbox execution activity, streamed by /k8e-sandbox/activity. */
+export type K8eExecEvent =
+  | { phase: 'start'; id: string; command: string; cwd?: string; at: number }
+  | { phase: 'output'; id: string; stream: 'stdout' | 'stderr'; data: string; at: number }
+  | { phase: 'exit'; id: string; exitCode: number | null; signal: string | null; at: number }
+
+/** One accumulated command for the log replay (`history` SSE event). */
+export interface ExecLogEntry {
+  id: string
+  command: string
+  cwd?: string
+  startedAt: number
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  signal: string | null
+  settled: boolean
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/index.tsx
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * Client half of dsh-k8e-sandbox (KIP-20 M2): registers the sandbox settings
+ * page (`settings.section`) with locale dictionaries. The terminal panel is a
+ * lazy chunk (see chunk-loader.ts / terminal.tsx) so xterm never ships in this
+ * core bundle.
+ * @module @k8e/dsh-k8e-sandbox-client-ui/client
+ */
+
+import type { Context } from './context-types.ts'
+import { K8eSettingsSection } from './settings-section.tsx'
+import { watchSandboxActivity } from './activity.ts'
+import { registerBetterSidebarTab } from './better-sidebar.ts'
+
+const NS = 'k8e-sandbox'
+
+const zh = {
+  'section.nav': 'K8E 沙盒',
+  'section.title': 'K8E 沙盒',
+  'status.heading': '沙盒状态',
+  'status.connected': '已连接',
+  'status.noGrpc': '未配置 gRPC（终端需要显式 endpoint）',
+  'status.cwd': '工作目录',
+  'prefs.heading': '终端偏好',
+  'prefs.rows': '行数',
+  'prefs.cols': '列数',
+  'prefs.autoOpen': '调用沙盒时自动打开终端',
+  'actions.openTerminal': '打开终端',
+  'actions.save': '保存',
+  'actions.saved': '已保存',
+  'hint.hostConfig': 'endpoint / runtimeClass 等部署级配置在 profile 的 dsh-k8e-sandbox 行里设置。',
+} as const
+
+const en: Record<keyof typeof zh, string> = {
+  'section.nav': 'K8E Sandbox',
+  'section.title': 'K8E Sandbox',
+  'status.heading': 'Sandbox status',
+  'status.connected': 'Connected',
+  'status.noGrpc': 'gRPC not configured (terminal needs an explicit endpoint)',
+  'status.cwd': 'Working directory',
+  'prefs.heading': 'Terminal preferences',
+  'prefs.rows': 'Rows',
+  'prefs.cols': 'Columns',
+  'prefs.autoOpen': 'Auto-open terminal on sandbox activity',
+  'actions.openTerminal': 'Open terminal',
+  'actions.save': 'Save',
+  'actions.saved': 'Saved',
+  'hint.hostConfig': 'Deploy-level config (endpoint / runtimeClass) lives in the dsh-k8e-sandbox profile row.',
+}
+
+/** Client services required before activation. */
+export const inject = ['slots', 'locale']
+
+export function apply(ctx: Context): void {
+  ctx.effect(() => ctx.locale.register(NS, { zh, en }), 'k8e-sandbox-ui: dictionaries')
+
+  // The nav label is a locale-following thunk (re-resolved per render); the
+  // section content reads the framework-injected `t` seat (`locale: NS`).
+  const t = ctx.locale.bind(NS)
+  ctx.slots.inject('settings.section', () => ctx.slots.register({
+    name: 'settings.section',
+    id: 'k8e-sandbox',
+    order: 300,
+    label: () => t('section.nav'),
+    locale: NS,
+  }, K8eSettingsSection))
+
+  // Auto-open the terminal panel on sandbox activity (M3). The EventSource is
+  // cheap; the heavy xterm chunk is loaded lazily on the first activity.
+  ctx.effect(() => watchSandboxActivity(), 'k8e-sandbox-ui: activity watcher')
+
+  // Optional better-sidebar tab (M4): skipped when better-sidebar is absent.
+  registerBetterSidebarTab(ctx)
+}
+
+export default apply

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/prefs.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/prefs.ts
@@ -1,0 +1,47 @@
+/**
+ * User-level terminal preferences (rows/cols/auto-open). These are pure
+ * browser concerns — persisted to localStorage, read by the settings section
+ * and the terminal panel. Deploy-level config (endpoint/runtimeClass/certDir)
+ * stays host-side in the `dsh-k8e-sandbox` owner row.
+ */
+
+export interface TerminalPrefs {
+  rows: number
+  cols: number
+  autoOpenTerminal: boolean
+}
+
+const KEY = 'k8e-sandbox:terminal-prefs'
+
+const DEFAULTS: TerminalPrefs = { rows: 24, cols: 80, autoOpenTerminal: true }
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, Math.round(n)))
+}
+
+export function loadPrefs(): TerminalPrefs {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (raw === null) return { ...DEFAULTS }
+    const parsed = JSON.parse(raw) as Partial<TerminalPrefs>
+    return {
+      rows: clampInt(parsed.rows, 1, 200, DEFAULTS.rows),
+      cols: clampInt(parsed.cols, 1, 400, DEFAULTS.cols),
+      autoOpenTerminal: typeof parsed.autoOpenTerminal === 'boolean'
+        ? parsed.autoOpenTerminal
+        : DEFAULTS.autoOpenTerminal,
+    }
+  } catch {
+    return { ...DEFAULTS }
+  }
+}
+
+export function savePrefs(prefs: TerminalPrefs): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(prefs))
+  } catch {
+    // Storage disabled (private mode, quota): the panel still works with defaults.
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/settings-section.tsx
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/settings-section.tsx
@@ -1,0 +1,177 @@
+/**
+ * The K8E Sandbox settings page (registered into `settings.section`). Shows
+ * the sandbox status (host /k8e-sandbox/api/status) and the user-level terminal
+ * preferences; the "打开终端" action lazy-loads the terminal chunk.
+ */
+
+import { createElement, useEffect, useState } from 'react'
+import type { ChangeEvent, CSSProperties, ReactNode } from 'react'
+import { loadChunk } from './chunk-loader.ts'
+import { loadPrefs, savePrefs, type TerminalPrefs } from './prefs.ts'
+
+export interface K8eSettingsSectionProps {
+  t: (key: string, params?: Record<string, string>) => string
+}
+
+interface Status {
+  ok: boolean
+  grpcAvailable: boolean
+  cwd?: string
+  endpoint?: string
+  runtimeClass?: string
+}
+
+const box: CSSProperties = {
+  background: 'var(--dsw-alias-bg-layer-1, #1f1f1f)',
+  border: '1px solid var(--dsw-alias-border, #333)',
+  borderRadius: '8px',
+  padding: '14px 16px',
+}
+
+const labelStyle: CSSProperties = {
+  display: 'block',
+  fontSize: '12px',
+  color: 'var(--dsw-alias-label-secondary, #999)',
+  marginBottom: '6px',
+}
+
+const fieldStyle: CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  padding: '8px 10px',
+  borderRadius: '6px',
+  border: '1px solid var(--dsw-alias-border, #333)',
+  background: 'var(--dsw-alias-bg-input, transparent)',
+  color: 'var(--dsw-alias-label-primary, #eee)',
+  fontSize: '13px',
+}
+
+const buttonStyle: CSSProperties = {
+  padding: '8px 14px',
+  borderRadius: '6px',
+  border: '1px solid var(--dsw-alias-border, #333)',
+  background: 'var(--dsw-alias-bg-button, #2a2a2a)',
+  color: 'var(--dsw-alias-label-primary, #eee)',
+  cursor: 'pointer',
+  fontSize: '13px',
+}
+
+const primaryButtonStyle: CSSProperties = {
+  ...buttonStyle,
+  background: 'var(--dsw-alias-accent, #2f6fed)',
+  borderColor: 'var(--dsw-alias-accent, #2f6fed)',
+  color: '#fff',
+}
+
+function Field(props: { label: string; children: ReactNode }): ReactNode {
+  return createElement('div', { style: { marginBottom: '14px' } },
+    createElement('label', { style: labelStyle }, props.label),
+    props.children,
+  )
+}
+
+export function K8eSettingsSection(props: K8eSettingsSectionProps): ReactNode {
+  const { t } = props
+  const [status, setStatus] = useState<Status | undefined>(undefined)
+  const [prefs, setPrefs] = useState<TerminalPrefs>(() => loadPrefs())
+  const [saved, setSaved] = useState(false)
+  const [opening, setOpening] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/k8e-sandbox/api/status', { method: 'POST' })
+        const body = (await res.json()) as Status
+        if (!cancelled) setStatus(body)
+      } catch {
+        if (!cancelled) setStatus({ ok: false, grpcAvailable: false })
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const openTerminal = async (): Promise<void> => {
+    if (opening) return
+    setOpening(true)
+    try {
+      const chunk = await loadChunk('terminal')
+      const { openTerminalPanel } = chunk as { openTerminalPanel: () => void }
+      openTerminalPanel()
+    } finally {
+      setOpening(false)
+    }
+  }
+
+  const onSave = (): void => {
+    savePrefs(prefs)
+    setSaved(true)
+    window.setTimeout(() => setSaved(false), 1500)
+  }
+
+  const connected = status?.grpcAvailable === true
+
+  return createElement('div', { style: { maxWidth: '560px' } },
+    createElement('h3', { style: { margin: '0 0 14px', fontSize: '16px', color: 'var(--dsw-alias-label-primary, #eee)' } },
+      t('section.title')),
+
+    createElement('div', { style: box },
+      createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-secondary, #999)', marginBottom: '8px' } },
+        t('status.heading')),
+      createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-primary, #eee)', marginBottom: '6px' } },
+        connected
+          ? createElement('span', { style: { color: '#4caf50' } }, '● ' + t('status.connected'))
+          : createElement('span', { style: { color: '#e5a50a' } }, '● ' + t('status.noGrpc'))),
+      status?.cwd !== undefined
+        ? createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-secondary, #999)' } },
+          t('status.cwd') + ': ' + status.cwd)
+        : null,
+      status?.endpoint !== undefined
+        ? createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-secondary, #999)' } },
+          'endpoint: ' + (status.endpoint || '—'))
+        : null,
+      status?.runtimeClass !== undefined
+        ? createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-secondary, #999)' } },
+          'runtimeClass: ' + status.runtimeClass)
+        : null,
+      createElement('div', { style: { fontSize: '12px', color: 'var(--dsw-alias-label-secondary, #999)', marginTop: '10px' } },
+        t('hint.hostConfig')),
+    ),
+
+    createElement('div', { style: { ...box, marginTop: '16px' } },
+      createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-secondary, #999)', marginBottom: '14px' } },
+        t('prefs.heading')),
+
+      Field({ label: t('prefs.rows'), children: createElement('input', {
+        type: 'number', min: 1, max: 200, value: prefs.rows, style: fieldStyle,
+        onChange: (e: ChangeEvent<HTMLInputElement>) => {
+          const n = Number(e.target.value)
+          setPrefs({ ...prefs, rows: Number.isFinite(n) ? n : prefs.rows })
+        },
+      }) }),
+
+      Field({ label: t('prefs.cols'), children: createElement('input', {
+        type: 'number', min: 1, max: 400, value: prefs.cols, style: fieldStyle,
+        onChange: (e: ChangeEvent<HTMLInputElement>) => {
+          const n = Number(e.target.value)
+          setPrefs({ ...prefs, cols: Number.isFinite(n) ? n : prefs.cols })
+        },
+      }) }),
+
+      Field({ label: t('prefs.autoOpen'), children: createElement('input', {
+        type: 'checkbox',
+        checked: prefs.autoOpenTerminal,
+        onChange: (e: ChangeEvent<HTMLInputElement>) => {
+          setPrefs({ ...prefs, autoOpenTerminal: e.target.checked })
+        },
+      }) }),
+
+      createElement('div', { style: { display: 'flex', gap: '10px', alignItems: 'center', marginTop: '18px' } },
+        createElement('button', { type: 'button', style: primaryButtonStyle, onClick: openTerminal, disabled: opening },
+          opening ? '…' : t('actions.openTerminal')),
+        createElement('button', { type: 'button', style: buttonStyle, onClick: onSave },
+          saved ? t('actions.saved') : t('actions.save')),
+      ),
+    ),
+  )
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/terminal.tsx
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/terminal.tsx
@@ -1,0 +1,262 @@
+/**
+ * The sandbox terminal panel (lazy chunk): xterm.js rendering the remote PTY
+ * bridged by the host over /k8e-sandbox/ws/terminal, plus a read-only command
+ * log fed by the /k8e-sandbox/activity SSE (running commands live). Loaded on
+ * first open via the chunk loader, so xterm never ships in the core bundle.
+ * xterm + @xterm/addon-fit are INLINED here; react/react-dom come from the
+ * module table.
+ */
+
+import { createElement, useEffect, useRef, useState } from 'react'
+import type { CSSProperties, Dispatch, ReactNode, SetStateAction } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Terminal } from 'xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { loadPrefs } from './prefs.ts'
+import type { ExecLogEntry, K8eExecEvent } from './exec-types.ts'
+
+export interface TerminalViewProps {
+  rows?: number
+  cols?: number
+}
+
+export function TerminalView(props: TerminalViewProps): ReturnType<typeof createElement> {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (host === null) return
+    let socket: WebSocket | undefined
+    let term: Terminal | undefined
+    let fit: FitAddon | undefined
+
+    term = new Terminal({
+      rows: props.rows ?? 24,
+      cols: props.cols ?? 80,
+      fontSize: 13,
+      cursorBlink: true,
+    })
+    fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(host)
+    fit.fit()
+
+    const onResize = (): void => { fit?.fit() }
+
+    const query = new URLSearchParams({ rows: String(term.rows), cols: String(term.cols) })
+    socket = new WebSocket(`/k8e-sandbox/ws/terminal?${query.toString()}`)
+    socket.binaryType = 'arraybuffer'
+    socket.onmessage = (event) => {
+      term?.write(typeof event.data === 'string' ? event.data : new Uint8Array(event.data as ArrayBuffer))
+    }
+    socket.onclose = () => {
+      term?.write('\r\n[terminal closed]\r\n')
+    }
+    // Buffer input/resize during the brief CONNECTING window and flush once the
+    // socket opens, so early keystrokes are not silently dropped.
+    const pending: string[] = []
+    const send = (data: string): void => {
+      if (socket?.readyState === WebSocket.OPEN) socket.send(data)
+      else if (socket?.readyState === WebSocket.CONNECTING) pending.push(data)
+    }
+    socket.onopen = () => {
+      for (const chunk of pending.splice(0)) {
+        if (socket?.readyState === WebSocket.OPEN) socket.send(chunk)
+      }
+    }
+    term.onData((data) => { send(data) })
+    term.onResize((size) => {
+      send(JSON.stringify({ type: 'resize', cols: size.cols, rows: size.rows }))
+    })
+    window.addEventListener('resize', onResize)
+
+    return () => {
+      window.removeEventListener('resize', onResize)
+      if (socket?.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: 'close' }))
+      }
+      socket?.close()
+      term?.dispose()
+    }
+  }, [props.rows, props.cols])
+
+  return createElement('div', {
+    ref: hostRef,
+    style: { width: '100%', height: '100%', background: '#1e1e1e' },
+  })
+}
+
+type SetEntries = Dispatch<SetStateAction<ExecLogEntry[]>>
+
+function applyExecEvent(ev: K8eExecEvent, setEntries: SetEntries): void {
+  if (ev.phase === 'start') {
+    setEntries((prev) => [...prev, {
+      id: ev.id,
+      command: ev.command,
+      cwd: ev.cwd,
+      startedAt: ev.at,
+      stdout: '',
+      stderr: '',
+      exitCode: null,
+      signal: null,
+      settled: false,
+    }])
+  } else if (ev.phase === 'output') {
+    setEntries((prev) => prev.map((entry) => {
+      if (entry.id !== ev.id) return entry
+      return ev.stream === 'stderr'
+        ? { ...entry, stderr: entry.stderr + ev.data }
+        : { ...entry, stdout: entry.stdout + ev.data }
+    }))
+  } else {
+    setEntries((prev) => prev.map((entry) => (
+      entry.id === ev.id ? { ...entry, exitCode: ev.exitCode, signal: ev.signal, settled: true } : entry
+    )))
+  }
+}
+
+const logStyle: CSSProperties = {
+  flex: '0 0 auto',
+  maxHeight: '45%',
+  overflowY: 'auto',
+  padding: '8px 10px',
+  background: '#161616',
+  borderBottom: '1px solid #2a2a2a',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: '12px',
+  lineHeight: '1.5',
+}
+
+const cmdStyle: CSSProperties = { color: '#7fd4c1', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }
+const outStyle: CSSProperties = { color: '#d6d6d6', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }
+const errStyle: CSSProperties = { color: '#e5979a', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }
+const exitStyle: CSSProperties = { color: '#888', marginBottom: '8px' }
+
+function ExecLogRow(props: { entry: ExecLogEntry }): ReactNode {
+  const { entry } = props
+  const exitLabel = entry.exitCode === null ? '[exited]' : `[exit ${entry.exitCode}]`
+  return createElement('div', { style: { marginBottom: '4px' } },
+    createElement('div', { style: cmdStyle }, '$ ' + entry.command),
+    entry.stdout.length > 0 ? createElement('div', { style: outStyle }, entry.stdout) : null,
+    entry.stderr.length > 0 ? createElement('div', { style: errStyle }, entry.stderr) : null,
+    entry.settled
+      ? createElement('div', { style: exitStyle }, exitLabel)
+      : createElement('div', { style: exitStyle }, '…'),
+  )
+}
+
+function CommandLog(): ReactNode {
+  const [entries, setEntries] = useState<ExecLogEntry[]>([])
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const es = new EventSource('/k8e-sandbox/activity')
+    es.addEventListener('history', (event) => {
+      try {
+        const parsed = JSON.parse((event as MessageEvent).data as string) as { entries: ExecLogEntry[] }
+        if (Array.isArray(parsed.entries)) setEntries(parsed.entries)
+      } catch {
+        // Ignore malformed history; live events still arrive.
+      }
+    })
+    es.addEventListener('exec', (event) => {
+      try {
+        applyExecEvent(JSON.parse((event as MessageEvent).data as string) as K8eExecEvent, setEntries)
+      } catch {
+        // Ignore malformed frames.
+      }
+    })
+    return () => { es.close() }
+  }, [])
+
+  useEffect(() => {
+    const el = listRef.current
+    if (el !== null) el.scrollTop = el.scrollHeight
+  }, [entries])
+
+  if (entries.length === 0) {
+    return createElement('div', { style: logStyle },
+      createElement('div', { style: { color: '#666' } }, 'No sandbox commands yet.'),
+    )
+  }
+
+  return createElement('div', { ref: listRef, style: logStyle },
+    entries.map((entry) => createElement(ExecLogRow, { key: entry.id, entry })),
+  )
+}
+
+const headerStyle: CSSProperties = {
+  flex: '0 0 auto',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '6px 10px',
+  background: '#222',
+  color: '#eee',
+  fontSize: '13px',
+  borderBottom: '1px solid #2a2a2a',
+}
+
+const closeButtonStyle: CSSProperties = {
+  border: 'none',
+  background: 'transparent',
+  color: '#999',
+  fontSize: '18px',
+  lineHeight: '1',
+  cursor: 'pointer',
+}
+
+/** The terminal content without floating chrome: command log + interactive PTY. */
+export function SandboxTerminalTab(props: { rows?: number; cols?: number }): ReactNode {
+  return createElement('div', { style: { display: 'flex', flexDirection: 'column', width: '100%', height: '100%' } },
+    createElement(CommandLog, {}),
+    createElement('div', { style: { flex: 1, minHeight: '120px', background: '#1e1e1e' } },
+      createElement(TerminalView, { rows: props.rows, cols: props.cols }),
+    ),
+  )
+}
+
+/** One live sandbox terminal panel: header + command log + interactive PTY. */
+function SandboxTerminalPanel(props: { rows?: number; cols?: number; onClose: () => void }): ReactNode {
+  return createElement('div', { style: { display: 'flex', flexDirection: 'column', width: '100%', height: '100%' } },
+    createElement('div', { style: headerStyle },
+      createElement('span', null, 'K8E Sandbox Terminal'),
+      createElement('button', { type: 'button', style: closeButtonStyle, onClick: props.onClose, 'aria-label': 'close' }, '×'),
+    ),
+    createElement(SandboxTerminalTab, { rows: props.rows, cols: props.cols }),
+  )
+}
+
+let activePanel: { host: HTMLDivElement; close: () => void } | undefined
+
+/** Open (or focus) the terminal panel; idempotent across repeated activity. */
+export function openTerminalPanel(): void {
+  if (activePanel !== undefined) {
+    activePanel.host.style.boxShadow = '0 8px 34px rgba(0,0,0,.65)'
+    return
+  }
+  const prefs = loadPrefs()
+  const host = document.createElement('div')
+  host.dataset.k8eSandboxTerminal = ''
+  Object.assign(host.style, {
+    position: 'fixed',
+    right: '16px',
+    bottom: '16px',
+    width: 'min(680px, calc(100vw - 32px))',
+    height: 'min(520px, calc(100vh - 32px))',
+    zIndex: '2147483000',
+    borderRadius: '10px',
+    overflow: 'hidden',
+    boxShadow: '0 8px 30px rgba(0,0,0,.4)',
+  } as CSSStyleDeclaration)
+  document.body.appendChild(host)
+
+  const root = createRoot(host)
+  const close = (): void => {
+    activePanel = undefined
+    root.unmount()
+    host.remove()
+  }
+  activePanel = { host, close }
+  root.render(createElement(SandboxTerminalPanel, { rows: prefs.rows, cols: prefs.cols, onClose: close }))
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["react", "react-dom"]
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@k8e/dsh-k8e-sandbox-host-ui",
+  "version": "0.1.0",
+  "description": "k8e-sandbox host UI bridge: /k8e-sandbox HTTP API + terminal WebSocket (KIP-20 client half M1).",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": ["lib"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@k8e/dsh-k8e-sandbox": "workspace:*",
+    "@k8e/dsh-k8e-sandbox-client-ui": "workspace:*",
+    "ws": "^8.18.0"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/schemastery": "*"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/schemastery": "*",
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.10",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/context-types.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/context-types.ts
@@ -1,0 +1,73 @@
+/**
+ * Local structural contracts for the services this host-UI plugin consumes.
+ * Mirrors DSH-better-sidebar's context-types.ts: the `@deepseek-ai/*` service
+ * type packages publish broken dependency chains on npm, so a third-party
+ * plugin declares the documented harness faces locally. Drift is contained to
+ * this file.
+ * @module @k8e/dsh-k8e-sandbox-host-ui/context-types
+ */
+
+export type { Context } from '@deepseek-ai/cordis'
+import type { K8eSandboxRuntime } from '@k8e/dsh-k8e-sandbox'
+
+/** The HTTP request face (structural subset of node's IncomingMessage). */
+export interface SandboxHttpRequest {
+  url?: string
+  method?: string
+  headers: Record<string, string | string[] | undefined>
+  [Symbol.asyncIterator](): AsyncIterator<string | Uint8Array>
+}
+
+/** The HTTP response face (structural subset of node's ServerResponse). */
+export interface SandboxHttpResponse {
+  statusCode: number
+  writeHead(status: number, headers?: Record<string, string>): void
+  write(chunk: string | Uint8Array): boolean
+  end(body?: string | Uint8Array): void
+  on(event: 'close', listener: () => void): void
+}
+
+/** One webserver route (mirror of the host-webserver WebRoute). */
+export interface SandboxWebRoute {
+  kind: 'exact' | 'prefix'
+  path: string
+  handler: (req: SandboxHttpRequest, res: SandboxHttpResponse) => void | Promise<void>
+}
+
+/** One HTTP upgrade registration (mirror of WebUpgradeRoute). */
+export interface SandboxWebUpgradeRoute {
+  path: string
+  handler: (req: SandboxHttpRequest, socket: SandboxUpgradeSocket, head: Uint8Array) => void | Promise<void>
+}
+
+/** The upgrade socket face (the destroy the fence uses). */
+export interface SandboxUpgradeSocket {
+  destroy(): void
+}
+
+/** The webServer service face this plugin uses. */
+export interface SandboxWebServer {
+  register(route: SandboxWebRoute): () => void
+  registerUpgrade(route: SandboxWebUpgradeRoute): () => void
+}
+
+/**
+ * One sandbox execution activity emitted by `K8eSubprocessRuntime.spawn` on the
+ * `k8e-sandbox/exec` event (structural mirror of the subprocess package's
+ * `K8eExecEvent`; restated here so this bridge need not depend on it).
+ */
+export type K8eExecEvent =
+  | { phase: 'start'; id: string; command: string; cwd?: string; at: number }
+  | { phase: 'output'; id: string; stream: 'stdout' | 'stderr'; data: string; at: number }
+  | { phase: 'exit'; id: string; exitCode: number | null; signal: string | null; at: number }
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    webServer: SandboxWebServer
+    k8eSandbox: K8eSandboxRuntime
+    effect(fn: () => void | (() => void), label?: string): void
+  }
+  interface Events {
+    'k8e-sandbox/exec'(event: K8eExecEvent): void
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/index.ts
@@ -1,0 +1,350 @@
+/**
+ * k8e-sandbox host-UI bridge (KIP-20 client half): the transport the browser
+ * half talks to — a `/k8e-sandbox/api` status route, a lazy-chunk bundle route
+ * (`/k8e-sandbox/bundle/<name>.js`), and a `/k8e-sandbox/ws/terminal`
+ * WebSocket that bridges the sandbox's remote PTY (KIP-19 spawnTerminal) to a
+ * browser terminal. The config page itself lives in the client half.
+ * @module @k8e/dsh-k8e-sandbox-host-ui
+ */
+
+import { readFile } from 'node:fs/promises'
+import type { IncomingMessage } from 'node:http'
+import { createRequire } from 'node:module'
+import type { Duplex } from 'node:stream'
+import { WebSocket, WebSocketServer } from 'ws'
+import type { Context, K8eExecEvent, SandboxHttpRequest, SandboxHttpResponse } from './context-types.ts'
+
+export const name = 'dsh-k8e-sandbox-host-ui'
+
+/** Services required before mounting. */
+export const inject = ['webServer', 'k8eSandbox']
+
+function clamp(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback
+  return Math.min(max, Math.max(min, value))
+}
+
+function writeJson(res: SandboxHttpResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(body))
+}
+
+/**
+ * Parse a request's path-relative URL. `req.url` is always an origin-form
+ * path + query (never an absolute URL), so parsing it directly avoids the
+ * synthetic scheme a `new URL(…, base)` would otherwise require.
+ */
+function parseRequestUrl(req: SandboxHttpRequest): { pathname: string; searchParams: URLSearchParams } {
+  const raw = req.url ?? '/'
+  const queryIndex = raw.indexOf('?')
+  const pathname = queryIndex === -1 ? raw : raw.slice(0, queryIndex)
+  const query = queryIndex === -1 ? '' : raw.slice(queryIndex + 1)
+  return { pathname, searchParams: new URLSearchParams(query) }
+}
+
+/**
+ * Lazy client chunks (the heavy xterm stack). The core bundle references
+ * `/k8e-sandbox/bundle/<name>.js`; this route resolves the built chunk from the
+ * client-ui package and serves it fresh (no-cache — the browser reloads on HMR).
+ */
+const require_ = createRequire(import.meta.url)
+const CHUNK_RESOLVER: Record<string, string> = {
+  terminal: '@k8e/dsh-k8e-sandbox-client-ui/client-terminal',
+}
+
+async function serveChunk(req: SandboxHttpRequest, res: SandboxHttpResponse): Promise<void> {
+  const { pathname } = parseRequestUrl(req)
+  const name = pathname.slice('/k8e-sandbox/bundle/'.length).replace(/\.js$/, '')
+  const spec = CHUNK_RESOLVER[name]
+  if (spec === undefined) {
+    writeJson(res, 404, { ok: false, error: { code: 'not-found', message: `unknown chunk "${name}"` } })
+    return
+  }
+  try {
+    const path = require_.resolve(spec)
+    const content = await readFile(path)
+    res.writeHead(200, {
+      'content-type': 'application/javascript; charset=utf-8',
+      'cache-control': 'no-cache',
+    })
+    res.end(content)
+  } catch (error) {
+    writeJson(res, 404, { ok: false, error: { code: 'missing', message: error instanceof Error ? error.message : String(error) } })
+  }
+}
+
+/** One recent sandbox execution, accumulated for the command-log replay. */
+interface ExecLogEntry {
+  id: string
+  command: string
+  cwd?: string
+  startedAt: number
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  signal: string | null
+  settled: boolean
+}
+
+const MAX_HISTORY = 30
+const MAX_OUTPUT = 256 * 1024
+
+function sseWrite(res: SandboxHttpResponse, event: string, data: unknown): void {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+}
+
+function appendCapped(base: string, chunk: string, max: number): string {
+  const next = base + chunk
+  return next.length > max ? next.slice(next.length - max) : next
+}
+
+/** Clamp a WebSocket close reason to the 123-byte UTF-8 limit without splitting code points. */
+function clampCloseReason(reason: string): string {
+  const MAX = 123
+  if (Buffer.byteLength(reason, 'utf8') <= MAX) return reason
+  const suffix = '…'
+  const budget = MAX - Buffer.byteLength(suffix, 'utf8')
+  let result = ''
+  for (const char of reason) {
+    const next = result + char
+    if (Buffer.byteLength(next, 'utf8') > budget) break
+    result = next
+  }
+  return result + suffix
+}
+
+type ExecStartEvent = Extract<K8eExecEvent, { phase: 'start' }>
+type ExecOutputEvent = Extract<K8eExecEvent, { phase: 'output' }>
+type ExecExitEvent = Extract<K8eExecEvent, { phase: 'exit' }>
+
+function recordExecStart(event: ExecStartEvent, entries: Map<string, ExecLogEntry>, order: string[]): void {
+  entries.set(event.id, {
+    id: event.id,
+    command: event.command,
+    cwd: event.cwd,
+    startedAt: event.at,
+    stdout: '',
+    stderr: '',
+    exitCode: null,
+    signal: null,
+    settled: false,
+  })
+  order.push(event.id)
+  if (order.length <= MAX_HISTORY) return
+  const evicted = order.shift()
+  if (evicted !== undefined) entries.delete(evicted)
+}
+
+function recordExecOutput(event: ExecOutputEvent, entries: Map<string, ExecLogEntry>): void {
+  const entry = entries.get(event.id)
+  if (entry === undefined) return
+  if (event.stream === 'stderr') entry.stderr = appendCapped(entry.stderr, event.data, MAX_OUTPUT)
+  else entry.stdout = appendCapped(entry.stdout, event.data, MAX_OUTPUT)
+}
+
+function recordExecExit(event: ExecExitEvent, entries: Map<string, ExecLogEntry>): void {
+  const entry = entries.get(event.id)
+  if (entry === undefined) return
+  entry.exitCode = event.exitCode
+  entry.signal = event.signal
+  entry.settled = true
+}
+
+/** Bridge one WebSocket to a sandbox PTY. */
+async function attachTerminal(ctx: Context, ws: WebSocket, req: SandboxHttpRequest): Promise<void> {
+  // Registered before any await so a client that disconnects during session
+  // creation is still observed; cleanup is assigned once the terminal exists.
+  let cleanup: (() => void) | undefined
+  ws.on('close', () => { cleanup?.() })
+
+  try {
+    const { searchParams } = parseRequestUrl(req)
+    const rows = clamp(Number.parseInt(searchParams.get('rows') ?? '24', 10), 1, 200, 24)
+    const cols = clamp(Number.parseInt(searchParams.get('cols') ?? '80', 10), 1, 400, 80)
+
+    const grpc = ctx.k8eSandbox.getGrpcClient()
+    const sessionId = await ctx.k8eSandbox.getSession()
+    const created = await grpc.createTerminal({
+      sessionId,
+      argv: ['bash', '-l'],
+      workdir: ctx.k8eSandbox.cwd,
+      rows,
+      cols,
+    })
+    const id = created.terminalId
+
+    let destroyed = false
+    cleanup = (): void => {
+      if (destroyed) return
+      destroyed = true
+      void grpc.terminalDestroy(id, 1000).catch(() => undefined)
+    }
+
+    // A write/resize against an exited terminal rejects; report it and tear the
+    // session down instead of leaving a dead socket silently swallowing input.
+    const fail = (reason: string): void => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(`\r\n[terminal error: ${reason}]\r\n`)
+      }
+      cleanup?.()
+      ws.close(1011, clampCloseReason(reason))
+    }
+
+    // The socket may have closed while the terminal was being created; destroy
+    // it now instead of leaking the PTY and its gRPC stream.
+    if (ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+      cleanup()
+      return
+    }
+
+    const stream = grpc.terminalStream(id)
+    stream.on('data', (frame: any) => {
+      if (frame.data !== undefined && ws.readyState === WebSocket.OPEN) {
+        ws.send(frame.data)
+      } else if (frame.exit !== undefined) {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(`\r\n[process exited with code ${String(frame.exit.exitCode ?? 0)}]\r\n`)
+        }
+        cleanup?.()
+        ws.close(1000, 'terminal exited')
+      }
+    })
+    stream.on('error', (err: unknown) => {
+      fail(err instanceof Error ? err.message : String(err))
+    })
+
+    interface ControlFrame { type?: unknown; cols?: unknown; rows?: unknown }
+    ws.on('message', (data) => {
+      const text = data.toString('utf8')
+      let control: ControlFrame | null = null
+      try {
+        const parsed: unknown = JSON.parse(text)
+        if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          control = parsed as ControlFrame
+        }
+      } catch {
+        // Not JSON: raw terminal input.
+      }
+      if (control !== null && control.type === 'close') {
+        cleanup?.()
+        return
+      }
+      if (control !== null && control.type === 'resize' && typeof control.cols === 'number' && typeof control.rows === 'number') {
+        void grpc.terminalResize(id, clamp(control.cols, 1, 400, cols), clamp(control.rows, 1, 200, rows))
+          .catch(() => fail('terminal resize failed; the terminal may have exited'))
+        return
+      }
+      void grpc.terminalWrite(id, new TextEncoder().encode(text))
+        .catch(() => fail('terminal write failed; the terminal may have exited'))
+    })
+  } catch (error) {
+    cleanup?.()
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(`\r\n[terminal failed: ${error instanceof Error ? error.message : String(error)}]\r\n`)
+    }
+    ws.close(1011, error instanceof Error ? error.message : String(error))
+  }
+}
+
+export function apply(ctx: Context): void {
+  // ── JSON API ────────────────────────────────────────────────────────────
+  ctx.effect(() => ctx.webServer.register({
+    kind: 'prefix',
+    path: '/k8e-sandbox/api',
+    handler: async (req, res) => {
+      if (req.method !== 'POST') {
+        writeJson(res, 405, { ok: false, error: { code: 'method-error', message: 'method not allowed' } })
+        return
+      }
+      const { pathname } = parseRequestUrl(req)
+      const method = pathname.startsWith('/k8e-sandbox/api/') ? pathname.slice('/k8e-sandbox/api/'.length) : undefined
+      if (method === 'status') {
+        let grpcAvailable = false
+        try {
+          ctx.k8eSandbox.getGrpcClient()
+          grpcAvailable = true
+        } catch {
+          grpcAvailable = false
+        }
+        writeJson(res, 200, {
+          ok: true,
+          grpcAvailable,
+          cwd: ctx.k8eSandbox.cwd,
+          endpoint: ctx.k8eSandbox.endpoint,
+          certDir: ctx.k8eSandbox.certDir,
+          runtimeClass: ctx.k8eSandbox.runtimeClass,
+        })
+        return
+      }
+      writeJson(res, 404, { ok: false, error: { code: 'not-found', message: `unknown method "${method ?? ''}"` } })
+    },
+  }), 'k8e-sandbox-host-ui: /k8e-sandbox/api routes')
+
+  // ── Lazy chunk bundle route ────────────────────────────────────────────
+  ctx.effect(() => ctx.webServer.register({
+    kind: 'prefix',
+    path: '/k8e-sandbox/bundle',
+    handler: (req, res) => { void serveChunk(req, res) },
+  }), 'k8e-sandbox-host-ui: /k8e-sandbox/bundle chunk route')
+
+  // ── Sandbox activity SSE (KIP-20 M3) ────────────────────────────────────
+  // Replays a small recent-command log on connect, then streams `k8e-sandbox/exec`
+  // events live so the browser terminal panel renders running commands and the
+  // core bundle can auto-open on activity.
+  const execLog = new Map<string, ExecLogEntry>()
+  const execOrder: string[] = []
+  const activityClients = new Set<SandboxHttpResponse>()
+
+  const broadcastExec = (event: K8eExecEvent): void => {
+    for (const client of activityClients) {
+      try {
+        sseWrite(client, 'exec', event)
+      } catch {
+        activityClients.delete(client)
+      }
+    }
+  }
+
+  const onExec = (event: K8eExecEvent): void => {
+    if (event.phase === 'start') recordExecStart(event, execLog, execOrder)
+    else if (event.phase === 'output') recordExecOutput(event, execLog)
+    else recordExecExit(event, execLog)
+    broadcastExec(event)
+  }
+
+  ctx.effect(() => {
+    const off = ctx.on('k8e-sandbox/exec', onExec)
+    return () => { off() }
+  }, 'k8e-sandbox-host-ui: exec log subscription')
+
+  ctx.effect(() => ctx.webServer.register({
+    kind: 'exact',
+    path: '/k8e-sandbox/activity',
+    handler: (req, res) => {
+      res.writeHead(200, {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache',
+        'connection': 'keep-alive',
+      })
+      const history = execOrder.map((id) => execLog.get(id)).filter((entry): entry is ExecLogEntry => entry !== undefined)
+      sseWrite(res, 'history', { entries: history })
+      activityClients.add(res)
+      res.on('close', () => { activityClients.delete(res) })
+    },
+  }), 'k8e-sandbox-host-ui: /k8e-sandbox/activity SSE')
+
+  // ── Terminal WebSocket ──────────────────────────────────────────────────
+  const wss = new WebSocketServer({ noServer: true })
+  ctx.effect(() => ctx.webServer.registerUpgrade({
+    path: '/k8e-sandbox/ws/terminal',
+    handler: (req, socket, head) => {
+      wss.handleUpgrade(req as unknown as IncomingMessage, socket as unknown as Duplex, head as Buffer, (ws) => {
+        void attachTerminal(ctx, ws, req)
+      })
+    },
+  }), 'k8e-sandbox-host-ui: terminal WebSocket')
+
+  ctx.effect(() => () => { wss.close() }, 'k8e-sandbox-host-ui: teardown')
+}
+
+export default apply

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -24,6 +24,29 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll('\'', `'"'"'`)}'`
 }
 
+let execIdCounter = 0
+function nextExecId(): string {
+  execIdCounter += 1
+  return `exec-${process.pid}-${execIdCounter}`
+}
+
+/**
+ * One sandbox execution activity, broadcast on the `k8e-sandbox/exec` event.
+ * The host-ui bridge forwards it to the browser so the terminal panel can show
+ * running commands live and auto-open on activity (KIP-20 M3).
+ */
+export type K8eExecEvent =
+  | { phase: 'start'; id: string; command: string; cwd?: string; at: number }
+  | { phase: 'output'; id: string; stream: 'stdout' | 'stderr'; data: string; at: number }
+  | { phase: 'exit'; id: string; exitCode: number | null; signal: string | null; at: number }
+
+declare module '@deepseek-ai/cordis' {
+  interface Events {
+    /** A sandbox execution advanced (started / emitted output / exited). @mode emit */
+    'k8e-sandbox/exec'(event: K8eExecEvent): void
+  }
+}
+
 /** k8e-sandbox command manager registered as `ctx.subprocess`. */
 export class K8eSubprocessRuntime extends SubprocessRuntime {
   static inject = ['k8eSandbox']
@@ -55,6 +78,11 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
 
   override spawn(spec: SubprocessSpawnSpec): SubprocessHandle {
     const command = spec.argv.map(shellQuote).join(' ')
+    const id = nextExecId()
+    const cwd = this.ctx.k8eSandbox.cwd
+    const emit = (event: K8eExecEvent): void => { this.ctx.emit('k8e-sandbox/exec', event) }
+    emit({ phase: 'start', id, command, cwd, at: Date.now() })
+
     const stdout = new PassThrough()
     const stderr = new PassThrough()
     let grpcClient: GrpcK8eClient | undefined
@@ -71,11 +99,17 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
         try {
           const sid = await this.ctx.k8eSandbox.getSession()
           const result = grpcClient.execStream(sid, command)
+          result.stdout.on('data', (chunk: Buffer) => {
+            emit({ phase: 'output', id, stream: 'stdout', data: chunk.toString('utf8'), at: Date.now() })
+          })
           result.stdout.pipe(stdout)
-          return await result.done
+          const outcome = await result.done
+          emit({ phase: 'exit', id, exitCode: outcome.exitCode, signal: outcome.signal, at: Date.now() })
+          return outcome
         } catch (cause) {
           const error = cause instanceof Error ? cause : new Error(String(cause))
           stdout.destroy(error)
+          emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
           return { exitCode: 1, signal: null }
         } finally {
           settled = true
@@ -88,11 +122,15 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
         const result = await client.run(command, { sessionId: sid, timeout: Math.ceil(spec.graceMs / 1000) })
         stdout.end(result.stdout)
         stderr.end(result.stderr)
+        if (result.stdout.length > 0) emit({ phase: 'output', id, stream: 'stdout', data: result.stdout, at: Date.now() })
+        if (result.stderr.length > 0) emit({ phase: 'output', id, stream: 'stderr', data: result.stderr, at: Date.now() })
+        emit({ phase: 'exit', id, exitCode: result.exitCode, signal: null, at: Date.now() })
         return { exitCode: result.exitCode, signal: null }
       } catch (cause) {
         const error = cause instanceof Error ? cause : new Error(String(cause))
         stdout.destroy(error)
         stderr.destroy(error)
+        emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
         return { exitCode: 1, signal: null }
       } finally {
         settled = true

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -65,6 +65,12 @@ export class K8eSandboxRuntime extends Service {
 
   /** Validated remote working directory shared by provider adapters. */
   readonly cwd: string
+  /** gRPC gateway endpoint (undefined = CLI local auto-discovery). */
+  readonly endpoint: string | undefined
+  /** mTLS material dir for the direct gRPC terminal client. */
+  readonly certDir: string | undefined
+  /** RuntimeClass for the session pod. */
+  readonly runtimeClass: string
 
   private readonly config: ResolvedConfig
   private readonly client: CliK8eClient
@@ -84,6 +90,9 @@ export class K8eSandboxRuntime extends Service {
       pauseOnDispose: resolved.pauseOnDispose,
     }
     this.cwd = this.config.cwd
+    this.endpoint = config.endpoint
+    this.certDir = config.certDir
+    this.runtimeClass = this.config.runtimeClass
     this.client = new CliK8eClient({
       bin: process.env.K8E_SANDBOX_CLI_BIN,
       profile: config.profile,

--- a/plugins/deepseek-harness/scripts/build-client.mjs
+++ b/plugins/deepseek-harness/scripts/build-client.mjs
@@ -1,0 +1,97 @@
+// Builds the k8e-sandbox client half (KIP-20 M2) into the dsh client-bundle
+// wire format, mirroring the shipped tsdown client preset but with esbuild:
+//
+//   lib/client.js            core bundle  — window.__ModuleLoader__.load({id, factory})
+//   lib/client-terminal.js   lazy chunk   — globalThis.__dshChunks__["terminal"] = (require) => {...}
+//
+// Platform modules (react, react-dom/client, react/jsx-runtime) stay external
+// and resolve from the shell module table; xterm + @xterm/addon-fit are inlined
+// INTO the terminal chunk so they are only fetched on first terminal open.
+//
+// Usage: node scripts/build-client.mjs
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const PKG = join(ROOT, 'packages', 'dsh-k8e-sandbox-client-ui')
+const CLIENT_DIR = join(PKG, 'src', 'client')
+const OUT_DIR = join(PKG, 'lib')
+
+const CLIENT_ID = '@k8e/dsh-k8e-sandbox-client-ui'
+
+const PLATFORM_EXTERNALS = ['react', 'react/jsx-runtime', 'react-dom/client']
+
+/**
+ * Wrap esbuild's CJS output (which expects free `require`/`exports`/`module`
+ * bindings) in the client-modules closure handoff. The factory returns
+ * `module.exports`, which the loader memoizes as the bundle's exports.
+ */
+function handoff(body, open, close) {
+  return [
+    open,
+    'var module = { exports: {} };',
+    'var exports = module.exports;',
+    'Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });',
+    body.trim(),
+    'return module.exports;',
+    close,
+    '',
+  ].join('\n')
+}
+
+async function bundleCore() {
+  const result = await build({
+    entryPoints: [join(CLIENT_DIR, 'index.tsx')],
+    bundle: true,
+    write: false,
+    platform: 'browser',
+    format: 'cjs',
+    target: 'es2020',
+    external: PLATFORM_EXTERNALS,
+    define: { 'process.env.NODE_ENV': '"production"' },
+  })
+  const body = result.outputFiles[0].text
+  const out = handoff(
+    body,
+    `window.__ModuleLoader__.load({\n\tid: ${JSON.stringify(CLIENT_ID)},\n\tfactory: (require) => {`,
+    '\t}\n});',
+  )
+  await writeFile(join(OUT_DIR, 'client.js'), out)
+  return result.outputFiles[0].contents.length
+}
+
+async function bundleTerminalChunk() {
+  const result = await build({
+    entryPoints: [join(CLIENT_DIR, 'terminal.tsx')],
+    bundle: true,
+    write: false,
+    platform: 'browser',
+    format: 'cjs',
+    target: 'es2020',
+    minify: true,
+    external: PLATFORM_EXTERNALS,
+    define: { 'process.env.NODE_ENV': '"production"' },
+  })
+  const body = result.outputFiles[0].text
+  const out = handoff(
+    body,
+    'globalThis.__dshChunks__["terminal"] = (require) => {',
+    '};',
+  )
+  await writeFile(join(OUT_DIR, 'client-terminal.js'), out)
+  return result.outputFiles[0].contents.length
+}
+
+await mkdir(OUT_DIR, { recursive: true })
+const coreBytes = await bundleCore()
+const chunkBytes = await bundleTerminalChunk()
+
+const [core, chunk] = await Promise.all([
+  readFile(join(OUT_DIR, 'client.js'), 'utf8'),
+  readFile(join(OUT_DIR, 'client-terminal.js'), 'utf8'),
+])
+console.log(`client core   lib/client.js          ${core.length} bytes (entry ${coreBytes} bytes)`)
+console.log(`terminal chunk lib/client-terminal.js ${chunk.length} bytes (entry ${chunkBytes} bytes)`)
+console.log(`bundle external: ${core.includes('__ModuleLoader__') && chunk.includes('__dshChunks__') ? 'ok' : 'MISSING HANDOFF'}`)

--- a/plugins/deepseek-harness/tests/subprocess.test.mjs
+++ b/plugins/deepseek-harness/tests/subprocess.test.mjs
@@ -43,11 +43,15 @@ function makeGrpcClient() {
 }
 
 function makeCtx(owner) {
+  const emitted = []
   const ctx = {
     k8eSandbox: owner,
     reflect: { provide() { return () => {} } },
     effect() { return () => {} },
+    emit(name, payload) { emitted.push([name, payload]) },
+    on() { return () => false },
   }
+  ctx.emitted = emitted
   return ctx
 }
 
@@ -160,7 +164,8 @@ function makeCtx(owner) {
     getSession: async () => 's1',
     getClient: () => ({ run: async (code, opts) => { cliCalls.push([code, opts]); return { stdout: 'cli-out\n', stderr: '', exitCode: 7 } } }),
   }
-  const runtime = new K8eSubprocessRuntime(makeCtx(owner))
+  const ctx = makeCtx(owner)
+  const runtime = new K8eSubprocessRuntime(ctx)
   const handle = runtime.spawn({
     argv: ['echo', 'hi'],
     cwd: '/workspace',
@@ -175,6 +180,15 @@ function makeCtx(owner) {
   assert.equal(Buffer.concat(chunks).toString('utf8'), 'cli-out\n')
   assert.equal(cliCalls.length, 1, 'CLI fallback used exactly once')
   assert.equal(cliCalls[0][0], "'echo' 'hi'", 'argv is shell-quoted into one command')
+
+  // M3: the activity side-channel emits start / output / exit events.
+  const execEvents = ctx.emitted.filter(([name]) => name === 'k8e-sandbox/exec').map(([, payload]) => payload)
+  assert.equal(execEvents[0].phase, 'start')
+  assert.equal(execEvents[0].command, "'echo' 'hi'")
+  assert.ok(execEvents.some((e) => e.phase === 'output' && e.stream === 'stdout' && e.data === 'cli-out\n'))
+  const exitEvent = execEvents[execEvents.length - 1]
+  assert.equal(exitEvent.phase, 'exit')
+  assert.equal(exitEvent.exitCode, 7)
 }
 
 console.log('✔ subprocess fake-ctx test passed (spawnTerminal mapping, stream frames, spawn gRPC + CLI fallback)')


### PR DESCRIPTION
Completes the **client half** of KIP-20 (`dsh-k8e-sandbox` plugin), giving the DeepSeek Harness web surface a config page and a sandbox terminal that shows live running commands. Closes #542.

## What

Following the plan in `plugins/deepseek-harness/docs/ui-design.md` (inspired by [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)), this PR lands M1–M4:

- **M1 — host bridge** (`dsh-k8e-sandbox-host-ui`): `/k8e-sandbox/api/status`, the `/k8e-sandbox/ws/terminal` WebSocket that bridges the sandbox's remote PTY (KIP-19 `spawnTerminal`) to a browser terminal, and the `/k8e-sandbox/bundle/<name>.js` lazy-chunk route.
- **M2 — client half** (`dsh-k8e-sandbox-client-ui`): a `settings.section` config page (sandbox status + terminal prefs) and the xterm terminal panel, shipped as a `dsh.client` bundle — a ~14KB core bundle plus a lazy terminal chunk (`globalThis.__dshChunks__`) so xterm (~289KB) is fetched only on first open.
- **M3 — live monitoring**: `K8eSubprocessRuntime.spawn` emits `k8e-sandbox/exec` events; the host replays + streams them over `/k8e-sandbox/activity` SSE; the terminal panel renders running commands and `autoOpenTerminal` auto-opens it on activity.
- **M4 — better-sidebar**: optional soft-dependency integration — registers a `k8e-sandbox:terminal` tab when better-sidebar is installed (skipped otherwise, no value-import).

## Key decisions

- Terminal backend is the **remote sandbox PTY** (KIP-19 gRPC), not local `node-pty`.
- `dsh.client` manifest lives on the client package (exporting `./client`), not the bundle — matching `dsh-client-modules`' node-half scan.
- Lazy loading keeps startup parsing to the ~14KB core; react/react-dom resolve from the shell module table (purity gate: no `@deepseek-ai/*` value-imports).

## Testing

- `node scripts/test.mjs` — fake-ctx tests (fs, grpc-SSE decoder, subprocess) pass; subprocess now asserts the `exec` event sequence.
- `node scripts/build-client.mjs` — core + terminal chunk handoffs verified (`__ModuleLoader__` / `__dshChunks__`).
- Typecheck via the paths-mapped `tsconfig.check.json` (now includes `.tsx` + DOM lib).