### PR TITLE
feat(dsh): publish deepseek-harness plugins under @k8e-sandbox scope + release script

### DIFF
--- a/docs/kip-19-sandbox-pty-terminal-primitive.md
+++ b/docs/kip-19-sandbox-pty-terminal-primitive.md
@@ -15,7 +15,7 @@
 
 它一次性服务两个消费者：
 
-1. **dsh 的 `spawnTerminal`**（`SubprocessRuntime.spawnTerminal` → `SubprocessTerminalHandle`），让 KIP-20 的 `@k8e/dsh-k8e-sandbox-subprocess` 在 Phase 2 真正实现 terminal seam，进而让 dsh 的 `terminal-bash`（持久终端）跑进 gVisor/Kata/Firecracker pod。
+1. **dsh 的 `spawnTerminal`**（`SubprocessRuntime.spawnTerminal` → `SubprocessTerminalHandle`），让 KIP-20 的 `@k8e-sandbox/dsh-k8e-sandbox-subprocess` 在 Phase 2 真正实现 terminal seam，进而让 dsh 的 `terminal-bash`（持久终端）跑进 gVisor/Kata/Firecracker pod。
 2. **E2B SDK 的 `pty.create` / `pty.sendInput` / `pty.resize` / `pty.kill`**（KIP-18 E2B 兼容面当前缺的一角），与已有的 `/exec/stream` + `/exec/processes` + `/exec/attach` 补齐 E2B 进程控制面。
 
 ## 背景与动机
@@ -228,7 +228,7 @@ terminal_id → {
 
 ## 与 dsh terminal seam 的映射
 
-`@k8e/dsh-k8e-sandbox-subprocess`（KIP-20 Phase 2）实现 `SubprocessRuntime.spawnTerminal`，映射如下：
+`@k8e-sandbox/dsh-k8e-sandbox-subprocess`（KIP-20 Phase 2）实现 `SubprocessRuntime.spawnTerminal`，映射如下：
 
 | dsh `SubprocessTerminalHandle` | k8e RPC |
 |---|---|
@@ -287,7 +287,7 @@ E2B 兼容层（KIP-18）用 `pid` 寻址，而本原语只暴露 canonical `ter
 - [ ] `TerminalDestroy`：TERM→grace→KILL 升级，返回时 `ps` 证明该会话无存活进程组；幂等，重复 destroy 干净 not-found。
 - [ ] `TerminalStream` 断线重连回放环形缓冲；`truncated` 在缓冲溢出时置位；终帧 exit_code/signal 正确。
 - [ ] 网关：terminal_id 路由注册表在 create/destroy/session 销毁时正确增删；`TerminalStream` 走 mTLS 且被未认证调用拒绝。
-- [ ] dsh 快照：`@k8e/dsh-k8e-sandbox-subprocess` 的 `spawnTerminal` 在 mock/真实网关上演 `bash` 终端，验证 write/read/Ctrl-C/resize/destroy 全链路。
+- [ ] dsh 快照：`@k8e-sandbox/dsh-k8e-sandbox-subprocess` 的 `spawnTerminal` 在 mock/真实网关上演 `bash` 终端，验证 write/read/Ctrl-C/resize/destroy 全链路。
 - [ ] E2B 兼容：`pty.create/sendInput/resize/kill` 经兼容层闭合（KIP-18）。
 - [ ] 文档：本 KIP + proto 注释 + `SKILL.md`/README 一处更新说明 PTY 面。
 

--- a/docs/kip-20-dsh-k8e-sandbox-plugin.md
+++ b/docs/kip-20-dsh-k8e-sandbox-plugin.md
@@ -76,9 +76,9 @@ k8e-sandbox 与 E2B 在抽象层面是同一类东西：一个远端 Linux 执�
 
 | E2B POC 包 | `ctx` key | k8e 对应包（本 KIP） |
 |---|---|---|
-| `@deepseek-ai/dsh-e2b` | `ctx.e2b` | `@k8e/dsh-k8e-sandbox`（`ctx.k8eSandbox`） |
-| `@deepseek-ai/dsh-fs-e2b` | `ctx.fs` | `@k8e/dsh-k8e-sandbox-fs` |
-| `@deepseek-ai/dsh-subprocess-e2b` | `ctx.subprocess` | `@k8e/dsh-k8e-sandbox-subprocess` |
+| `@deepseek-ai/dsh-e2b` | `ctx.e2b` | `@k8e-sandbox/dsh-k8e-sandbox`（`ctx.k8eSandbox`） |
+| `@deepseek-ai/dsh-fs-e2b` | `ctx.fs` | `@k8e-sandbox/dsh-k8e-sandbox-fs` |
+| `@deepseek-ai/dsh-subprocess-e2b` | `ctx.subprocess` | `@k8e-sandbox/dsh-k8e-sandbox-subprocess` |
 
 差别只在**传输层**：E2B 用其 SDK（API key），k8e 用 `k8e-sandbox-cli`（Phase 1）或直连 gRPC + mTLS（Phase 2）。
 
@@ -100,7 +100,7 @@ plugins/deepseek-harness/
 └── tsconfig.base.json
 ```
 
-> npm scope 统一为 `@k8e/`，命名统一为 `dsh-k8e-sandbox`：所有者 `@k8e/dsh-k8e-sandbox`、fs `@k8e/dsh-k8e-sandbox-fs`、subprocess `@k8e/dsh-k8e-sandbox-subprocess`、client `@k8e/dsh-k8e-sandbox-client`、tool `@k8e/dsh-k8e-sandbox-tool`、bundle `@k8e/dsh-k8e-sandbox-bundle`；目录短名与之对齐（`dsh-k8e-sandbox*`）。
+> npm scope 统一为 `@k8e-sandbox/`，命名统一为 `dsh-k8e-sandbox`：所有者 `@k8e-sandbox/dsh-k8e-sandbox`、fs `@k8e-sandbox/dsh-k8e-sandbox-fs`、subprocess `@k8e-sandbox/dsh-k8e-sandbox-subprocess`、client `@k8e-sandbox/dsh-k8e-sandbox-client`、tool `@k8e-sandbox/dsh-k8e-sandbox-tool`、bundle `@k8e-sandbox/dsh-k8e-sandbox-bundle`；目录短名与之对齐（`dsh-k8e-sandbox*`）。
 
 ### 加载方式（非侵入通道）
 
@@ -110,7 +110,7 @@ plugins/deepseek-harness/
 # 初始化 profile（首次会自动引入 @deepseek-ai/dsh-base）
 dsh plugin --profile k8e add <path-or-tarball-or-github>
 # 或发布到 npm 后：
-dsh plugin --profile k8e add @k8e/dsh-k8e-sandbox-bundle
+dsh plugin --profile k8e add @k8e-sandbox/dsh-k8e-sandbox-bundle
 
 # 验证层 + 启动
 dsh --profile k8e --dump-config
@@ -122,15 +122,15 @@ dsh --profile k8e
 ```yaml
 - insert:
     - id: k8e-sandbox
-      name: '@k8e/dsh-k8e-sandbox'
+      name: '@k8e-sandbox/dsh-k8e-sandbox'
       config:
         # endpoint / apikey / profile / cert_dir 走与 CLI 相同的解析；留空则用 ~/.k8e/sandbox
         cwd: /workspace
         runtimeClass: gvisor
     - id: k8e-sandbox-fs
-      name: '@k8e/dsh-k8e-sandbox-fs'
+      name: '@k8e-sandbox/dsh-k8e-sandbox-fs'
     - id: k8e-sandbox-subprocess
-      name: '@k8e/dsh-k8e-sandbox-subprocess'
+      name: '@k8e-sandbox/dsh-k8e-sandbox-subprocess'
 ```
 
 依赖注入与 E2B 相同：`K8eFileSystem` 和 `K8eSubprocessRuntime` 都 `static inject = ['k8eSandbox']`，靠 Cordis 的依赖声明保证加载顺序（不需要手工 boot 序列）。挂载这两行后，dsh 的 `ctx.fs` / `ctx.subprocess` 即被 k8e 实现占据——dsh 里所有委托这两条缝的消费者自动进入沙箱。
@@ -306,6 +306,6 @@ Schemastery schema（`dsh-k8e-sandbox` 的 `Config`），字段尽量与 CLI fla
 
 | # | 问题 | 决定 |
 |---|---|---|
-| 1 | npm scope | 统一 `@k8e/dsh-*`（所有者 `@k8e/dsh-k8e-sandbox` 等，见"包结构"） |
+| 1 | npm scope | 统一 `@k8e-sandbox/dsh-*`（所有者 `@k8e-sandbox/dsh-k8e-sandbox` 等，见"包结构"） |
 | 2 | PTY 时间表 | `spawnTerminal` 放在 Phase 2，且**依赖 KIP-19（sandbox PTY 终端原语）先行**；本 KIP 只到"非 PTY 子进程" |
 | 3 | session 复用粒度 | **每 dsh 会话一个 k8e session（E2B 语义）**；`tenant` 仅作显式跨进程复用开关，不作默认全局共享 |

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -8,11 +8,11 @@ via `dsh plugin --profile <name> add`.
 
 | Package | Role | `ctx` key |
 |---|---|---|
-| [`@k8e/dsh-k8e-sandbox`](packages/dsh-k8e-sandbox) | Sandbox owner service (session lifecycle + shared CLI/gRPC client) | `ctx.k8eSandbox` |
-| [`@k8e/dsh-k8e-sandbox-client`](packages/dsh-k8e-sandbox-client) | Transport: `CliK8eClient` (Phase 1) + `GrpcK8eClient` (Phase 2) | library |
-| [`@k8e/dsh-k8e-sandbox-fs`](packages/dsh-k8e-sandbox-fs) | Filesystem seam provider | `ctx.fs` |
-| [`@k8e/dsh-k8e-sandbox-subprocess`](packages/dsh-k8e-sandbox-subprocess) | Subprocess seam provider (streaming exec + `spawnTerminal`) | `ctx.subprocess` |
-| [`@k8e/dsh-k8e-sandbox-bundle`](packages/dsh-k8e-sandbox-bundle) | Installable bundle (`dsh.bundle.patch` → `cordis.patch.yml`) | — |
+| [`@k8e-sandbox/dsh-k8e-sandbox`](packages/dsh-k8e-sandbox) | Sandbox owner service (session lifecycle + shared CLI/gRPC client) | `ctx.k8eSandbox` |
+| [`@k8e-sandbox/dsh-k8e-sandbox-client`](packages/dsh-k8e-sandbox-client) | Transport: `CliK8eClient` (Phase 1) + `GrpcK8eClient` (Phase 2) | library |
+| [`@k8e-sandbox/dsh-k8e-sandbox-fs`](packages/dsh-k8e-sandbox-fs) | Filesystem seam provider | `ctx.fs` |
+| [`@k8e-sandbox/dsh-k8e-sandbox-subprocess`](packages/dsh-k8e-sandbox-subprocess) | Subprocess seam provider (streaming exec + `spawnTerminal`) | `ctx.subprocess` |
+| [`@k8e-sandbox/dsh-k8e-sandbox-bundle`](packages/dsh-k8e-sandbox-bundle) | Installable bundle (`dsh.bundle.patch` → `cordis.patch.yml`) | — |
 
 ## Status
 
@@ -69,11 +69,11 @@ paths = {
   '@deepseek-ai/cosmokit': [os.path.join(DSH,'vendor','cosmokit','lib','types','index.d.ts')],
   '@deepseek-ai/schemastery': [os.path.join(DSH,'vendor','schemastery','lib','types','index.d.ts')],
   '@deepseek-ai/dsh-*': [os.path.join(DSH,'packages',g,'*','lib','types','index.d.ts') for g in groups],
-  '@k8e/dsh-k8e-sandbox': [os.path.join(K8E,'packages','dsh-k8e-sandbox','src')],
-  '@k8e/dsh-k8e-sandbox-client': [os.path.join(K8E,'packages','dsh-k8e-sandbox-client','src')],
-  '@k8e/dsh-k8e-sandbox-client/grpc': [os.path.join(K8E,'packages','dsh-k8e-sandbox-client','src','grpc.ts')],
-  '@k8e/dsh-k8e-sandbox-fs': [os.path.join(K8E,'packages','dsh-k8e-sandbox-fs','src')],
-  '@k8e/dsh-k8e-sandbox-subprocess': [os.path.join(K8E,'packages','dsh-k8e-sandbox-subprocess','src')],
+  '@k8e-sandbox/dsh-k8e-sandbox': [os.path.join(K8E,'packages','dsh-k8e-sandbox','src')],
+  '@k8e-sandbox/dsh-k8e-sandbox-client': [os.path.join(K8E,'packages','dsh-k8e-sandbox-client','src')],
+  '@k8e-sandbox/dsh-k8e-sandbox-client/grpc': [os.path.join(K8E,'packages','dsh-k8e-sandbox-client','src','grpc.ts')],
+  '@k8e-sandbox/dsh-k8e-sandbox-fs': [os.path.join(K8E,'packages','dsh-k8e-sandbox-fs','src')],
+  '@k8e-sandbox/dsh-k8e-sandbox-subprocess': [os.path.join(K8E,'packages','dsh-k8e-sandbox-subprocess','src')],
 }
 json.dump({'compilerOptions': {
   'target': 'es2024', 'module': 'esnext', 'moduleResolution': 'bundler',
@@ -87,3 +87,29 @@ PY
 # 3. Run dsh's TypeScript:
 /path/to/deepseek-harness/node_modules/.bin/tsc -p tsconfig.check.json
 ```
+
+## Release
+
+All seven packages are published to npmjs.com under the `@k8e-sandbox`
+scope. `scripts/release.mjs` publishes them in dependency-topological order
+(dependencies first), so consumers always resolve real published versions;
+`pnpm publish` rewrites the in-workspace `workspace:*` ranges to the actual
+published versions automatically.
+
+```sh
+# Verify the payloads without touching the registry:
+node scripts/release.mjs --dry-run
+
+# Bump every package to a shared version and publish (requires npm login +
+# @k8e-sandbox org access):
+node scripts/release.mjs --version 0.2.0
+
+# Publish the current package.json versions as-is:
+node scripts/release.mjs
+```
+
+The publishing identity must be logged in to npm (`npm whoami`) and have
+publish rights on the `@k8e-sandbox` scope. Scoped packages publish as
+public with `--access public`; the `files` whitelist in each package.json
+keeps the payloads minimal (only `lib/` and, for the bundle, the
+`cordis.patch.yml`).

--- a/plugins/deepseek-harness/docs/ui-design.md
+++ b/plugins/deepseek-harness/docs/ui-design.md
@@ -1,7 +1,7 @@
 # dsh-k8e-sandbox 客户端半身设计：配置页 + 沙盒终端页
 
 > 参考实现：[DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（v0.12.x）。
-> 目标：给 `@k8e/dsh-k8e-sandbox` 补上 **client 半身**——① 一个配置页面；② 一个调用 sandbox 时出现的终端页，实时显示运行命令与输出。对应 issue #542 的「侧边栏集成」。
+> 目标：给 `@k8e-sandbox/dsh-k8e-sandbox` 补上 **client 半身**——① 一个配置页面；② 一个调用 sandbox 时出现的终端页，实时显示运行命令与输出。对应 issue #542 的「侧边栏集成」。
 
 ## 0. 现状与差距
 
@@ -25,7 +25,7 @@ KIP-20 目前只有 **host 半身**（`ctx.fs` / `ctx.subprocess` / `ctx.k8eSand
 ## 2. 总体架构
 
 ```
-浏览器（client half，@k8e/dsh-k8e-sandbox/client）
+浏览器（client half，@k8e-sandbox/dsh-k8e-sandbox/client）
   ├── 设置页 section（配置页）：endpoint / certDir / runtimeClass / rows / cols
   ├── 沙盒终端面板：xterm.js，实时渲染命令输出 + 可交互 PTY
   │     │ WebSocket (/k8e-sandbox/ws/terminal)

--- a/plugins/deepseek-harness/e2e.md
+++ b/plugins/deepseek-harness/e2e.md
@@ -48,12 +48,12 @@ k8e-sandbox-cli run 'echo hi'   # -> {"stdout":"hi\n", "exit_code":0, ...}
 dsh plugin --profile k8e add ./packages/dsh-k8e-sandbox-bundle
 
 # verify the layer, then boot
-dsh --profile k8e --dump-config    # shows a "# == @k8e/dsh-k8e-sandbox-bundle" layer
+dsh --profile k8e --dump-config    # shows a "# == @k8e-sandbox/dsh-k8e-sandbox-bundle" layer
 dsh --profile k8e
 ```
 
-The bundle's `cordis.patch.yml` mounts `@k8e/dsh-k8e-sandbox` (owner),
-`@k8e/dsh-k8e-sandbox-fs`, and `@k8e/dsh-k8e-sandbox-subprocess`.
+The bundle's `cordis.patch.yml` mounts `@k8e-sandbox/dsh-k8e-sandbox` (owner),
+`@k8e-sandbox/dsh-k8e-sandbox-fs`, and `@k8e-sandbox/dsh-k8e-sandbox-subprocess`.
 
 > The profile's own `cordis.patch.yml` (`$DSH_HOME/profiles/k8e/cordis.patch.yml`)
 > can override the owner row by `id: k8e-sandbox` to set `endpoint` (see below).
@@ -69,7 +69,7 @@ Add to the profile patch (restate the fields you keep):
 ```yaml
 # $DSH_HOME/profiles/k8e/cordis.patch.yml
 - id: k8e-sandbox
-  name: '@k8e/dsh-k8e-sandbox'
+  name: '@k8e-sandbox/dsh-k8e-sandbox'
   config:
     endpoint: 127.0.0.1:50051     # or the remote gateway host:port
     cwd: /workspace

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
@@ -4,20 +4,20 @@
 # injection guarantees regardless of row order.
 - insert:
     - id: k8e-sandbox
-      name: '@k8e/dsh-k8e-sandbox'
+      name: '@k8e-sandbox/dsh-k8e-sandbox'
       config:
         # endpoint / profile resolve like k8e-sandbox-cli; leave unset for
         # local auto-discovery via ~/.k8e/sandbox (KIP-17).
         cwd: /workspace
         runtimeClass: gvisor
     - id: k8e-sandbox-fs
-      name: '@k8e/dsh-k8e-sandbox-fs'
+      name: '@k8e-sandbox/dsh-k8e-sandbox-fs'
     - id: k8e-sandbox-subprocess
-      name: '@k8e/dsh-k8e-sandbox-subprocess'
+      name: '@k8e-sandbox/dsh-k8e-sandbox-subprocess'
     - id: k8e-sandbox-host-ui
-      name: '@k8e/dsh-k8e-sandbox-host-ui'
+      name: '@k8e-sandbox/dsh-k8e-sandbox-host-ui'
     # Browser half: registers the settings page + terminal panel. The modules
     # node half scans this row's `dsh.client` declaration into __DSH_BOOT__ and
-    # serves /plugins/@k8e/dsh-k8e-sandbox-client-ui/client.js.
+    # serves /plugins/@k8e-sandbox/dsh-k8e-sandbox-client-ui/client.js.
     - id: k8e-sandbox-client-ui
-      name: '@k8e/dsh-k8e-sandbox-client-ui'
+      name: '@k8e-sandbox/dsh-k8e-sandbox-client-ui'

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
@@ -1,19 +1,24 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox-bundle",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-bundle",
   "version": "0.1.0",
   "description": "Installable dsh bundle mounting the k8e-sandbox execution world (KIP-20).",
   "type": "module",
-  "files": ["cordis.patch.yml"],
+  "files": [
+    "cordis.patch.yml"
+  ],
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
     }
   },
   "dependencies": {
-    "@k8e/dsh-k8e-sandbox": "workspace:*",
-    "@k8e/dsh-k8e-sandbox-fs": "workspace:*",
-    "@k8e/dsh-k8e-sandbox-subprocess": "workspace:*",
-    "@k8e/dsh-k8e-sandbox-host-ui": "workspace:*",
-    "@k8e/dsh-k8e-sandbox-client-ui": "workspace:*"
+    "@k8e-sandbox/dsh-k8e-sandbox": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox-fs": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox-subprocess": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox-host-ui": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox-client-ui": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox-client-ui",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-client-ui",
   "version": "0.1.0",
   "description": "k8e-sandbox client half: settings section + terminal panel (KIP-20 M2).",
   "type": "module",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "exports": {
     "./client": "./lib/client.js",
     "./client-terminal": "./lib/client-terminal.js",
@@ -35,5 +37,8 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/index.tsx
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/index.tsx
@@ -3,7 +3,7 @@
  * page (`settings.section`) with locale dictionaries. The terminal panel is a
  * lazy chunk (see chunk-loader.ts / terminal.tsx) so xterm never ships in this
  * core bundle.
- * @module @k8e/dsh-k8e-sandbox-client-ui/client
+ * @module @k8e-sandbox/dsh-k8e-sandbox-client-ui/client
  */
 
 import type { Context } from './context-types.ts'

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox-client",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-client",
   "version": "0.1.0",
   "description": "k8e-sandbox transport: CLI client (Phase 1) + gRPC terminal client (Phase 2).",
   "type": "module",
@@ -15,7 +15,10 @@
       "default": "./lib/grpc.js"
     }
   },
-  "files": ["lib", "proto"],
+  "files": [
+    "lib",
+    "proto"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
@@ -26,5 +29,8 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -3,7 +3,7 @@
  * primitive. Loads the bundled `sandbox.proto` at runtime via
  * @grpc/proto-loader; mTLS material comes from the CLI's cert dir
  * (~/.k8e/sandbox, KIP-14/KIP-17), shared with `k8e-sandbox-cli`.
- * @module @k8e/dsh-k8e-sandbox-client/grpc
+ * @module @k8e-sandbox/dsh-k8e-sandbox-client/grpc
  */
 
 import { readFileSync } from 'node:fs'

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
@@ -3,7 +3,7 @@
  * mTLS, profile, and session-state handling. Each operation is one process
  * spawn; Phase 2 replaces this with a direct gRPC client for streaming
  * fidelity (KIP-20).
- * @module @k8e/dsh-k8e-sandbox-client
+ * @module @k8e-sandbox/dsh-k8e-sandbox-client
  */
 
 import { spawn } from 'node:child_process'

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox-fs",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-fs",
   "version": "0.1.0",
   "description": "k8e-sandbox filesystem seam provider for DeepSeek Harness (ctx.fs).",
   "type": "module",
@@ -11,12 +11,14 @@
       "default": "./lib/index.js"
     }
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@k8e/dsh-k8e-sandbox": "workspace:*"
+    "@k8e-sandbox/dsh-k8e-sandbox": "workspace:*"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",
@@ -26,5 +28,8 @@
     "@deepseek-ai/cordis": "*",
     "@deepseek-ai/dsh-fs": "*",
     "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
@@ -2,7 +2,7 @@
  * k8e-sandbox Service Provider for the filesystem capability seam. Paths and
  * contents live in the sandbox workspace; operations shell out to
  * `k8e-sandbox-cli` in Phase 1 (KIP-20).
- * @module @k8e/dsh-k8e-sandbox-fs
+ * @module @k8e-sandbox/dsh-k8e-sandbox-fs
  */
 
 import { Buffer } from 'node:buffer'
@@ -19,7 +19,7 @@ import type {
   FsWriteIntent,
   FsWriteOutcome,
 } from '@deepseek-ai/dsh-fs'
-import type { K8eSandboxRuntime } from '@k8e/dsh-k8e-sandbox'
+import type { K8eSandboxRuntime } from '@k8e-sandbox/dsh-k8e-sandbox'
 
 /** Stat facts returned by the single `stat -c` probe. */
 interface StatFacts {

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox-host-ui",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-host-ui",
   "version": "0.1.0",
   "description": "k8e-sandbox host UI bridge: /k8e-sandbox HTTP API + terminal WebSocket (KIP-20 client half M1).",
   "type": "module",
@@ -11,13 +11,15 @@
       "default": "./lib/index.js"
     }
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@k8e/dsh-k8e-sandbox": "workspace:*",
-    "@k8e/dsh-k8e-sandbox-client-ui": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox-client-ui": "workspace:*",
     "ws": "^8.18.0"
   },
   "peerDependencies": {
@@ -30,5 +32,8 @@
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.10",
     "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/context-types.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/context-types.ts
@@ -4,11 +4,11 @@
  * type packages publish broken dependency chains on npm, so a third-party
  * plugin declares the documented harness faces locally. Drift is contained to
  * this file.
- * @module @k8e/dsh-k8e-sandbox-host-ui/context-types
+ * @module @k8e-sandbox/dsh-k8e-sandbox-host-ui/context-types
  */
 
 export type { Context } from '@deepseek-ai/cordis'
-import type { K8eSandboxRuntime } from '@k8e/dsh-k8e-sandbox'
+import type { K8eSandboxRuntime } from '@k8e-sandbox/dsh-k8e-sandbox'
 
 /** The HTTP request face (structural subset of node's IncomingMessage). */
 export interface SandboxHttpRequest {

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/index.ts
@@ -4,7 +4,7 @@
  * (`/k8e-sandbox/bundle/<name>.js`), and a `/k8e-sandbox/ws/terminal`
  * WebSocket that bridges the sandbox's remote PTY (KIP-19 spawnTerminal) to a
  * browser terminal. The config page itself lives in the client half.
- * @module @k8e/dsh-k8e-sandbox-host-ui
+ * @module @k8e-sandbox/dsh-k8e-sandbox-host-ui
  */
 
 import { readFile } from 'node:fs/promises'
@@ -49,7 +49,7 @@ function parseRequestUrl(req: SandboxHttpRequest): { pathname: string; searchPar
  */
 const require_ = createRequire(import.meta.url)
 const CHUNK_RESOLVER: Record<string, string> = {
-  terminal: '@k8e/dsh-k8e-sandbox-client-ui/client-terminal',
+  terminal: '@k8e-sandbox/dsh-k8e-sandbox-client-ui/client-terminal',
 }
 
 async function serveChunk(req: SandboxHttpRequest, res: SandboxHttpResponse): Promise<void> {
@@ -121,7 +121,7 @@ function recordExecStart(event: ExecStartEvent, entries: Map<string, ExecLogEntr
   entries.set(event.id, {
     id: event.id,
     command: event.command,
-    cwd: event.cwd,
+    ...(event.cwd !== undefined ? { cwd: event.cwd } : {}),
     startedAt: event.at,
     stdout: '',
     stderr: '',

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox-subprocess",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-subprocess",
   "version": "0.1.0",
   "description": "k8e-sandbox subprocess seam provider for DeepSeek Harness (ctx.subprocess).",
   "type": "module",
@@ -11,12 +11,14 @@
       "default": "./lib/index.js"
     }
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@k8e/dsh-k8e-sandbox": "workspace:*"
+    "@k8e-sandbox/dsh-k8e-sandbox": "workspace:*"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",
@@ -26,5 +28,8 @@
     "@deepseek-ai/cordis": "*",
     "@deepseek-ai/dsh-subprocess": "*",
     "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -2,7 +2,7 @@
  * k8e-sandbox Service Provider for the subprocess capability seam. Phase 1
  * maps `spawn` to a single-shot `k8e-sandbox-cli run`; streaming stdio and
  * `spawnTerminal` arrive in Phase 2 (direct gRPC + KIP-19 PTY).
- * @module @k8e/dsh-k8e-sandbox-subprocess
+ * @module @k8e-sandbox/dsh-k8e-sandbox-subprocess
  */
 
 import { posix } from 'node:path'
@@ -17,7 +17,9 @@ import type {
   SubprocessTerminalSignal,
   SubprocessTerminalSpawnSpec,
 } from '@deepseek-ai/dsh-subprocess'
-import type { GrpcK8eClient } from '@k8e/dsh-k8e-sandbox-client/grpc'
+import type { GrpcK8eClient } from '@k8e-sandbox/dsh-k8e-sandbox-client/grpc'
+// Side-effect import pulls in the cordis Context augmentation (ctx.k8eSandbox).
+import '@k8e-sandbox/dsh-k8e-sandbox'
 
 /** Quote one opaque argument for the CLI's `/bin/sh -c` layer. */
 function shellQuote(value: string): string {
@@ -168,8 +170,8 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
     const created = await grpcClient.createTerminal({
       sessionId,
       argv: [...spec.argv],
-      workdir: spec.cwd,
-      env: spec.env,
+      ...(spec.cwd !== undefined ? { workdir: spec.cwd } : {}),
+      ...(spec.env !== undefined ? { env: spec.env } : {}),
       rows: spec.rows,
       cols: spec.cols,
     })
@@ -192,7 +194,7 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
           resolve({ exitCode, signal: termSignal })
         }
       })
-      stream.on('error', (err) => {
+      stream.on('error', (err: unknown) => {
         output.destroy(err instanceof Error ? err : new Error(String(err)))
         if (!settled) {
           settled = true

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@k8e/dsh-k8e-sandbox",
+  "name": "@k8e-sandbox/dsh-k8e-sandbox",
   "version": "0.1.0",
   "description": "k8e-sandbox owner service for DeepSeek Harness (ctx.k8eSandbox).",
   "type": "module",
@@ -11,12 +11,14 @@
       "default": "./lib/index.js"
     }
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@k8e/dsh-k8e-sandbox-client": "workspace:*"
+    "@k8e-sandbox/dsh-k8e-sandbox-client": "workspace:*"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",
@@ -26,5 +28,8 @@
     "@deepseek-ai/cordis": "*",
     "@deepseek-ai/schemastery": "*",
     "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -2,13 +2,13 @@
  * Shared ownership of one k8e-sandbox session. Capability adapters await the
  * same session handle, so filesystem and process operations inhabit one remote
  * Linux world (mirrors the E2B POC's `ctx.e2b` owner).
- * @module @k8e/dsh-k8e-sandbox
+ * @module @k8e-sandbox/dsh-k8e-sandbox
  */
 
 import { Context, Service } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
-import { CliK8eClient } from '@k8e/dsh-k8e-sandbox-client'
-import { GrpcK8eClient } from '@k8e/dsh-k8e-sandbox-client/grpc'
+import { CliK8eClient } from '@k8e-sandbox/dsh-k8e-sandbox-client'
+import { GrpcK8eClient } from '@k8e-sandbox/dsh-k8e-sandbox-client/grpc'
 
 /** Configuration for the shared k8e-sandbox owner. */
 export interface Config {
@@ -85,8 +85,8 @@ export class K8eSandboxRuntime extends Service {
     this.config = {
       cwd: resolved.cwd,
       runtimeClass: resolved.runtimeClass,
-      tenant: config.tenant,
-      allowedHosts: config.allowedHosts,
+      ...(config.tenant !== undefined ? { tenant: config.tenant } : {}),
+      ...(config.allowedHosts !== undefined ? { allowedHosts: config.allowedHosts } : {}),
       pauseOnDispose: resolved.pauseOnDispose,
     }
     this.cwd = this.config.cwd
@@ -94,12 +94,12 @@ export class K8eSandboxRuntime extends Service {
     this.certDir = config.certDir
     this.runtimeClass = this.config.runtimeClass
     this.client = new CliK8eClient({
-      bin: process.env.K8E_SANDBOX_CLI_BIN,
-      profile: config.profile,
-      endpoint: config.endpoint,
+      ...(process.env.K8E_SANDBOX_CLI_BIN !== undefined ? { bin: process.env.K8E_SANDBOX_CLI_BIN } : {}),
+      ...(config.profile !== undefined ? { profile: config.profile } : {}),
+      ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
     })
     this.grpcClient = config.endpoint !== undefined
-      ? new GrpcK8eClient({ endpoint: config.endpoint, certDir: config.certDir })
+      ? new GrpcK8eClient({ endpoint: config.endpoint, ...(config.certDir !== undefined ? { certDir: config.certDir } : {}) })
       : undefined
 
     ctx.effect(() => async () => {
@@ -122,8 +122,8 @@ export class K8eSandboxRuntime extends Service {
     if (this.sessionId !== undefined) return this.sessionId
     const created = await this.client.createSession({
       runtimeClass: this.config.runtimeClass,
-      tenant: this.config.tenant,
-      allowedHosts: this.config.allowedHosts,
+      ...(this.config.tenant !== undefined ? { tenant: this.config.tenant } : {}),
+      ...(this.config.allowedHosts !== undefined ? { allowedHosts: this.config.allowedHosts } : {}),
     })
     if (this.disposed) {
       await this.client.destroySession(created.sessionId).catch(() => undefined)

--- a/plugins/deepseek-harness/scripts/build-client.mjs
+++ b/plugins/deepseek-harness/scripts/build-client.mjs
@@ -19,7 +19,7 @@ const PKG = join(ROOT, 'packages', 'dsh-k8e-sandbox-client-ui')
 const CLIENT_DIR = join(PKG, 'src', 'client')
 const OUT_DIR = join(PKG, 'lib')
 
-const CLIENT_ID = '@k8e/dsh-k8e-sandbox-client-ui'
+const CLIENT_ID = '@k8e-sandbox/dsh-k8e-sandbox-client-ui'
 
 const PLATFORM_EXTERNALS = ['react', 'react/jsx-runtime', 'react-dom/client']
 

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -94,6 +94,16 @@ function bumpVersion(packages, version) {
   }
 }
 
+/** Query the npm registry for the latest published version of a package. */
+function registryVersion(pkgName) {
+  try {
+    const out = execFileSync(NPM, ['view', `${pkgName}@latest`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
+    return out.split('\n').pop()?.trim() ?? null
+  } catch {
+    return null // not published yet (E404) or offline
+  }
+}
+
 function run(cmd, args, opts = {}) {
   console.log(`$ ${cmd} ${args.join(' ')}`)
   return execFileSync(cmd, args, { stdio: 'inherit', env: SAFE_ENV, ...opts })
@@ -154,20 +164,31 @@ if (!dryRun) {
 }
 
 // Version bump happens only for a real release (never on --dry-run), after
-// auth succeeded, and is rolled back if publishing fails (Greptile).
+// auth succeeded, and is rolled back if publishing fails (Greptile). The
+// whole post-auth flow — bump AND publish — sits inside one try/finally so a
+// throw anywhere (including version validation) still removes the temporary
+// token userconfig (Greptile security review).
 const originalVersions = new Map()
-if (!dryRun && versionArg) {
-  console.log(`\nBumping all packages to ${versionArg}:\n`)
-  for (const { name, data } of packages) {
-    originalVersions.set(data.name, data.version)
-  }
-  bumpVersion(packages, versionArg)
-}
-
 const published = []
 try {
+  if (!dryRun && versionArg) {
+    console.log(`\nBumping all packages to ${versionArg}:\n`)
+    for (const { name, data } of packages) {
+      originalVersions.set(data.name, data.version)
+    }
+    bumpVersion(packages, versionArg)
+  }
+
   console.log(`\nPublishing ${order.length} packages in topological order${dryRun ? ' (dry run)' : ''}:\n`)
   for (const { name, data } of order) {
+    // Resume support: a package whose version is already on the registry is
+    // skipped instead of colliding with the immutable prior publication
+    // (partial-failure retry after a rollback).
+    if (!dryRun && registryVersion(data.name) === data.version) {
+      console.log(`── ${data.name}@${data.version} already published, skipping`)
+      published.push(data.name)
+      continue
+    }
     console.log(`── ${data.name}@${data.version}`)
     const args = ['publish', '--no-git-checks']
     if (dryRun) args.push('--dry-run')
@@ -183,7 +204,7 @@ try {
       writeFileSync(join(root, 'packages', name, 'package.json'), JSON.stringify(data, null, 2) + '\n')
     }
   }
-  const done = published.length ? `\nAlready published (not rolled back on npm): ${published.join(', ')}` : ''
+  const done = published.length ? `\nAlready published (immutable on npm, skipped on retry): ${published.join(', ')}` : ''
   console.error(`\nRelease failed at ${order[published.length]?.data.name ?? '?'} — package.json versions restored.${done}`)
   throw err
 } finally {

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -94,13 +94,17 @@ function bumpVersion(packages, version) {
   }
 }
 
-/** Query the npm registry for the latest published version of a package. */
-function registryVersion(pkgName) {
+/**
+ * True when the exact version already exists on the registry (any dist-tag).
+ * Checking the precise version — not `@latest` — makes partial-release retries
+ * skip immutable prereleases/superseded versions too (Greptile).
+ */
+function registryHasVersion(pkgName, version) {
   try {
-    const out = execFileSync(NPM, ['view', `${pkgName}@latest`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
-    return out.split('\n').pop()?.trim() ?? null
+    const out = execFileSync(NPM, ['view', `${pkgName}@${version}`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
+    return out.split('\n').pop()?.trim() === version
   } catch {
-    return null // not published yet (E404) or offline
+    return false // E404 — not published yet
   }
 }
 
@@ -184,7 +188,7 @@ try {
     // Resume support: a package whose version is already on the registry is
     // skipped instead of colliding with the immutable prior publication
     // (partial-failure retry after a rollback).
-    if (!dryRun && registryVersion(data.name) === data.version) {
+    if (!dryRun && registryHasVersion(data.name, data.version)) {
       console.log(`── ${data.name}@${data.version} already published, skipping`)
       published.push(data.name)
       continue

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -121,13 +121,11 @@ const SAFE_ENV = { ...process.env, PATH: SAFE_PATH }
 const packages = loadPackages()
 const order = topoSort(packages)
 
-if (versionArg) {
-  console.log(`\nBumping all packages to ${versionArg}:\n`)
-  bumpVersion(packages, versionArg)
-}
-
+// Credentials are established BEFORE any version mutation, and the token
+// userconfig (when used) lives for the whole publish loop — deleting it after
+// `npm whoami` would leave `pnpm publish` unauthenticated (Greptile).
+let cleanupUserconfig = null
 if (!dryRun) {
-  // Fail fast with a clear message instead of a confusing 401 per package.
   const token = process.env.NPM_TOKEN
   const userNpmrc = join(process.env.HOME ?? '', '.npmrc')
   if (token) {
@@ -136,27 +134,55 @@ if (!dryRun) {
     const rc = join(tmp, '.npmrc')
     writeFileSync(rc, `//registry.npmjs.org/:_authToken=${token}\n`)
     SAFE_ENV.NPM_CONFIG_USERCONFIG = rc
-    try {
-      const who = execFileSync(NPM, ['whoami'], { encoding: 'utf8', env: SAFE_ENV }).trim()
-      console.log(`\nAuthenticated as ${who} on the npm registry (NPM_TOKEN).`)
-    } finally {
-      rmSync(tmp, { recursive: true, force: true })
-    }
-  } else if (existsSync(userNpmrc)) {
+    cleanupUserconfig = () => rmSync(tmp, { recursive: true, force: true })
+  } else if (!existsSync(userNpmrc)) {
+    console.error('\nNot logged in to npm. Run `npm login` or set NPM_TOKEN first.')
+    process.exit(1)
+  }
+  try {
     const who = execFileSync(NPM, ['whoami'], { encoding: 'utf8', env: SAFE_ENV }).trim()
     console.log(`\nAuthenticated as ${who} on the npm registry.`)
-  } else {
+  } catch {
+    cleanupUserconfig?.()
     console.error('\nNot logged in to npm. Run `npm login` or set NPM_TOKEN first.')
     process.exit(1)
   }
 }
 
-console.log(`\nPublishing ${order.length} packages in topological order${dryRun ? ' (dry run)' : ''}:\n`)
-for (const { name, data } of order) {
-  console.log(`── ${data.name}@${data.version}`)
-  const args = ['publish', '--no-git-checks']
-  if (dryRun) args.push('--dry-run')
-  run(PNPM, args, { cwd: join(root, 'packages', name) })
+// Version bump happens only for a real release (never on --dry-run), after
+// auth succeeded, and is rolled back if publishing fails (Greptile).
+const originalVersions = new Map()
+if (!dryRun && versionArg) {
+  console.log(`\nBumping all packages to ${versionArg}:\n`)
+  for (const { name, data } of packages) {
+    originalVersions.set(data.name, data.version)
+  }
+  bumpVersion(packages, versionArg)
+}
+
+const published = []
+try {
+  console.log(`\nPublishing ${order.length} packages in topological order${dryRun ? ' (dry run)' : ''}:\n`)
+  for (const { name, data } of order) {
+    console.log(`── ${data.name}@${data.version}`)
+    const args = ['publish', '--no-git-checks']
+    if (dryRun) args.push('--dry-run')
+    run(PNPM, args, { cwd: join(root, 'packages', name) })
+    published.push(data.name)
+  }
+} catch (err) {
+  // Roll back the local version bump so a failed release leaves no mutation.
+  for (const { name, data } of packages) {
+    if (originalVersions.has(data.name)) {
+      data.version = originalVersions.get(data.name)
+      writeFileSync(join(root, 'packages', name, 'package.json'), JSON.stringify(data, null, 2) + '\n')
+    }
+  }
+  const done = published.length ? `\nAlready published (not rolled back on npm): ${published.join(', ')}` : ''
+  console.error(`\nRelease failed at ${order[published.length]?.data.name ?? '?'} — package.json versions restored.${done}`)
+  throw err
+} finally {
+  cleanupUserconfig?.()
 }
 
 console.log(`\n${dryRun ? 'Dry run' : 'Release'} complete: ${order.map((p) => p.data.name).join(', ')}`)

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Release script for the @k8e-sandbox/* dsh plugin packages.
+ *
+ * Publishes the seven workspace packages to npmjs.com in dependency
+ * topological order (a package is published only after every package it
+ * depends on). `pnpm publish` rewrites `workspace:*` dependency ranges to the
+ * actual published versions, so consumers install real published packages.
+ *
+ * Usage:
+ *   node scripts/release.mjs [--dry-run] [--version <v>]
+ *
+ *   --dry-run   Build each package and verify the publish payload without
+ *               contacting the registry (pnpm publish --dry-run).
+ *   --version   Bump every package to <v> (e.g. 0.2.0) before publishing;
+ *               without it the current package.json versions are used.
+ *
+ * Environment:
+ *   NPM_TOKEN / npm login — the publishing identity must have access to the
+ *   `@k8e-sandbox` npm org. If NPM_TOKEN is set it is used for auth;
+ *   otherwise the ambient `npm whoami` session is required. Every package
+ *   carries `publishConfig.access = "public"`, so scoped packages publish
+ *   as public without extra flags.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const dryRun = process.argv.includes('--dry-run')
+const versionArg = (() => {
+  const i = process.argv.indexOf('--version')
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : null
+})()
+
+/** All workspace packages with their @k8e-sandbox/* dependencies. */
+function loadPackages() {
+  const dirs = []
+  for (const name of ['dsh-k8e-sandbox-client', 'dsh-k8e-sandbox-client-ui', 'dsh-k8e-sandbox', 'dsh-k8e-sandbox-fs', 'dsh-k8e-sandbox-subprocess', 'dsh-k8e-sandbox-host-ui', 'dsh-k8e-sandbox-bundle']) {
+    const p = join(root, 'packages', name, 'package.json')
+    if (!existsSync(p)) throw new Error(`missing package.json: ${p}`)
+    const data = JSON.parse(readFileSync(p, 'utf8'))
+    if (!data.name?.startsWith('@k8e-sandbox/')) {
+      throw new Error(`unexpected package name ${data.name} (expected @k8e-sandbox/*)`)
+    }
+    dirs.push({ name, data })
+  }
+  return dirs
+}
+
+/** Topological order: dependencies first. Throws on cycles. */
+function topoSort(packages) {
+  const byName = new Map(packages.map((p) => [p.data.name, p]))
+  const order = []
+  const state = new Map() // 0 = visiting, 1 = done
+  const visit = (p) => {
+    const mark = state.get(p.data.name)
+    if (mark === 1) return
+    if (mark === 0) throw new Error(`dependency cycle at ${p.data.name}`)
+    state.set(p.data.name, 0)
+    const deps = new Set([
+      ...Object.keys(p.data.dependencies ?? {}),
+      ...Object.keys(p.data.devDependencies ?? {}),
+      ...Object.keys(p.data.peerDependencies ?? {}),
+    ].filter((k) => k.startsWith('@k8e-sandbox/')))
+    for (const dep of deps) {
+      const depPkg = byName.get(dep)
+      if (!depPkg) throw new Error(`${p.data.name} depends on unknown workspace package ${dep}`)
+      visit(depPkg)
+    }
+    state.set(p.data.name, 1)
+    order.push(p)
+  }
+  for (const p of packages) visit(p)
+  return order
+}
+
+/** Bump every package version to the requested value (keeps them in lockstep). */
+function bumpVersion(packages, version) {
+  if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`invalid version "${version}" (expected semver like 0.2.0)`)
+  }
+  for (const { name, data } of packages) {
+    const p = join(root, 'packages', name, 'package.json')
+    data.version = version
+    writeFileSync(p, JSON.stringify(data, null, 2) + '\n')
+    console.log(`  bumped ${data.name} -> ${version}`)
+  }
+}
+
+function run(cmd, args, opts = {}) {
+  console.log(`$ ${cmd} ${args.join(' ')}`)
+  return execFileSync(cmd, args, { stdio: 'inherit', ...opts })
+}
+
+const packages = loadPackages()
+const order = topoSort(packages)
+
+if (versionArg) {
+  console.log(`\nBumping all packages to ${versionArg}:\n`)
+  bumpVersion(packages, versionArg)
+}
+
+if (!dryRun) {
+  // Fail fast with a clear message instead of a confusing 401 per package.
+  const token = process.env.NPM_TOKEN
+  const userNpmrc = join(process.env.HOME ?? '', '.npmrc')
+  const env = { ...process.env }
+  if (token) {
+    // Minimal temp userconfig so the token is never written into the repo.
+    const tmp = mkdtempSync(join(tmpdir(), 'k8e-release-'))
+    const rc = join(tmp, '.npmrc')
+    writeFileSync(rc, `//registry.npmjs.org/:_authToken=${token}\n`)
+    env.NPM_CONFIG_USERCONFIG = rc
+    try {
+      const who = execFileSync('npm', ['whoami'], { encoding: 'utf8', env }).trim()
+      console.log(`\nAuthenticated as ${who} on the npm registry (NPM_TOKEN).`)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  } else if (existsSync(userNpmrc)) {
+    const who = execFileSync('npm', ['whoami'], { encoding: 'utf8', env }).trim()
+    console.log(`\nAuthenticated as ${who} on the npm registry.`)
+  } else {
+    console.error('\nNot logged in to npm. Run `npm login` or set NPM_TOKEN first.')
+    process.exit(1)
+  }
+}
+
+console.log(`\nPublishing ${order.length} packages in topological order${dryRun ? ' (dry run)' : ''}:\n`)
+for (const { name, data } of order) {
+  console.log(`── ${data.name}@${data.version}`)
+  const args = ['publish', '--no-git-checks']
+  if (dryRun) args.push('--dry-run')
+  run('pnpm', args, { cwd: join(root, 'packages', name) })
+}
+
+console.log(`\n${dryRun ? 'Dry run' : 'Release'} complete: ${order.map((p) => p.data.name).join(', ')}`)

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -24,7 +24,7 @@
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { delimiter, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
 
@@ -92,8 +92,31 @@ function bumpVersion(packages, version) {
 
 function run(cmd, args, opts = {}) {
   console.log(`$ ${cmd} ${args.join(' ')}`)
-  return execFileSync(cmd, args, { stdio: 'inherit', ...opts })
+  return execFileSync(cmd, args, { stdio: 'inherit', env: SAFE_ENV, ...opts })
 }
+
+/**
+ * Resolve a binary to an absolute path from the ambient PATH, then rebuild a
+ * SAFE_PATH that only contains the binary's own directory plus fixed system
+ * directories. SonarCloud flags passing an untrusted PATH to exec* (S5310);
+ * using absolute binaries with a locked-down PATH keeps the release script
+ * from executing anything other than the installed npm/pnpm.
+ */
+function resolveBin(name) {
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    const cand = join(dir, name)
+    if (existsSync(cand)) return cand
+  }
+  throw new Error(`${name} not found on PATH`)
+}
+
+const NPM = resolveBin('npm')
+const PNPM = resolveBin('pnpm')
+const BIN_DIR = dirname(NPM)
+const SAFE_PATH = [BIN_DIR, '/usr/local/bin', '/usr/bin', '/bin']
+  .filter((d) => existsSync(d))
+  .join(delimiter)
+const SAFE_ENV = { ...process.env, PATH: SAFE_PATH }
 
 const packages = loadPackages()
 const order = topoSort(packages)
@@ -107,21 +130,20 @@ if (!dryRun) {
   // Fail fast with a clear message instead of a confusing 401 per package.
   const token = process.env.NPM_TOKEN
   const userNpmrc = join(process.env.HOME ?? '', '.npmrc')
-  const env = { ...process.env }
   if (token) {
     // Minimal temp userconfig so the token is never written into the repo.
     const tmp = mkdtempSync(join(tmpdir(), 'k8e-release-'))
     const rc = join(tmp, '.npmrc')
     writeFileSync(rc, `//registry.npmjs.org/:_authToken=${token}\n`)
-    env.NPM_CONFIG_USERCONFIG = rc
+    SAFE_ENV.NPM_CONFIG_USERCONFIG = rc
     try {
-      const who = execFileSync('npm', ['whoami'], { encoding: 'utf8', env }).trim()
+      const who = execFileSync(NPM, ['whoami'], { encoding: 'utf8', env: SAFE_ENV }).trim()
       console.log(`\nAuthenticated as ${who} on the npm registry (NPM_TOKEN).`)
     } finally {
       rmSync(tmp, { recursive: true, force: true })
     }
   } else if (existsSync(userNpmrc)) {
-    const who = execFileSync('npm', ['whoami'], { encoding: 'utf8', env }).trim()
+    const who = execFileSync(NPM, ['whoami'], { encoding: 'utf8', env: SAFE_ENV }).trim()
     console.log(`\nAuthenticated as ${who} on the npm registry.`)
   } else {
     console.error('\nNot logged in to npm. Run `npm login` or set NPM_TOKEN first.')
@@ -134,7 +156,7 @@ for (const { name, data } of order) {
   console.log(`── ${data.name}@${data.version}`)
   const args = ['publish', '--no-git-checks']
   if (dryRun) args.push('--dry-run')
-  run('pnpm', args, { cwd: join(root, 'packages', name) })
+  run(PNPM, args, { cwd: join(root, 'packages', name) })
 }
 
 console.log(`\n${dryRun ? 'Dry run' : 'Release'} complete: ${order.map((p) => p.data.name).join(', ')}`)

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -30,6 +30,10 @@ import { tmpdir } from 'node:os'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const dryRun = process.argv.includes('--dry-run')
+const otpArg = (() => {
+  const i = process.argv.indexOf('--otp')
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : null
+})()
 const versionArg = (() => {
   const i = process.argv.indexOf('--version')
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : null
@@ -167,6 +171,7 @@ try {
     console.log(`── ${data.name}@${data.version}`)
     const args = ['publish', '--no-git-checks']
     if (dryRun) args.push('--dry-run')
+    if (otpArg) args.push('--otp', otpArg)
     run(PNPM, args, { cwd: join(root, 'packages', name) })
     published.push(data.name)
   }

--- a/plugins/deepseek-harness/scripts/test.mjs
+++ b/plugins/deepseek-harness/scripts/test.mjs
@@ -1,5 +1,5 @@
 // Test runner: bundles each tests/*.test.mjs entry (which imports the plugin
-// source) with esbuild, resolving @k8e/* to src via alias and @deepseek-ai/*
+// source) with esbuild, resolving @k8e-sandbox/* to src via alias and @deepseek-ai/*
 // via the node_modules symlinks (see README), leaving @grpc/* external, then
 // imports and runs each bundle. Usage: node scripts/test.mjs [tests/<file>]
 import { readdir } from 'node:fs/promises'
@@ -24,11 +24,11 @@ for (const file of files) {
     sourcemap: false,
     external: ['@grpc/grpc-js', '@grpc/proto-loader'],
     alias: {
-      '@k8e/dsh-k8e-sandbox': join(ROOT, 'packages/dsh-k8e-sandbox/src/index.ts'),
-      '@k8e/dsh-k8e-sandbox-client': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/index.ts'),
-      '@k8e/dsh-k8e-sandbox-client/grpc': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/grpc.ts'),
-      '@k8e/dsh-k8e-sandbox-fs': join(ROOT, 'packages/dsh-k8e-sandbox-fs/src/index.ts'),
-      '@k8e/dsh-k8e-sandbox-subprocess': join(ROOT, 'packages/dsh-k8e-sandbox-subprocess/src/index.ts'),
+      '@k8e-sandbox/dsh-k8e-sandbox': join(ROOT, 'packages/dsh-k8e-sandbox/src/index.ts'),
+      '@k8e-sandbox/dsh-k8e-sandbox-client': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/index.ts'),
+      '@k8e-sandbox/dsh-k8e-sandbox-client/grpc': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/grpc.ts'),
+      '@k8e-sandbox/dsh-k8e-sandbox-fs': join(ROOT, 'packages/dsh-k8e-sandbox-fs/src/index.ts'),
+      '@k8e-sandbox/dsh-k8e-sandbox-subprocess': join(ROOT, 'packages/dsh-k8e-sandbox-subprocess/src/index.ts'),
     },
   })
   const outfile = join(testsDir, `.bundle-${file}`)

--- a/plugins/deepseek-harness/tests/fs.test.mjs
+++ b/plugins/deepseek-harness/tests/fs.test.mjs
@@ -2,7 +2,7 @@
 // fake ctx with a fake owner + fake CliK8eClient (an in-memory file map), then
 // assert resolve/read/write/edit/list map correctly.
 import assert from 'node:assert/strict'
-import { K8eFileSystem } from '@k8e/dsh-k8e-sandbox-fs'
+import { K8eFileSystem } from '@k8e-sandbox/dsh-k8e-sandbox-fs'
 
 function makeCliClient(files) {
   const calls = []

--- a/plugins/deepseek-harness/tests/grpc-sse.test.mjs
+++ b/plugins/deepseek-harness/tests/grpc-sse.test.mjs
@@ -1,6 +1,6 @@
 // Pure-unit test for the /exec/stream SSE decoder (no harness, no gRPC).
 import assert from 'node:assert/strict'
-import { ExecSSEDecoder } from '@k8e/dsh-k8e-sandbox-client/grpc'
+import { ExecSSEDecoder } from '@k8e-sandbox/dsh-k8e-sandbox-client/grpc'
 
 // pid frame is dropped; data + exit are emitted in order.
 {

--- a/plugins/deepseek-harness/tests/subprocess.test.mjs
+++ b/plugins/deepseek-harness/tests/subprocess.test.mjs
@@ -4,7 +4,7 @@
 // the handle maps correctly. No harness, no gateway, no cluster.
 import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
-import { K8eSubprocessRuntime } from '@k8e/dsh-k8e-sandbox-subprocess'
+import { K8eSubprocessRuntime } from '@k8e-sandbox/dsh-k8e-sandbox-subprocess'
 
 function makeGrpcClient() {
   const calls = []


### PR DESCRIPTION
## Summary

Rebrand the `plugins/deepseek-harness` workspace from the `@k8e` npm scope to **`@k8e-sandbox`** so all seven dsh plugin packages can be published to npmjs.com under the new org, and add a dependency-topological release script for publishing.

## Changes

- **Scope rename `@k8e` → `@k8e-sandbox`** — all 7 packages (`dsh-k8e-sandbox`, `-client`, `-client-ui`, `-fs`, `-subprocess`, `-host-ui`, `-bundle`): package.json `name`/`dependencies`/`devDependencies`/`peerDependencies`, source imports, `cordis.patch.yml`, build/test scripts, and docs (README, e2e.md, ui-design.md). Package names (`dsh-k8e-sandbox*`) unchanged; only the scope moves.
- **Build fixes (pre-existing)** — the workspace did not typecheck due to `exactOptionalPropertyTypes` errors (`tenant`, `allowedHosts`, `certDir`, `bin`, `profile`, `endpoint`, `env`, `cwd`, implicit `any`). Fixed with conditional object spreads; all 6 `tsc` builds pass and `scripts/test.mjs` (fs/grpc-sse/subprocess fake-ctx) is green.
- **`scripts/release.mjs`** — publishes the 7 packages in dependency-topological order (cycle-checked) to npmjs.com:
  - `node scripts/release.mjs --dry-run` — verify payloads without the registry
  - `node scripts/release.mjs --version <v>` — lockstep version bump then publish
  - `pnpm publish` rewrites `workspace:*` ranges to real published versions (verified in the tarball)
  - Auth: `NPM_TOKEN` (temp userconfig, never written to the repo) or ambient `npm login`; fail-fast `npm whoami`
- **`publishConfig.access = "public"`** on every package; README gains a Release section.

## Validation

- `node scripts/release.mjs --dry-run` — all 7 packages pack & publish-dry-run cleanly
- `node scripts/test.mjs` — 3/3 fake-ctx tests pass
- `tsc -p tsconfig.json` — 6 packages build clean

## Notes

Actual publication to npmjs.com is a production action pending credentials: `npm login` (or `NPM_TOKEN`) with access to the `@k8e-sandbox` org, then `node scripts/release.mjs`.