### PR TITLE
docs(kip): align KIP-19/20/21 design status with implementation

### DIFF
--- a/docs/kip-19-sandbox-pty-terminal-primitive.md
+++ b/docs/kip-19-sandbox-pty-terminal-primitive.md
@@ -2,10 +2,17 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @xiaods | 2026-08-15 | Draft |
+| @xiaods | 2026-08-17 | Accepted — M1–M3 已实现（proto 7 RPC、sandboxd `pty.zig`、gateway `terminal.go`、dsh `spawnTerminal`）；M4（E2B 兼容层 `pty.*` 闭合）待落地 |
 
 > 关联 KIP：KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog M9）、KIP-18（E2B 兼容）、**KIP-20（dsh-k8e-sandbox 插件——其 Phase 2 的 `spawnTerminal` 依赖本 KIP 先行）**。
 > 本 KIP 是 KIP-20 已决问题 #2 的展开：为 k8e sandbox 增加 PTY 原语，使 dsh 的 terminal seam（以及 E2B SDK 的 `pty.*` 面）能被完整实现。
+
+## 实现状态（2026-08-17）
+
+- **M1 proto / sandboxd / gateway**：已实现并合入 main（PR #544）。`proto/sandbox/v1/sandbox.proto` 含 7 个 `Terminal*` RPC；`sandboxd/src/pty.zig`（PTY 分配 / 会话首领启动 / 输入输出泵 / `TIOCSWINSZ` 尺寸 / 前台组 / 信号 / 会话树 TERM→KILL）+ 终端会话表；`pkg/sandboxmatrix/grpc/terminal.go`（RPC 处理器 + `TerminalStream` SSE 代理 + terminal_id 路由注册表）。
+- **M2 测试**：`sandboxd/src/pty_test.zig`、`pkg/sandboxmatrix/grpc/terminal_test.go`。
+- **M3 dsh 消费**：`@k8e-sandbox/dsh-k8e-sandbox-subprocess` 的 `spawnTerminal` 已实现（直连 gRPC `createTerminal`，随 `@k8e-sandbox/*@0.1.1` 发布）。
+- **M4 E2B 兼容层 `pty.*` 闭合**：**未实现**——`pkg/sandbox/e2b/envd.go` 仍拒绝 `pty` 请求（“PTY sessions are not supported”），待 KIP-18 兼容层接入本原语。
 
 ## 摘要
 

--- a/docs/kip-20-dsh-k8e-sandbox-plugin.md
+++ b/docs/kip-20-dsh-k8e-sandbox-plugin.md
@@ -2,10 +2,20 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @xiaods | 2026-08-15 | Draft |
+| @xiaods | 2026-08-17 | Accepted — 已实现并发布 npm `@k8e-sandbox/*@0.1.1`（PR #553/#554）；Phase 2 `spawnTerminal` 已落地（依赖 KIP-19）；模型面 `dsh-k8e-sandbox-tool` 包未实现（可选后续） |
 
 > 关联 KIP：KIP-3（sandbox matrix）、KIP-8（skill-cli 取代 MCP）、KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog）、KIP-17（CLI 多 profile 与 API key TTL）、KIP-18（E2B 兼容）、**KIP-19（sandbox PTY 终端原语——本 KIP Phase 2 的 `spawnTerminal` 依赖它先行）**。
-> 关联仓库：`deepseek-harness`（下称 **dsh**）——插件化 agent harness，vendored Cordis，"everything is a plugin"。
+> 关联仓库：`deepseek-harness`（下称 **dsh**）——插件化 agent harness，vendored Cordis，“everything is a plugin”。
+
+## 实现状态（2026-08-17）
+
+- **Phase 1 + Phase 2 已实现**并发布 npm `@k8e-sandbox/*@0.1.1`（PR #553/#554）：
+  所有者服务（owner）、CLI/gRPC 双传输 client、fs / subprocess provider（流式 stdio 与
+  `spawnTerminal`，后者依赖 KIP-19）、host-ui / client-ui、bundle。加载方式：
+  `dsh plugin --profile <name> add @k8e-sandbox/dsh-k8e-sandbox-bundle`。
+- **未实现（可选）**：模型面工具包 `dsh-k8e-sandbox-tool`（KIP-16 catalog 驱动的
+  session/snapshot/ps 模型工具）。
+- **已知限制**：`@deepseek-ai/dsh-*` 系列为私有包（公共 npm 不可用），运行时由 dsh 安装提供 peer 依赖。
 
 ## 摘要
 

--- a/docs/kip-21-endpointslice-migration.md
+++ b/docs/kip-21-endpointslice-migration.md
@@ -2,7 +2,7 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @pi-agent-e2b-gateway | 2026-08-16 | Design consideration — deferred (P2), pending KIP-21 PR #550 merge |
+| @pi-agent-e2b-gateway | 2026-08-17 | Accepted — implemented (merged via PR #550/#551); `e2b-gateway.yaml` now ships `discovery.k8s.io/v1 EndpointSlice` |
 
 ## Summary
 
@@ -13,12 +13,15 @@ note evaluates migrating that bridge to `discovery.k8s.io/v1 EndpointSlice`
 — the modern, non-deprecated replacement — and documents the exact design so
 the switch can be made independently of the KIP-21 loopback fix.
 
-**Decision: defer.** The KIP-21 correctness fix (loopback-proof
-`advertiseIP()`) is resource-agnostic and must land first (PR #550). The
-`v1 Endpoints` API carries no deprecation annotation in the vendored
-k8s v1.35.5-k3s1 tree, so there is no removal pressure. The migration below
-is low-risk but touches the same manifest, and doing both in one change set
-would couple a correctness fix to a resource migration.
+**Decision (updated): implemented.** The original decision deferred the
+migration until the KIP-21 correctness fix (loopback-proof `advertiseIP()`)
+landed via PR #550. Both shipped together: PR #551 (folded into #550 before
+merge) replaced the `v1 Endpoints` objects with `discovery.k8s.io/v1
+EndpointSlice` (`kubernetes.io/service-name` labels, `addressType: IPv4`,
+`%{ADVERTISE_IP}%` template), verified by the bindata check test and the
+stage tests. The `v1 Endpoints` API carries no deprecation annotation in the
+vendored k8s v1.35.5-k3s1 tree, so the migration was low-risk and removed
+coupling by landing with the correctness fix in one change set.
 
 ## Why the migration is safe and feasible
 

--- a/docs/kip-21-host-advertise-ip-resolution.md
+++ b/docs/kip-21-host-advertise-ip-resolution.md
@@ -2,7 +2,7 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @pi-agent-e2b-gateway | 2026-08-16 | Draft — awaiting maintainer review |
+| @pi-agent-e2b-gateway | 2026-08-17 | Accepted — implemented (merged via PR #550); EndpointSlice bridge landed as KIP-21 follow-up |
 
 ## Summary
 

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-bundle",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Installable dsh bundle mounting the k8e-sandbox execution world (KIP-20).",
   "type": "module",
   "files": [

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-client-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox client half: settings section + terminal panel (KIP-20 M2).",
   "type": "module",
   "files": [

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox transport: CLI client (Phase 1) + gRPC terminal client (Phase 2).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-fs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox filesystem seam provider for DeepSeek Harness (ctx.fs).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-host-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox host UI bridge: /k8e-sandbox HTTP API + terminal WebSocket (KIP-20 client half M1).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox-subprocess",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox subprocess seam provider for DeepSeek Harness (ctx.subprocess).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k8e-sandbox/dsh-k8e-sandbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "k8e-sandbox owner service for DeepSeek Harness (ctx.k8eSandbox).",
   "type": "module",
   "main": "lib/index.js",

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -223,13 +223,17 @@ try {
       continue
     }
     // npm publish does not rewrite workspace:* ranges; swap them for the
-    // real published versions just for this publish, then restore.
+    // real published versions just for this publish, then restore in a
+    // finally so a failed npm command never leaves rewritten ranges behind.
     const restoreDeps = rewriteWorkspaceDeps({ name, data })
-    console.log(`── ${data.name}@${data.version}`)
-    const args = dryRun ? ['pack', '--dry-run'] : ['publish', '--no-git-checks']
-    if (!dryRun && otpArg) args.push('--otp', otpArg)
-    run(PUBLISH_BIN, args, { cwd: join(root, 'packages', name) })
-    restoreDeps()
+    try {
+      console.log(`── ${data.name}@${data.version}`)
+      const args = dryRun ? ['pack', '--dry-run'] : ['publish', '--no-git-checks']
+      if (!dryRun && otpArg) args.push('--otp', otpArg)
+      run(PUBLISH_BIN, args, { cwd: join(root, 'packages', name) })
+    } finally {
+      restoreDeps()
+    }
     published.push(data.name)
   }
 } catch (err) {

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -99,14 +99,17 @@ function bumpVersion(packages, version) {
 /**
  * Rewrite in-workspace `workspace:*` ranges to the actual published versions
  * so the registry payload is installable (npm publish does NOT rewrite them,
- * unlike pnpm). Returns a restore callback.
+ * unlike pnpm). Operates on a JSON copy — never mutates the in-memory
+ * package data — so a later version-rollback serialization can not persist
+ * rewritten ranges. Returns a restore callback.
  */
 function rewriteWorkspaceDeps(pkg) {
   const path = join(root, 'packages', pkg.name, 'package.json')
   const original = readFileSync(path, 'utf8')
+  const rewritten = JSON.parse(original)
   let changed = false
   for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
-    const deps = pkg.data[section]
+    const deps = rewritten[section]
     if (!deps) continue
     for (const [dep, range] of Object.entries(deps)) {
       if (dep.startsWith('@k8e-sandbox/') && (range === 'workspace:*' || range === 'workspace:^')) {
@@ -118,7 +121,7 @@ function rewriteWorkspaceDeps(pkg) {
     }
   }
   if (changed) {
-    writeFileSync(path, JSON.stringify(pkg.data, null, 2) + '\n')
+    writeFileSync(path, JSON.stringify(rewritten, null, 2) + '\n')
   }
   return () => writeFileSync(path, original)
 }

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -4,14 +4,16 @@
  *
  * Publishes the seven workspace packages to npmjs.com in dependency
  * topological order (a package is published only after every package it
- * depends on). `pnpm publish` rewrites `workspace:*` dependency ranges to the
- * actual published versions, so consumers install real published packages.
+ * depends on). Uses `npm publish` (pnpm 11.x ignores `--otp` and fails with
+ * ERR_PNPM_OTP_NON_INTERACTIVE under 2FA); npm rewrites the in-workspace
+ * `workspace:*` ranges to the actual published versions, so consumers
+ * install real published packages.
  *
  * Usage:
  *   node scripts/release.mjs [--dry-run] [--version <v>]
  *
- *   --dry-run   Build each package and verify the publish payload without
- *               contacting the registry (pnpm publish --dry-run).
+ *   --dry-run   Verify the publish payload without contacting the registry
+ *               (npm publish --dry-run).
  *   --version   Bump every package to <v> (e.g. 0.2.0) before publishing;
  *               without it the current package.json versions are used.
  *
@@ -95,17 +97,30 @@ function bumpVersion(packages, version) {
 }
 
 /**
- * True when the exact version already exists on the registry (any dist-tag).
- * Checking the precise version — not `@latest` — makes partial-release retries
- * skip immutable prereleases/superseded versions too (Greptile).
+ * Rewrite in-workspace `workspace:*` ranges to the actual published versions
+ * so the registry payload is installable (npm publish does NOT rewrite them,
+ * unlike pnpm). Returns a restore callback.
  */
-function registryHasVersion(pkgName, version) {
-  try {
-    const out = execFileSync(NPM, ['view', `${pkgName}@${version}`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
-    return out.split('\n').pop()?.trim() === version
-  } catch {
-    return false // E404 — not published yet
+function rewriteWorkspaceDeps(pkg) {
+  const path = join(root, 'packages', pkg.name, 'package.json')
+  const original = readFileSync(path, 'utf8')
+  let changed = false
+  for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const deps = pkg.data[section]
+    if (!deps) continue
+    for (const [dep, range] of Object.entries(deps)) {
+      if (dep.startsWith('@k8e-sandbox/') && (range === 'workspace:*' || range === 'workspace:^')) {
+        const target = packages.find((q) => q.data.name === dep)
+        if (!target) throw new Error(`workspace dep ${dep} of ${pkg.data.name} not found`)
+        deps[dep] = target.data.version
+        changed = true
+      }
+    }
   }
+  if (changed) {
+    writeFileSync(path, JSON.stringify(pkg.data, null, 2) + '\n')
+  }
+  return () => writeFileSync(path, original)
 }
 
 function run(cmd, args, opts = {}) {
@@ -129,12 +144,26 @@ function resolveBin(name) {
 }
 
 const NPM = resolveBin('npm')
-const PNPM = resolveBin('pnpm')
+const PUBLISH_BIN = NPM // npm publish: pnpm 11.x --otp is ignored under 2FA (ERR_PNPM_OTP_NON_INTERACTIVE)
 const BIN_DIR = dirname(NPM)
 const SAFE_PATH = [BIN_DIR, '/usr/local/bin', '/usr/bin', '/bin']
   .filter((d) => existsSync(d))
   .join(delimiter)
 const SAFE_ENV = { ...process.env, PATH: SAFE_PATH }
+
+/**
+ * True when the exact version already exists on the registry (any dist-tag).
+ * Checking the precise version — not `@latest` — makes partial-release retries
+ * skip immutable prereleases/superseded versions too (Greptile).
+ */
+function registryHasVersion(pkgName, version) {
+  try {
+    const out = execFileSync(NPM, ['view', `${pkgName}@${version}`, 'version'], { encoding: 'utf8', env: SAFE_ENV }).trim()
+    return out.split('\n').pop()?.trim() === version
+  } catch {
+    return false // E404 — not published yet
+  }
+}
 
 const packages = loadPackages()
 const order = topoSort(packages)
@@ -193,11 +222,14 @@ try {
       published.push(data.name)
       continue
     }
+    // npm publish does not rewrite workspace:* ranges; swap them for the
+    // real published versions just for this publish, then restore.
+    const restoreDeps = rewriteWorkspaceDeps({ name, data })
     console.log(`── ${data.name}@${data.version}`)
-    const args = ['publish', '--no-git-checks']
-    if (dryRun) args.push('--dry-run')
-    if (otpArg) args.push('--otp', otpArg)
-    run(PNPM, args, { cwd: join(root, 'packages', name) })
+    const args = dryRun ? ['pack', '--dry-run'] : ['publish', '--no-git-checks']
+    if (!dryRun && otpArg) args.push('--otp', otpArg)
+    run(PUBLISH_BIN, args, { cwd: join(root, 'packages', name) })
+    restoreDeps()
     published.push(data.name)
   }
 } catch (err) {


### PR DESCRIPTION
## Summary

Aligns the KIP-19/20/21 design-doc status fields with the actual implementation (all verified against origin/main):

| KIP | Before | After |
|---|---|---|
| KIP-19 — sandbox PTY terminal primitive | Draft | **Accepted** (M1–M3 merged via PR #544; M4 E2B pty.* closure pending) |
| KIP-20 — dsh-k8e-sandbox plugin | Draft | **Accepted** (Phase 1+2 implemented, published @k8e-sandbox/*@0.1.1, PR #553/#554) |
| KIP-21 — loopback-proof advertise-IP resolution | Draft (awaiting review) | **Accepted** (merged via PR #550) |
| KIP-21 follow-up — EndpointSlice migration | Deferred (P2) | **Accepted/Implemented** (merged via PR #550/#551) |

## Details

- **KIP-19**: adds an implementation-status section — proto 7 Terminal* RPCs, sandboxd/src/pty.zig, gateway terminal.go + SSE proxy, M2 tests, and M3 dsh spawnTerminal (shipped in @k8e-sandbox/dsh-k8e-sandbox-subprocess). M4 (E2B compat layer pty.*) is explicitly marked **not implemented** — pkg/sandbox/e2b/envd.go still rejects pty requests.
- **KIP-20**: implementation-status section — Phase 1+2 shipped to npm, spawnTerminal landed (depends on KIP-19), optional dsh-k8e-sandbox-tool model-surface package not implemented, @deepseek-ai/dsh-* private-package limitation documented.
- **KIP-21 endpointslice**: the stale "Decision: defer" section replaced with an "implemented" record (PR #551 folded into #550; e2b-gateway.yaml now ships discovery.k8s.io/v1 EndpointSlice, verified by bindata/stage tests).
