### PR TITLE
fix(dsh): rewrite workspace:* deps for npm publish + bump to 0.1.1

### DIFF
--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-bundle",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Installable dsh bundle mounting the k8e-sandbox execution world (KIP-20).",
   "type": "module",
   "files": [

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-client-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox client half: settings section + terminal panel (KIP-20 M2).",
   "type": "module",
   "files": [

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox transport: CLI client (Phase 1) + gRPC terminal client (Phase 2).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-fs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox filesystem seam provider for DeepSeek Harness (ctx.fs).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-host-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox host UI bridge: /k8e-sandbox HTTP API + terminal WebSocket (KIP-20 client half M1).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-subprocess",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox subprocess seam provider for DeepSeek Harness (ctx.subprocess).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox owner service for DeepSeek Harness (ctx.k8eSandbox).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -223,13 +223,17 @@ try {
       continue
     }
     // npm publish does not rewrite workspace:* ranges; swap them for the
-    // real published versions just for this publish, then restore.
+    // real published versions just for this publish, then restore in a
+    // finally so a failed npm command never leaves rewritten ranges behind.
     const restoreDeps = rewriteWorkspaceDeps({ name, data })
-    console.log(`── ${data.name}@${data.version}`)
-    const args = dryRun ? ['pack', '--dry-run'] : ['publish', '--no-git-checks']
-    if (!dryRun && otpArg) args.push('--otp', otpArg)
-    run(PUBLISH_BIN, args, { cwd: join(root, 'packages', name) })
-    restoreDeps()
+    try {
+      console.log(`── ${data.name}@${data.version}`)
+      const args = dryRun ? ['pack', '--dry-run'] : ['publish', '--no-git-checks']
+      if (!dryRun && otpArg) args.push('--otp', otpArg)
+      run(PUBLISH_BIN, args, { cwd: join(root, 'packages', name) })
+    } finally {
+      restoreDeps()
+    }
     published.push(data.name)
   }
 } catch (err) {

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -99,14 +99,17 @@ function bumpVersion(packages, version) {
 /**
  * Rewrite in-workspace `workspace:*` ranges to the actual published versions
  * so the registry payload is installable (npm publish does NOT rewrite them,
- * unlike pnpm). Returns a restore callback.
+ * unlike pnpm). Operates on a JSON copy — never mutates the in-memory
+ * package data — so a later version-rollback serialization can not persist
+ * rewritten ranges. Returns a restore callback.
  */
 function rewriteWorkspaceDeps(pkg) {
   const path = join(root, 'packages', pkg.name, 'package.json')
   const original = readFileSync(path, 'utf8')
+  const rewritten = JSON.parse(original)
   let changed = false
   for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
-    const deps = pkg.data[section]
+    const deps = rewritten[section]
     if (!deps) continue
     for (const [dep, range] of Object.entries(deps)) {
       if (dep.startsWith('@k8e-sandbox/') && (range === 'workspace:*' || range === 'workspace:^')) {
@@ -118,7 +121,7 @@ function rewriteWorkspaceDeps(pkg) {
     }
   }
   if (changed) {
-    writeFileSync(path, JSON.stringify(pkg.data, null, 2) + '\n')
+    writeFileSync(path, JSON.stringify(rewritten, null, 2) + '\n')
   }
   return () => writeFileSync(path, original)
 }

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -4,14 +4,16 @@
  *
  * Publishes the seven workspace packages to npmjs.com in dependency
  * topological order (a package is published only after every package it
- * depends on). `pnpm publish` rewrites `workspace:*` dependency ranges to the
- * actual published versions, so consumers install real published packages.
+ * depends on). Uses `npm publish` (pnpm 11.x ignores `--otp` and fails with
+ * ERR_PNPM_OTP_NON_INTERACTIVE under 2FA); npm rewrites the in-workspace
+ * `workspace:*` ranges to the actual published versions, so consumers
+ * install real published packages.
  *
  * Usage:
  *   node scripts/release.mjs [--dry-run] [--version <v>]
  *
- *   --dry-run   Build each package and verify the publish payload without
- *               contacting the registry (pnpm publish --dry-run).
+ *   --dry-run   Verify the publish payload without contacting the registry
+ *               (npm publish --dry-run).
  *   --version   Bump every package to <v> (e.g. 0.2.0) before publishing;
  *               without it the current package.json versions are used.
  *
@@ -95,17 +97,30 @@ function bumpVersion(packages, version) {
 }
 
 /**
- * True when the exact version already exists on the registry (any dist-tag).
- * Checking the precise version — not `@latest` — makes partial-release retries
- * skip immutable prereleases/superseded versions too (Greptile).
+ * Rewrite in-workspace `workspace:*` ranges to the actual published versions
+ * so the registry payload is installable (npm publish does NOT rewrite them,
+ * unlike pnpm). Returns a restore callback.
  */
-function registryHasVersion(pkgName, version) {
-  try {
-    const out = execFileSync(NPM, ['view', `${pkgName}@${version}`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
-    return out.split('\n').pop()?.trim() === version
-  } catch {
-    return false // E404 — not published yet
+function rewriteWorkspaceDeps(pkg) {
+  const path = join(root, 'packages', pkg.name, 'package.json')
+  const original = readFileSync(path, 'utf8')
+  let changed = false
+  for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const deps = pkg.data[section]
+    if (!deps) continue
+    for (const [dep, range] of Object.entries(deps)) {
+      if (dep.startsWith('@k8e-sandbox/') && (range === 'workspace:*' || range === 'workspace:^')) {
+        const target = packages.find((q) => q.data.name === dep)
+        if (!target) throw new Error(`workspace dep ${dep} of ${pkg.data.name} not found`)
+        deps[dep] = target.data.version
+        changed = true
+      }
+    }
   }
+  if (changed) {
+    writeFileSync(path, JSON.stringify(pkg.data, null, 2) + '\n')
+  }
+  return () => writeFileSync(path, original)
 }
 
 function run(cmd, args, opts = {}) {
@@ -129,12 +144,26 @@ function resolveBin(name) {
 }
 
 const NPM = resolveBin('npm')
-const PNPM = resolveBin('pnpm')
+const PUBLISH_BIN = NPM // npm publish: pnpm 11.x --otp is ignored under 2FA (ERR_PNPM_OTP_NON_INTERACTIVE)
 const BIN_DIR = dirname(NPM)
 const SAFE_PATH = [BIN_DIR, '/usr/local/bin', '/usr/bin', '/bin']
   .filter((d) => existsSync(d))
   .join(delimiter)
 const SAFE_ENV = { ...process.env, PATH: SAFE_PATH }
+
+/**
+ * True when the exact version already exists on the registry (any dist-tag).
+ * Checking the precise version — not `@latest` — makes partial-release retries
+ * skip immutable prereleases/superseded versions too (Greptile).
+ */
+function registryHasVersion(pkgName, version) {
+  try {
+    const out = execFileSync(NPM, ['view', `${pkgName}@${version}`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
+    return out.split('\n').pop()?.trim() === version
+  } catch {
+    return false // E404 — not published yet
+  }
+}
 
 const packages = loadPackages()
 const order = topoSort(packages)
@@ -193,11 +222,14 @@ try {
       published.push(data.name)
       continue
     }
+    // npm publish does not rewrite workspace:* ranges; swap them for the
+    // real published versions just for this publish, then restore.
+    const restoreDeps = rewriteWorkspaceDeps({ name, data })
     console.log(`── ${data.name}@${data.version}`)
-    const args = ['publish', '--no-git-checks']
-    if (dryRun) args.push('--dry-run')
-    if (otpArg) args.push('--otp', otpArg)
-    run(PNPM, args, { cwd: join(root, 'packages', name) })
+    const args = dryRun ? ['pack', '--dry-run'] : ['publish', '--no-git-checks']
+    if (!dryRun && otpArg) args.push('--otp', otpArg)
+    run(PUBLISH_BIN, args, { cwd: join(root, 'packages', name) })
+    restoreDeps()
     published.push(data.name)
   }
 } catch (err) {


### PR DESCRIPTION
## Summary

Fixes the npm publishing path discovered during the 0.1.0 release: **`npm publish` does NOT rewrite `workspace:*` dependency ranges** (pnpm does), so the published 0.1.0 packages carried uninstallable `workspace:*` ranges. This PR rewrites them to real versions at publish time and ships the corrected **0.1.1** release.

## Changes

- **`scripts/release.mjs`**:
  - `rewriteWorkspaceDeps()` swaps `workspace:*`/`workspace:^` ranges for the actual published versions before each publish, restoring the local manifests afterwards (workspace development keeps `workspace:*`).
  - Uses **`npm publish`** instead of `pnpm publish` — pnpm 11.x ignores `--otp` under 2FA (`ERR_PNPM_OTP_NON_INTERACTIVE`), which blocked the release; `npm publish --otp` works.
  - Dry-run uses **`npm pack --dry-run`** (no version-collision check against the registry).
- **Version bump** — all 7 packages to `0.1.1`, published to npmjs.com; verified `latest` is `0.1.1` and the bundle depends on `@k8e-sandbox/*@0.1.1` (real ranges, no `workspace:*`).

## Validation

- `node scripts/release.mjs --dry-run` — 7 packages pack cleanly
- Published 0.1.1: registry shows real version ranges for all workspace deps
- `npm install @k8e-sandbox/dsh-k8e-sandbox-bundle` resolves past `workspace:*`; the remaining `@deepseek-ai/dsh-*` 404s are expected (private dsh ecosystem, provided as peer deps by the harness)

## Note

The initial 0.1.0 publication (broken `workspace:*` ranges) is still on the registry; 0.1.1 is now `latest`. Unpublishing 0.1.0 is optional (needs npm 2FA OTP).