### PR TITLE
fix(build): align Cilium chart version with runtime (1.20.0)

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -62,7 +62,7 @@ fi
 
 VERSION_CNIPLUGINS="v1.6.0-k3s1"
 
-VERSION_CILIUM_CHART="1.17.1"
+VERSION_CILIUM_CHART="1.20.0"
 
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${VERSION_K8S}/build/dependencies.yaml"
 if command -v yq >/dev/null 2>&1 && yq --version >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

`helm-install-cilium` CrashLoopBackOffs immediately after install:

```
Error: INSTALLATION FAILED: failed to fetch https://127.0.0.1:6443/static/charts/cilium-1.20.0.tgz : 404 Not Found
```

Since Cilium is the default CNI, the cluster never comes up: coredns,
local-path-provisioner, metrics-server stay `Pending` (node not Ready,
no network plugin).

## Root cause

KIP-18 commit `d2bc43cd` bumped `pkg/version/version.go`
`CiliumChartVersion` to **1.20.0** (Gateway API controller → Gateway API
v1.6.1 CRDs) but left `hack/version.sh` `VERSION_CILIUM_CHART` at
**1.17.1**. The release pipeline (`zig build download` → `hack/download`)
downloads `cilium-${VERSION_CILIUM_CHART}.tgz` and embeds it in the
binary, while the server renders the HelmChart URL from
`version.CiliumChartVersion`. Version mismatch → 404 → helm install
fails → no CNI.

| file | before | after |
|---|---|---|
| `hack/version.sh` `VERSION_CILIUM_CHART` | 1.17.1 | **1.20.0** |
| `pkg/version/version.go` `CiliumChartVersion` | 1.20.0 | 1.20.0 (unchanged) |

Affects the latest release `v1.35.5-20260815-rc1+k8e1`; the previous
`v1.35.5-20260811+k8e1` is consistent (both 1.17.1).

## Fix

One line in `hack/version.sh`: `VERSION_CILIUM_CHART="1.17.1"` →
`"1.20.0"`. `hack/download` uses this variable for both the download URL
and the output filename, so the embedded chart now matches what the
runtime requests.

## Verification

- `hack/download` fetches `https://helm.cilium.io/cilium-1.20.0.tgz` into
  `build/static/charts/cilium-1.20.0.tgz`
- Runtime HelmChart URL: `/static/charts/cilium-1.20.0.tgz` → match
- Manual cluster workaround (already-shipped binaries): drop the chart
  into `/var/lib/k8e/server/static/charts/` and delete the
  `helm-install-cilium-*` job pod to retry

## Note for release

New binaries must be built from this fix; existing published binaries
(`v1.35.5-20260815-rc1+k8e1`) remain affected and need the manual
workaround above.