### PR TITLE
feat(e2b, dsh): close KIP-19 M4 E2B pty compat + KIP-20 model-surface tool package

### DIFF
--- a/docs/kip-20-dsh-k8e-sandbox-plugin.md
+++ b/docs/kip-20-dsh-k8e-sandbox-plugin.md
@@ -2,7 +2,7 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @xiaods | 2026-08-17 | Accepted — 已实现并发布 npm `@k8e-sandbox/*@0.1.1`（PR #553/#554）；Phase 2 `spawnTerminal` 已落地（依赖 KIP-19）；模型面 `dsh-k8e-sandbox-tool` 包未实现（可选后续） |
+| @xiaods | 2026-08-17 | Accepted — 已实现并发布 npm `@k8e-sandbox/*@0.1.1`（PR #553/#554）；Phase 2 `spawnTerminal` 已落地（依赖 KIP-19）；模型面 `dsh-k8e-sandbox-tool` 已实现（session/exec/background/poll 工具，随 bundle 挂载） |
 
 > 关联 KIP：KIP-3（sandbox matrix）、KIP-8（skill-cli 取代 MCP）、KIP-14（mTLS 动态证书）、KIP-16（沙箱架构教训 / catalog）、KIP-17（CLI 多 profile 与 API key TTL）、KIP-18（E2B 兼容）、**KIP-19（sandbox PTY 终端原语——本 KIP Phase 2 的 `spawnTerminal` 依赖它先行）**。
 > 关联仓库：`deepseek-harness`（下称 **dsh**）——插件化 agent harness，vendored Cordis，“everything is a plugin”。
@@ -13,8 +13,7 @@
   所有者服务（owner）、CLI/gRPC 双传输 client、fs / subprocess provider（流式 stdio 与
   `spawnTerminal`，后者依赖 KIP-19）、host-ui / client-ui、bundle。加载方式：
   `dsh plugin --profile <name> add @k8e-sandbox/dsh-k8e-sandbox-bundle`。
-- **未实现（可选）**：模型面工具包 `dsh-k8e-sandbox-tool`（KIP-16 catalog 驱动的
-  session/snapshot/ps 模型工具）。
+- **未实现（可选）**：模型面工具的 snapshot/pause/resume/ps/confirm 子集（当前工具包提供 session 状态/销毁、前台 exec、后台 exec + poll；其余依赖 CLI 命令面扩展）。
 - **已知限制**：`@deepseek-ai/dsh-*` 系列为私有包（公共 npm 不可用），运行时由 dsh 安装提供 peer 依赖。
 
 ## 摘要

--- a/pkg/sandbox/e2b/envd.go
+++ b/pkg/sandbox/e2b/envd.go
@@ -1,7 +1,9 @@
 package e2b
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -55,9 +57,11 @@ func (s *Server) handleProcessStart(w http.ResponseWriter, r *http.Request) {
 	envs, _ := proc["envs"].(map[string]any)
 	cwd, _ := proc["cwd"].(string)
 
-	// A pty block makes this a terminal session — K8E has no PTY support.
-	if _, hasPty := body["pty"]; hasPty {
-		writeEnvdStreamError(w, connectError("invalid_argument", "PTY sessions are not supported"))
+	// A pty block makes this a terminal session (E2B SDK pty.create): the
+	// process runs as a controlling-terminal session leader via the KIP-19
+	// PTY primitive instead of the pipe-based exec path.
+	if ptyBlock, hasPty := body["pty"].(map[string]any); hasPty {
+		s.runPtyStart(w, r, sandboxIDOf(r), proc, ptyBlock)
 		return
 	}
 	// Without a pty, the SDK always sends /bin/bash [-l] -c <command>;
@@ -108,9 +112,7 @@ func (s *Server) handleProcessStart(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 	_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/connect+json\r\n\r\n")
 
-	writeEnvelopeRaw(buf, envelope(FlagMessage, map[string]any{
-		"event": map[string]any{"start": map[string]int{"pid": rec.PID}},
-	}))
+	writeStreamStartFrame(buf, rec.PID)
 
 	sub := &streamSubscriber{pid: rec.PID, w: buf}
 	if !s.processes.Subscribe(rec.PID, sub) {
@@ -140,6 +142,136 @@ func (s *Server) handleProcessStart(w http.ResponseWriter, r *http.Request) {
 		},
 	}))
 	writeEnvelopeRaw(buf, envelope(FlagEndStream, map[string]any{}))
+}
+
+// runPtyStart implements the E2B pty.create path (KIP-19 M4): it creates a
+// PTY terminal via the gateway, streams output frames back over the Connect
+// stream, and registers the pid -> terminal_id bridge so SendInput / Update /
+// SendSignal / Connect address the terminal by the SDK-facing pid.
+func (s *Server) runPtyStart(w http.ResponseWriter, r *http.Request, sandboxID string, proc, ptyBlock map[string]any) {
+	if sandboxID == "" {
+		writeEnvdStreamError(w, connectError("unauthenticated", "missing E2b-Sandbox-Id header"))
+		return
+	}
+	// Auto-resume a paused sandbox before the terminal lands.
+	if _, _, e2e := s.wakeForTraffic(r, sandboxID); e2e != nil {
+		writeEnvdStreamError(w, e2e)
+		return
+	}
+
+	cmd, _ := proc["cmd"].(string)
+	args := stringSlice(proc["args"])
+	envs, _ := proc["envs"].(map[string]any)
+	cwd, _ := proc["cwd"].(string)
+	argv := append([]string{cmd}, args...)
+	if len(argv) == 0 || argv[0] == "" {
+		writeEnvdStreamError(w, connectError("invalid_argument", "missing process cmd"))
+		return
+	}
+
+	// pty: { size: { rows, cols } } (E2B SDK pty.create). Defaults 24x80.
+	rows, cols := ptyWindowSize(ptyBlock)
+
+	resp, err := s.gw.CreateTerminal(r.Context(), &pb.CreateTerminalRequest{
+		SessionId: sandboxID,
+		Argv:      argv,
+		Workdir:   cwd,
+		Env:       toStringMap(envs),
+		Rows:      rows,
+		Cols:      cols,
+	})
+	if err != nil {
+		writeEnvdStreamError(w, connectError("internal", "create terminal failed: "+err.Error()))
+		return
+	}
+	terminalID := resp.TerminalId
+
+	// Register the process (SDK pid addressing) and the pid -> terminal_id
+	// bridge. The E2B-facing pid is the table pid; the in-sandbox session
+	// leader is resp.Pid (what List/Connect expose for process management).
+	cfg := ProcessConfig{Cmd: cmd, Args: args, Envs: toStringMap(envs), Cwd: cwd, Pty: true}
+	rec := s.processes.Start(sandboxID, cfg)
+	s.processes.SetGuestPID(rec.PID, int(resp.Pid))
+	s.registerPty(&ptyRow{terminalID: terminalID, sandboxID: sandboxID, pid: rec.PID, rows: rows, cols: cols})
+
+	// Stream the terminal: start frame, subscriber broadcast (keepalive-
+	// aware so pty.connect can reattach), terminal frames, end frame.
+	exitCode := s.streamTerminalOverHTTP(w, r, rec.PID, func(buf *bufio.ReadWriter) int32 {
+		sub := &streamSubscriber{pid: rec.PID, w: buf}
+		if !s.processes.Subscribe(rec.PID, sub) {
+			return -1
+		}
+		defer s.processes.Unsubscribe(rec.PID, sub)
+		ksub, stopKeepalive := newKeepaliveSubscriber(sub, buf)
+		s.processes.ReplaceSubscriber(rec.PID, sub, ksub)
+		defer stopKeepalive()
+		return s.drainTerminalStream(r.Context(), terminalID, func(data []byte) {
+			s.processes.Broadcast(rec.PID, ChannelStdout, data)
+		})
+	})
+	s.processes.End(rec.PID, ProcessEnd{ExitCode: int(exitCode)})
+	s.dropPty(rec.PID)
+}
+
+// streamTerminalOverHTTP hijacks the response, writes the start frame, runs
+// the stream callback (which drains the TerminalStream and returns the exit
+// code) and writes the end frame. The shared response shape of pty.create
+// and pty.connect.
+func (s *Server) streamTerminalOverHTTP(w http.ResponseWriter, r *http.Request, pid int, run func(*bufio.ReadWriter) int32) int32 {
+	hijack, ok := w.(http.Hijacker)
+	if !ok {
+		return -1
+	}
+	conn, buf, err := hijack.Hijack()
+	if err != nil {
+		return -1
+	}
+	defer conn.Close()
+	_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/connect+json\r\n\r\n")
+	writeStreamStartFrame(buf, pid)
+	exitCode := run(buf)
+	writeStreamEndFrame(buf, exitCode)
+	return exitCode
+}
+
+// drainTerminalStream reads a TerminalStream until exit, invoking onData for
+// every output frame, and returns the exit code (-1 when the stream cut or
+// could not be opened).
+func (s *Server) drainTerminalStream(ctx context.Context, terminalID string, onData func([]byte)) int32 {
+	stream, err := s.gw.TerminalStream(ctx, &pb.TerminalStreamRequest{TerminalId: terminalID})
+	if err != nil {
+		return -1
+	}
+	exitCode := int32(-1)
+	for {
+		frame, recvErr := stream.Recv()
+		if recvErr != nil {
+			break
+		}
+		if data := frame.GetData(); len(data) > 0 {
+			onData(data)
+		}
+		if exit := frame.GetExit(); exit != nil {
+			exitCode = exit.ExitCode
+			break
+		}
+	}
+	return exitCode
+}
+
+// runPtyStream re-opens a TerminalStream for a living PTY and streams its
+// frames to a hijacked Connect response (used by pty.connect reconnects).
+func (s *Server) runPtyStream(w http.ResponseWriter, r *http.Request, sandboxID string, pid int) {
+	row, ok := s.ptyFor(pid)
+	if !ok {
+		writeEnvdStreamError(w, connectError("not_found", fmt.Sprintf("process not found: %d", pid)))
+		return
+	}
+	s.streamTerminalOverHTTP(w, r, pid, func(buf *bufio.ReadWriter) int32 {
+		return s.drainTerminalStream(r.Context(), row.terminalID, func(data []byte) {
+			writeStreamDataFrame(buf, ChannelStdout, data)
+		})
+	})
 }
 
 // runProcessStream executes the command via ExecStream, stripping sandboxd
@@ -246,14 +378,30 @@ func (s *Server) handleProcessConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	proc, _ := body["process"].(map[string]any)
-	pidFloat, ok := proc["pid"].(float64)
-	if !ok {
+	// Accept both the flat pid shape and the SDK selector shape
+	// ({selector: {case: "pid", value: N}}).
+	var pid int
+	if f, ok := proc["pid"].(float64); ok {
+		pid = int(f)
+	} else if sel, ok := proc["selector"].(map[string]any); ok {
+		if f, ok := sel["value"].(float64); ok {
+			pid = int(f)
+		}
+	}
+	if pid == 0 {
 		writeEnvdStreamError(w, connectError("invalid_argument", "missing process pid"))
 		return
 	}
-	pid := int(pidFloat)
 	sandboxID := sandboxIDOf(r)
 	rec := s.processes.Get(sandboxID, pid)
+
+	// PTY reconnect: pull a fresh TerminalStream (the sandboxd side replays
+	// the ring buffer) instead of subscribing to the (possibly gone) Start
+	// broadcast.
+	if rec != nil && rec.Config.Pty {
+		s.runPtyStream(w, r, sandboxID, pid)
+		return
+	}
 
 	// Cross-node Connect: the process's Start stream may have been served by
 	// a different control-plane node, so this node's local process table has
@@ -276,9 +424,7 @@ func (s *Server) handleProcessConnect(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 	_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: application/connect+json\r\n\r\n")
 
-	writeEnvelopeRaw(buf, envelope(FlagMessage, map[string]any{
-		"event": map[string]any{"start": map[string]int{"pid": pid}},
-	}))
+	writeStreamStartFrame(buf, pid)
 
 	sub := &streamSubscriber{pid: pid, w: buf}
 	if !s.processes.Subscribe(pid, sub) {
@@ -363,36 +509,47 @@ func (s *Server) requireGuestPID(sandboxID string, pid int) (int, *E2bError) {
 // handleProcessSendInput implements process.Process/SendInput: write stdin
 // to the running process via sandboxd's /exec/stdin.
 func (s *Server) handleProcessSendInput(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Process struct {
-			PID int `json:"pid"`
-		} `json:"process"`
-		Input struct {
-			Stdin string `json:"stdin"`
-		} `json:"input"`
+	// The official SDK sends the selector shape
+	//   {process: {selector: {case: "pid", value: N}}, input: {input: {case: "pty", value: <b64>}}}
+	// (KIP-18 earlier clients used {process: {pid}, input: {stdin}}). Accept both.
+	body, ok := s.readUnaryBody(w, r)
+	if !ok {
+		return
 	}
-	_ = json.NewDecoder(r.Body).Decode(&body)
-	if body.Process.PID == 0 {
+	pid := pidFromBody(body)
+	if pid == 0 {
 		s.writeEnvdError(w, connectError("invalid_argument", "missing process pid"))
 		return
 	}
+	data := inputData(body)
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		s.writeEnvdError(w, connectError("invalid_argument", "invalid base64 input"))
+		return
+	}
+
+	// PTY sessions route input to the terminal (KIP-19 M4); everything else
+	// goes through sandboxd's stdin pipe.
+	if row, isPty := s.ptyFor(pid); isPty {
+		if _, err := s.gw.TerminalWrite(r.Context(), &pb.TerminalWriteRequest{TerminalId: row.terminalID, Data: decoded}); err != nil {
+			s.writeEnvdError(w, connectError("internal", "terminal write failed: "+err.Error()))
+			return
+		}
+		writeJSONOK(w)
+		return
+	}
+
 	sandboxID := sandboxIDOf(r)
-	guestPID, e2e := s.requireGuestPID(sandboxID, body.Process.PID)
+	guestPID, e2e := s.requireGuestPID(sandboxID, pid)
 	if e2e != nil {
 		s.writeEnvdError(w, e2e)
 		return
 	}
-	data, err := base64.StdEncoding.DecodeString(body.Input.Stdin)
-	if err != nil {
-		s.writeEnvdError(w, connectError("invalid_argument", "invalid base64 stdin"))
-		return
-	}
-	if err := s.sandboxd.sendStdin(r.Context(), sandboxID, guestPID, data); err != nil {
+	if err := s.sandboxd.sendStdin(r.Context(), sandboxID, guestPID, decoded); err != nil {
 		s.writeEnvdError(w, connectError("internal", "send stdin failed: "+err.Error()))
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte("{}"))
+	writeJSONOK(w)
 }
 
 // handleProcessCloseStdin implements process.Process/CloseStdin: EOF.
@@ -424,49 +581,149 @@ func (s *Server) handleProcessCloseStdin(w http.ResponseWriter, r *http.Request)
 // handleProcessSendSignal implements process.Process/SendSignal: SIGKILL /
 // SIGTERM via sandboxd's /exec/signal.
 func (s *Server) handleProcessSendSignal(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Process struct {
-			PID int `json:"pid"`
-		} `json:"process"`
-		Signal string `json:"signal"`
+	// Accept both the SDK selector shape ({process: {selector: {case: "pid",
+	// value: N}}, signal: 9}) and the earlier flat shape ({process: {pid},
+	// signal: "SIGKILL"}).
+	body, ok := s.readUnaryBody(w, r)
+	if !ok {
+		return
 	}
-	_ = json.NewDecoder(r.Body).Decode(&body)
-	if body.Process.PID == 0 {
+	pid := pidFromBody(body)
+	if pid == 0 {
 		s.writeEnvdError(w, connectError("invalid_argument", "missing process pid"))
 		return
 	}
-	sig := ""
-	switch body.Signal {
-	case "SIGNAL_SIGKILL", "SIGKILL", "9":
-		sig = "SIGKILL"
-	case "SIGNAL_SIGTERM", "SIGTERM", "15":
-		sig = "SIGTERM"
-	default:
-		s.writeEnvdError(w, connectError("invalid_argument",
-			"unsupported signal: only SIGKILL and SIGTERM are supported"))
-		return
+	var signal struct {
+		Signal json.RawMessage `json:"signal"`
 	}
-	sandboxID := sandboxIDOf(r)
-	guestPID, e2e := s.requireGuestPID(sandboxID, body.Process.PID)
+	_ = json.Unmarshal(body, &signal)
+	sig, e2e := parseSignal(signal.Signal)
 	if e2e != nil {
 		s.writeEnvdError(w, e2e)
 		return
 	}
-	if err := s.sandboxd.signal(r.Context(), sandboxID, guestPID, sig); err != nil {
+
+	// PTY sessions signal the terminal session (KIP-19 M4); pty.kill uses
+	// SIGKILL (9) against the whole session tree.
+	if row, isPty := s.ptyFor(pid); isPty {
+		if _, err := s.gw.TerminalSignal(r.Context(), &pb.TerminalSignalRequest{TerminalId: row.terminalID, Signal: sig}); err != nil {
+			s.writeEnvdError(w, connectError("internal", "terminal signal failed: "+err.Error()))
+			return
+		}
+		writeJSONOK(w)
+		return
+	}
+
+	sandboxID := sandboxIDOf(r)
+	// The pipe-based /exec/signal path supports KILL/TERM only; SIGINT is
+	// reserved for PTY sessions (the controlling-terminal signal path).
+	if sig == pb.TerminalSignal_TERMINAL_SIGNAL_INT {
+		s.writeEnvdError(w, connectError("invalid_argument", "unsupported signal: SIGINT requires a PTY session"))
+		return
+	}
+	guestPID, e2e := s.requireGuestPID(sandboxID, pid)
+	if e2e != nil {
+		s.writeEnvdError(w, e2e)
+		return
+	}
+	if err := s.sandboxd.signal(r.Context(), sandboxID, guestPID, sigName(sig)); err != nil {
 		if errors.Is(err, errNotFound) {
-			s.writeEnvdError(w, connectError("not_found", fmt.Sprintf("process not found: %d", body.Process.PID)))
+			s.writeEnvdError(w, connectError("not_found", fmt.Sprintf("process not found: %d", pid)))
 			return
 		}
 		s.writeEnvdError(w, connectError("internal", "signal failed: "+err.Error()))
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte("{}"))
+	writeJSONOK(w)
+}
+
+// parseSignal accepts the string forms the envd layer spoke before
+// ("SIGKILL", "SIGTERM", "9") and the numeric JSON form the official SDK
+// sends (9 = SIGKILL, 15 = SIGTERM).
+func parseSignal(raw json.RawMessage) (pb.TerminalSignal, *E2bError) {
+	if len(raw) == 0 {
+		return 0, connectError("invalid_argument", "missing signal")
+	}
+	if raw[0] == '"' {
+		switch strings.Trim(string(raw), "\"") {
+		case "SIGNAL_SIGKILL", "SIGKILL", "9":
+			return pb.TerminalSignal_TERMINAL_SIGNAL_KILL, nil
+		case "SIGNAL_SIGTERM", "SIGTERM", "15":
+			return pb.TerminalSignal_TERMINAL_SIGNAL_TERM, nil
+		case "SIGNAL_SIGINT", "SIGINT", "2":
+			return pb.TerminalSignal_TERMINAL_SIGNAL_INT, nil
+		default:
+			return 0, connectError("invalid_argument", "unsupported signal")
+		}
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0, connectError("invalid_argument", "invalid signal")
+	}
+	switch n {
+	case 9:
+		return pb.TerminalSignal_TERMINAL_SIGNAL_KILL, nil
+	case 15:
+		return pb.TerminalSignal_TERMINAL_SIGNAL_TERM, nil
+	case 2:
+		return pb.TerminalSignal_TERMINAL_SIGNAL_INT, nil
+	default:
+		return 0, connectError("invalid_argument", fmt.Sprintf("unsupported signal: %d", n))
+	}
+}
+
+// sigName maps a pb.TerminalSignal back to the sandboxd signal string used
+// by the pipe-based /exec/signal path.
+func sigName(sig pb.TerminalSignal) string {
+	switch sig {
+	case pb.TerminalSignal_TERMINAL_SIGNAL_KILL:
+		return "SIGKILL"
+	case pb.TerminalSignal_TERMINAL_SIGNAL_TERM:
+		return "SIGTERM"
+	case pb.TerminalSignal_TERMINAL_SIGNAL_INT:
+		return "SIGINT"
+	default:
+		return "SIGTERM"
+	}
+}
+
+// handleProcessUpdate implements process.Process/Update — the SDK's pty
+// resize path ({process: {selector: {case: "pid", value: N}}, pty: {size:
+// {cols, rows}}}). Only meaningful for PTY sessions (KIP-19 M4); pipe-based
+// processes have no window size.
+func (s *Server) handleProcessUpdate(w http.ResponseWriter, r *http.Request) {
+	// The SDK's pty resize path: {process: {selector: {case: "pid", value:
+	// N}}, pty: {size: {cols, rows}}}.
+	body, ok := s.readUnaryBody(w, r)
+	if !ok {
+		return
+	}
+	pid := pidFromBody(body)
+	if pid == 0 {
+		s.writeEnvdError(w, connectError("invalid_argument", "missing process pid"))
+		return
+	}
+	row, isPty := s.ptyFor(pid)
+	if !isPty {
+		s.writeEnvdError(w, connectError("invalid_argument", "resize requires a PTY session"))
+		return
+	}
+	rows, cols := resizeSize(body)
+	if rows < 1 || cols < 1 {
+		s.writeEnvdError(w, connectError("invalid_argument", "invalid window size"))
+		return
+	}
+	if _, err := s.gw.TerminalResize(r.Context(), &pb.TerminalResizeRequest{TerminalId: row.terminalID, Rows: rows, Cols: cols}); err != nil {
+		s.writeEnvdError(w, connectError("internal", "terminal resize failed: "+err.Error()))
+		return
+	}
+	row.rows, row.cols = rows, cols
+	writeJSONOK(w)
 }
 
 // handleUnimplementedProcess answers a Connect RPC with the honest
-// unimplemented code and a hint (PTY resize / streamed stdin remain unsupported:
-// sandboxd has no PTY and the SDK sends stdin via SendInput).
+// unimplemented code and a hint (streamed stdin remains unsupported: the SDK
+// sends stdin via SendInput; Update/UpdatePTY are PTY-only now implemented).
 func (s *Server) handleUnimplementedProcess(name string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		s.writeEnvdError(w, connectError("unimplemented", name+" is not supported"))
@@ -756,6 +1013,118 @@ func (s *Server) handleFSRemove(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("{}"))
 }
 
+// asMap decodes a JSON object body into a plain map (nil-safe).
+func asMap(body []byte) map[string]any {
+	var v map[string]any
+	_ = json.Unmarshal(body, &v)
+	return v
+}
+
+// pidFromBody extracts the SDK-facing pid from either the flat
+// {process: {pid}} shape or the selector {process: {selector: {case: "pid",
+// value: N}}} shape the official SDK sends.
+func pidFromBody(body []byte) int {
+	proc, _ := asMap(body)["process"].(map[string]any)
+	if f, ok := proc["pid"].(float64); ok && int(f) != 0 {
+		return int(f)
+	}
+	if sel, ok := proc["selector"].(map[string]any); ok {
+		if f, ok := sel["value"].(float64); ok {
+			return int(f)
+		}
+	}
+	return 0
+}
+
+// inputData extracts the base64 input payload from a SendInput body: the
+// SDK selector shape {input: {input: {case: "pty", value}}} or the earlier
+// flat {input: {stdin}} shape.
+func inputData(body []byte) string {
+	input, _ := asMap(body)["input"].(map[string]any)
+	if s, ok := input["stdin"].(string); ok && s != "" {
+		return s
+	}
+	if inner, ok := input["input"].(map[string]any); ok {
+		if s, ok := inner["value"].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// resizeSize extracts rows/cols from an Update (pty resize) body's
+// {pty: {size: {cols, rows}}} object.
+func resizeSize(body []byte) (rows, cols int32) {
+	pty, _ := asMap(body)["pty"].(map[string]any)
+	size, _ := pty["size"].(map[string]any)
+	if f, ok := size["rows"].(float64); ok {
+		rows = int32(f)
+	}
+	if f, ok := size["cols"].(float64); ok {
+		cols = int32(f)
+	}
+	return rows, cols
+}
+
+// writeJSONOK answers a unary envd RPC with an empty 200 JSON body.
+func writeJSONOK(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte("{}"))
+}
+
+// ptyWindowSize extracts rows/cols from the pty block's size object,
+// defaulting to 24x80 when absent or invalid.
+func ptyWindowSize(ptyBlock map[string]any) (rows, cols int32) {
+	rows, cols = 24, 80
+	if size, ok := ptyBlock["size"].(map[string]any); ok {
+		if v, ok := size["rows"].(float64); ok && v > 0 {
+			rows = int32(v)
+		}
+		if v, ok := size["cols"].(float64); ok && v > 0 {
+			cols = int32(v)
+		}
+	}
+	return rows, cols
+}
+
+// writeStreamDataFrame writes one envelope data frame (base64 stdout).
+func writeStreamDataFrame(w io.Writer, channel OutputChannel, data []byte) {
+	writeEnvelopeRaw(w, envelope(FlagMessage, map[string]any{
+		"event": map[string]any{"data": map[string]string{string(channel): base64.StdEncoding.EncodeToString(data)}},
+	}))
+}
+
+// writeStreamStartFrame writes the start event frame (SDK-facing pid).
+func writeStreamStartFrame(w io.Writer, pid int) {
+	writeEnvelopeRaw(w, envelope(FlagMessage, map[string]any{
+		"event": map[string]any{"start": map[string]int{"pid": pid}},
+	}))
+}
+
+// writeStreamEndFrame writes the end event + end-stream frames.
+func writeStreamEndFrame(w io.Writer, exitCode int32) {
+	writeEnvelopeRaw(w, envelope(FlagMessage, map[string]any{
+		"event": map[string]any{
+			"end": map[string]any{
+				"exitCode": exitCode,
+				"exited":   true,
+				"status":   exitStatus(int(exitCode)),
+			},
+		},
+	}))
+	writeEnvelopeRaw(w, envelope(FlagEndStream, map[string]any{}))
+}
+
+// readUnaryBody reads a unary envd request body, answering 400 on failure.
+func (s *Server) readUnaryBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.writeEnvdError(w, connectError("invalid_argument", "read body failed"))
+		return nil, false
+	}
+	return body, true
+}
+
 // --- helpers --------------------------------------------------------------
 
 // streamSubscriber writes enveloped frames to a hijacked connection.
@@ -765,9 +1134,7 @@ type streamSubscriber struct {
 }
 
 func (ss *streamSubscriber) OnOutput(channel OutputChannel, data []byte) {
-	writeEnvelopeRaw(ss.w, envelope(FlagMessage, map[string]any{
-		"event": map[string]any{"data": map[string]string{string(channel): base64.StdEncoding.EncodeToString(data)}},
-	}))
+	writeStreamDataFrame(ss.w, channel, data)
 }
 
 func (ss *streamSubscriber) OnEnd(end ProcessEnd) {}
@@ -903,9 +1270,7 @@ func (s *Server) attachRemote(w http.ResponseWriter, r *http.Request, sandboxID 
 			pidSeen = true
 		}
 		if len(out) > 0 {
-			writeEnvelopeRaw(buf, envelope(FlagMessage, map[string]any{
-				"event": map[string]any{"data": map[string]any{"stdout": base64.StdEncoding.EncodeToString(out)}},
-			}))
+			writeStreamDataFrame(buf, ChannelStdout, out)
 		}
 	}
 

--- a/pkg/sandbox/e2b/envd.go
+++ b/pkg/sandbox/e2b/envd.go
@@ -209,6 +209,11 @@ func (s *Server) runPtyStart(w http.ResponseWriter, r *http.Request, sandboxID s
 			s.processes.Broadcast(rec.PID, ChannelStdout, data)
 		})
 	})
+	// Release the backend terminal on every completion and failure path
+	// (idempotent; a normally exited session finds an empty group set) so a
+	// stream error or abandoned pty.create cannot leak a bounded sandboxd
+	// terminal entry (Greptile security review).
+	s.destroyPty(r.Context(), terminalID)
 	s.processes.End(rec.PID, ProcessEnd{ExitCode: int(exitCode)})
 	s.dropPty(rec.PID)
 }
@@ -262,7 +267,7 @@ func (s *Server) drainTerminalStream(ctx context.Context, terminalID string, onD
 // runPtyStream re-opens a TerminalStream for a living PTY and streams its
 // frames to a hijacked Connect response (used by pty.connect reconnects).
 func (s *Server) runPtyStream(w http.ResponseWriter, r *http.Request, sandboxID string, pid int) {
-	row, ok := s.ptyFor(pid)
+	row, ok := s.ptyForSandbox(pid, sandboxID)
 	if !ok {
 		writeEnvdStreamError(w, connectError("not_found", fmt.Sprintf("process not found: %d", pid)))
 		return
@@ -529,8 +534,10 @@ func (s *Server) handleProcessSendInput(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// PTY sessions route input to the terminal (KIP-19 M4); everything else
-	// goes through sandboxd's stdin pipe.
-	if row, isPty := s.ptyFor(pid); isPty {
+	// goes through sandboxd's stdin pipe. The terminal must belong to the
+	// authenticated sandbox (Greptile security review).
+	sandboxID := sandboxIDOf(r)
+	if row, isPty := s.ptyForSandbox(pid, sandboxID); isPty {
 		if _, err := s.gw.TerminalWrite(r.Context(), &pb.TerminalWriteRequest{TerminalId: row.terminalID, Data: decoded}); err != nil {
 			s.writeEnvdError(w, connectError("internal", "terminal write failed: "+err.Error()))
 			return
@@ -539,7 +546,6 @@ func (s *Server) handleProcessSendInput(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	sandboxID := sandboxIDOf(r)
 	guestPID, e2e := s.requireGuestPID(sandboxID, pid)
 	if e2e != nil {
 		s.writeEnvdError(w, e2e)
@@ -604,8 +610,10 @@ func (s *Server) handleProcessSendSignal(w http.ResponseWriter, r *http.Request)
 	}
 
 	// PTY sessions signal the terminal session (KIP-19 M4); pty.kill uses
-	// SIGKILL (9) against the whole session tree.
-	if row, isPty := s.ptyFor(pid); isPty {
+	// SIGKILL (9) against the whole session tree. The terminal must belong to
+	// the authenticated sandbox (Greptile security review).
+	sandboxID := sandboxIDOf(r)
+	if row, isPty := s.ptyForSandbox(pid, sandboxID); isPty {
 		if _, err := s.gw.TerminalSignal(r.Context(), &pb.TerminalSignalRequest{TerminalId: row.terminalID, Signal: sig}); err != nil {
 			s.writeEnvdError(w, connectError("internal", "terminal signal failed: "+err.Error()))
 			return
@@ -614,7 +622,6 @@ func (s *Server) handleProcessSendSignal(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	sandboxID := sandboxIDOf(r)
 	// The pipe-based /exec/signal path supports KILL/TERM only; SIGINT is
 	// reserved for PTY sessions (the controlling-terminal signal path).
 	if sig == pb.TerminalSignal_TERMINAL_SIGNAL_INT {
@@ -703,9 +710,9 @@ func (s *Server) handleProcessUpdate(w http.ResponseWriter, r *http.Request) {
 		s.writeEnvdError(w, connectError("invalid_argument", "missing process pid"))
 		return
 	}
-	row, isPty := s.ptyFor(pid)
+	row, isPty := s.ptyForSandbox(pid, sandboxIDOf(r))
 	if !isPty {
-		s.writeEnvdError(w, connectError("invalid_argument", "resize requires a PTY session"))
+		s.writeEnvdError(w, connectError("invalid_argument", "resize requires a PTY session in this sandbox"))
 		return
 	}
 	rows, cols := resizeSize(body)

--- a/pkg/sandbox/e2b/envd_test.go
+++ b/pkg/sandbox/e2b/envd_test.go
@@ -206,7 +206,7 @@ func buildStartRequest(t *testing.T, ts *httptest.Server, s *Server, sandboxID, 
 	return req
 }
 
-func TestEnvdProcessStartRejectsPTY(t *testing.T) {
+func TestEnvdProcessStartWithPTY(t *testing.T) {
 	gw := newFakeGateway()
 	s, ts := testServer(t, gw)
 	id := createSandboxID(t, ts)
@@ -215,7 +215,7 @@ func TestEnvdProcessStartRejectsPTY(t *testing.T) {
 		"process": map[string]any{
 			"cmd":  "/bin/bash",
 			"args": []string{"-i", "-l"},
-			"envs": map[string]string{},
+			"envs": map[string]string{"TERM": "xterm-256color"},
 		},
 		"pty": map[string]any{"size": map[string]int{"cols": 80, "rows": 24}},
 	}
@@ -233,13 +233,88 @@ func TestEnvdProcessStartRejectsPTY(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(frames) != 1 {
-		t.Fatalf("expected single error frame, got %d", len(frames))
+	if len(frames) < 1 {
+		t.Fatalf("expected frames, got %d", len(frames))
 	}
-	errObj := frames[0].json["error"].(map[string]any)
-	if errObj["code"] != "invalid_argument" {
-		t.Fatalf("expected invalid_argument, got %v", errObj)
+
+	// First frame: start with the E2B-facing pid.
+	startPID := envelopeStartPID(t, frames[0])
+	if startPID == 0 {
+		t.Fatalf("pty start pid must be non-zero")
 	}
+
+	// The gateway received the terminal create with the right argv/size.
+	assertPtyCreateRequest(t, gw, id)
+
+	// Terminal streamed a data frame then exited.
+	if got := ptyStreamedData(t, frames); string(got) != "hello tty" {
+		t.Fatalf("pty streamed data = %q, want %q", got, "hello tty")
+	}
+	if !envelopeHasEvent(frames, "end") {
+		t.Fatalf("missing end frame")
+	}
+	// The pty row is dropped after the stream exits.
+	if _, ok := s.ptyFor(startPID); ok {
+		t.Fatalf("pty row must be dropped after exit")
+	}
+}
+
+// assertPtyCreateRequest checks the gateway received exactly one
+// CreateTerminal for the sandbox with the SDK's argv and window size.
+func assertPtyCreateRequest(t *testing.T, gw *fakeGateway, sandboxID string) {
+	t.Helper()
+	if len(gw.term.created) != 1 {
+		t.Fatalf("expected 1 CreateTerminal, got %d", len(gw.term.created))
+	}
+	cr := gw.term.created[0]
+	if cr.SessionId != sandboxID || len(cr.Argv) != 3 || cr.Argv[0] != "/bin/bash" {
+		t.Fatalf("unexpected CreateTerminalRequest: %+v", cr)
+	}
+	if cr.Rows != 24 || cr.Cols != 80 {
+		t.Fatalf("pty size = %dx%d, want 24x80", cr.Rows, cr.Cols)
+	}
+}
+
+// envelopeStartPID extracts the pid from a start event frame, or 0.
+func envelopeStartPID(t *testing.T, f frame) int {
+	t.Helper()
+	ev, ok := f.json["event"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	start, ok := ev["start"].(map[string]any)
+	if !ok {
+		return 0
+	}
+	return int(start["pid"].(float64))
+}
+
+// envelopeHasEvent reports whether any frame carries the named event.
+func envelopeHasEvent(frames []frame, event string) bool {
+	for _, f := range frames {
+		if ev, ok := f.json["event"].(map[string]any); ok {
+			if _, ok := ev[event]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ptyStreamedData concatenates base64 stdout data frames.
+func ptyStreamedData(t *testing.T, frames []frame) []byte {
+	t.Helper()
+	var got []byte
+	for _, f := range frames {
+		if ev, ok := f.json["event"].(map[string]any); ok {
+			if data, ok := ev["data"].(map[string]any); ok {
+				if b64, ok := data["stdout"].(string); ok {
+					got = append(got, mustB64Decode(t, b64)...)
+				}
+			}
+		}
+	}
+	return got
 }
 
 func TestEnvdProcessStartUnknownShape(t *testing.T) {
@@ -291,15 +366,14 @@ func TestUnimplementedSurfaces(t *testing.T) {
 	s, ts := testServer(t, gw)
 	id := createSandboxID(t, ts)
 
-	// SendSignal/SendInput/CloseStdin and the polling watch trio
-	// (CreateWatcher/GetWatcherEvents/RemoveWatcher) are now implemented;
-	// the streaming WatchDir, PTY resize, and streamed stdin stay 501.
+	// SendSignal/SendInput/CloseStdin, PTY Update (resize), and the polling
+	// watch trio (CreateWatcher/GetWatcherEvents/RemoveWatcher) are now
+	// implemented; the streaming WatchDir and streamed stdin stay 501.
 	cases := []struct {
 		path string
 		body string
 	}{
 		{"/filesystem.Filesystem/WatchDir", `{}`},
-		{"/process.Process/Update", `{}`},
 		{"/process.Process/StreamInput", `{}`},
 	}
 	for _, c := range cases {

--- a/pkg/sandbox/e2b/fake_test.go
+++ b/pkg/sandbox/e2b/fake_test.go
@@ -3,6 +3,7 @@ package e2b
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -34,6 +35,13 @@ type fakeGateway struct {
 	getErrs map[string]error
 	paused  []string
 	resumed []string
+
+	// term records KIP-19 terminal RPCs for pty.* compat tests.
+	term *terminalRows
+	// hangTerminals makes unseeded TerminalStream calls hang forever (no
+	// frames) so a pty.create stays alive across sendInput/resize/kill
+	// tests, mirroring a long-running bash session.
+	hangTerminals bool
 }
 
 func newFakeGateway() *fakeGateway {
@@ -187,6 +195,112 @@ func (f *fakeGateway) ListFiles(ctx context.Context, req *pb.ListFilesRequest) (
 		out = append(out, &pb.FileEntry{Path: path, Modified: 0})
 	}
 	return &pb.ListFilesResponse{Files: out}, nil
+}
+
+// --- KIP-19 terminal primitive fakes ---------------------------------------
+
+// terminalRows records terminal RPCs for pty.* compat tests.
+type terminalRows struct {
+	created   []*pb.CreateTerminalRequest
+	writes    []*pb.TerminalWriteRequest
+	resizes   []*pb.TerminalResizeRequest
+	signals   []*pb.TerminalSignalRequest
+	destroyed []string
+	streams   map[string][]*pb.TerminalStreamResponse
+}
+
+func (f *fakeGateway) CreateTerminal(ctx context.Context, req *pb.CreateTerminalRequest) (*pb.CreateTerminalResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.term == nil {
+		f.term = &terminalRows{streams: map[string][]*pb.TerminalStreamResponse{}}
+	}
+	id := req.SessionId + "/t" + strconv.Itoa(len(f.term.created)+1)
+	f.term.created = append(f.term.created, req)
+	return &pb.CreateTerminalResponse{TerminalId: id, Pid: int32(5000 + len(f.term.created))}, nil
+}
+
+func (f *fakeGateway) TerminalStream(ctx context.Context, req *pb.TerminalStreamRequest) (TerminalStreamReader, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.term == nil {
+		return nil, errors.New("no terminal")
+	}
+	chunks := f.term.streams[req.TerminalId]
+	if len(chunks) == 0 && f.hangTerminals {
+		return &hangingTermStream{}, nil
+	}
+	// Default frames when a test did not seed a stream: one output chunk
+	// then a clean exit, so pty.create/connect paths have a deterministic
+	// stream to drain.
+	if len(chunks) == 0 {
+		chunks = []*pb.TerminalStreamResponse{
+			{Frame: &pb.TerminalStreamResponse_Data{Data: []byte("hello tty")}},
+			{Frame: &pb.TerminalStreamResponse_Exit{Exit: &pb.TerminalExit{ExitCode: 0}}},
+		}
+	}
+	return &fakeTermStream{chunks: chunks}, nil
+}
+
+// hangingTermStream blocks forever — a terminal whose process is still
+// running (no exit frame yet).
+type hangingTermStream struct{}
+
+func (h *hangingTermStream) Recv() (*pb.TerminalStreamResponse, error) {
+	<-make(chan struct{})
+	return nil, nil
+}
+
+func (f *fakeGateway) TerminalWrite(ctx context.Context, req *pb.TerminalWriteRequest) (*pb.TerminalWriteResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.term == nil {
+		return nil, errors.New("no terminal")
+	}
+	f.term.writes = append(f.term.writes, req)
+	return &pb.TerminalWriteResponse{Ok: true}, nil
+}
+
+func (f *fakeGateway) TerminalResize(ctx context.Context, req *pb.TerminalResizeRequest) (*pb.TerminalResizeResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.term == nil {
+		return nil, errors.New("no terminal")
+	}
+	f.term.resizes = append(f.term.resizes, req)
+	return &pb.TerminalResizeResponse{Ok: true}, nil
+}
+
+func (f *fakeGateway) TerminalSignal(ctx context.Context, req *pb.TerminalSignalRequest) (*pb.TerminalSignalResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.term == nil {
+		return nil, errors.New("no terminal")
+	}
+	f.term.signals = append(f.term.signals, req)
+	return &pb.TerminalSignalResponse{ProcessGroupId: 1}, nil
+}
+
+func (f *fakeGateway) TerminalDestroy(ctx context.Context, req *pb.TerminalDestroyRequest) (*pb.TerminalDestroyResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.term.destroyed = append(f.term.destroyed, req.TerminalId)
+	return &pb.TerminalDestroyResponse{Ok: true}, nil
+}
+
+// fakeTermStream yields canned terminal frames then EOF.
+type fakeTermStream struct {
+	chunks []*pb.TerminalStreamResponse
+	i      int
+}
+
+func (f *fakeTermStream) Recv() (*pb.TerminalStreamResponse, error) {
+	if f.i >= len(f.chunks) {
+		return nil, errors.New("EOF")
+	}
+	c := f.chunks[f.i]
+	f.i++
+	return c, nil
 }
 
 // fakeStream yields canned chunks then EOF.

--- a/pkg/sandbox/e2b/gateway.go
+++ b/pkg/sandbox/e2b/gateway.go
@@ -19,6 +19,12 @@ type ExecStreamReader interface {
 	Recv() (*pb.ExecStreamResponse, error)
 }
 
+// TerminalStreamReader is the subset of the gRPC server-streaming client for
+// TerminalStream: Recv returns the next terminal frame (data or exit).
+type TerminalStreamReader interface {
+	Recv() (*pb.TerminalStreamResponse, error)
+}
+
 // Gateway is the k8e backend contract the E2B layer translates to: the
 // sandbox gRPC gateway. A narrow subset of pb.SandboxServiceClient so tests
 // can fake it with a small stub.
@@ -34,6 +40,13 @@ type Gateway interface {
 	ListFiles(ctx context.Context, req *pb.ListFilesRequest) (*pb.ListFilesResponse, error)
 	PauseSession(ctx context.Context, req *pb.PauseSessionRequest) (*pb.PauseSessionResponse, error)
 	ResumeSession(ctx context.Context, req *pb.ResumeSessionRequest) (*pb.ResumeSessionResponse, error)
+	// KIP-19 PTY terminal primitive surface (closed by the E2B pty.* compat).
+	CreateTerminal(ctx context.Context, req *pb.CreateTerminalRequest) (*pb.CreateTerminalResponse, error)
+	TerminalStream(ctx context.Context, req *pb.TerminalStreamRequest) (TerminalStreamReader, error)
+	TerminalWrite(ctx context.Context, req *pb.TerminalWriteRequest) (*pb.TerminalWriteResponse, error)
+	TerminalResize(ctx context.Context, req *pb.TerminalResizeRequest) (*pb.TerminalResizeResponse, error)
+	TerminalSignal(ctx context.Context, req *pb.TerminalSignalRequest) (*pb.TerminalSignalResponse, error)
+	TerminalDestroy(ctx context.Context, req *pb.TerminalDestroyRequest) (*pb.TerminalDestroyResponse, error)
 }
 
 // grpcGateway adapts the real k8e gRPC client to the Gateway contract.
@@ -83,6 +96,30 @@ func (g *grpcGateway) PauseSession(ctx context.Context, req *pb.PauseSessionRequ
 
 func (g *grpcGateway) ResumeSession(ctx context.Context, req *pb.ResumeSessionRequest) (*pb.ResumeSessionResponse, error) {
 	return g.client.SandboxServiceClient.ResumeSession(ctx, req)
+}
+
+func (g *grpcGateway) CreateTerminal(ctx context.Context, req *pb.CreateTerminalRequest) (*pb.CreateTerminalResponse, error) {
+	return g.client.SandboxServiceClient.CreateTerminal(ctx, req)
+}
+
+func (g *grpcGateway) TerminalStream(ctx context.Context, req *pb.TerminalStreamRequest) (TerminalStreamReader, error) {
+	return g.client.SandboxServiceClient.TerminalStream(ctx, req)
+}
+
+func (g *grpcGateway) TerminalWrite(ctx context.Context, req *pb.TerminalWriteRequest) (*pb.TerminalWriteResponse, error) {
+	return g.client.SandboxServiceClient.TerminalWrite(ctx, req)
+}
+
+func (g *grpcGateway) TerminalResize(ctx context.Context, req *pb.TerminalResizeRequest) (*pb.TerminalResizeResponse, error) {
+	return g.client.SandboxServiceClient.TerminalResize(ctx, req)
+}
+
+func (g *grpcGateway) TerminalSignal(ctx context.Context, req *pb.TerminalSignalRequest) (*pb.TerminalSignalResponse, error) {
+	return g.client.SandboxServiceClient.TerminalSignal(ctx, req)
+}
+
+func (g *grpcGateway) TerminalDestroy(ctx context.Context, req *pb.TerminalDestroyRequest) (*pb.TerminalDestroyResponse, error) {
+	return g.client.SandboxServiceClient.TerminalDestroy(ctx, req)
 }
 
 // --- session views --------------------------------------------------------

--- a/pkg/sandbox/e2b/process.go
+++ b/pkg/sandbox/e2b/process.go
@@ -28,6 +28,9 @@ type ProcessConfig struct {
 	Args []string
 	Envs map[string]string
 	Cwd  string
+	// Pty marks a KIP-19 terminal session (E2B pty.create). Such processes
+	// are addressed via the pid -> terminal_id bridge in Server.ptys.
+	Pty bool
 }
 
 // OutputChannel is one of the two wire channels a subscriber may receive.

--- a/pkg/sandbox/e2b/pty.go
+++ b/pkg/sandbox/e2b/pty.go
@@ -1,0 +1,44 @@
+package e2b
+
+// ptyRow is the compat layer's pid -> terminal_id bridge (KIP-19 M4). The
+// E2B SDK addresses pty handles by the session-leader pid returned from
+// pty.create; the k8e gateway only speaks canonical terminal_id, so the
+// create path records the association here and every later pty RPC
+// (SendInput / Update / SendSignal / Connect / kill) resolves through it.
+type ptyRow struct {
+	terminalID string
+	sandboxID  string
+	// pid is the E2B-facing session-leader pid echoed to the SDK.
+	pid int
+	// rows/cols is the latest known window size (resize target).
+	rows int32
+	cols int32
+}
+
+// registerPty records the pid -> terminal association for a pty.create.
+func (s *Server) registerPty(row *ptyRow) {
+	s.ptysMu.Lock()
+	defer s.ptysMu.Unlock()
+	s.ptys[row.pid] = row
+}
+
+// ptyFor resolves an E2B-facing pid to its terminal row, if it is a PTY
+// session created through this compat layer.
+func (s *Server) ptyFor(pid int) (*ptyRow, bool) {
+	s.ptysMu.Lock()
+	defer s.ptysMu.Unlock()
+	row, ok := s.ptys[pid]
+	return row, ok
+}
+
+// dropPty removes the pid -> terminal association (terminal exit or
+// destroy). Returns the row that was removed, if any.
+func (s *Server) dropPty(pid int) (*ptyRow, bool) {
+	s.ptysMu.Lock()
+	defer s.ptysMu.Unlock()
+	row, ok := s.ptys[pid]
+	if ok {
+		delete(s.ptys, pid)
+	}
+	return row, ok
+}

--- a/pkg/sandbox/e2b/pty.go
+++ b/pkg/sandbox/e2b/pty.go
@@ -1,5 +1,11 @@
 package e2b
 
+import (
+	"context"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+)
+
 // ptyRow is the compat layer's pid -> terminal_id bridge (KIP-19 M4). The
 // E2B SDK addresses pty handles by the session-leader pid returned from
 // pty.create; the k8e gateway only speaks canonical terminal_id, so the
@@ -29,6 +35,29 @@ func (s *Server) ptyFor(pid int) (*ptyRow, bool) {
 	defer s.ptysMu.Unlock()
 	row, ok := s.ptys[pid]
 	return row, ok
+}
+
+// ptyForSandbox resolves an E2B-facing pid to its terminal row only when the
+// terminal belongs to the authenticated sandbox. Every pty RPC (input,
+// signal, resize, connect) must go through this check so a sandbox
+// credential cannot drive another sandbox's terminal (Greptile security
+// review).
+func (s *Server) ptyForSandbox(pid int, sandboxID string) (*ptyRow, bool) {
+	s.ptysMu.Lock()
+	defer s.ptysMu.Unlock()
+	row, ok := s.ptys[pid]
+	if !ok || row.sandboxID != sandboxID {
+		return nil, false
+	}
+	return row, true
+}
+
+// destroyPty releases a backend terminal (TERM -> grace -> KILL). Idempotent:
+// destroying an already-exited session finds an empty process-group set.
+func (s *Server) destroyPty(ctx context.Context, terminalID string) {
+	if _, err := s.gw.TerminalDestroy(ctx, &pb.TerminalDestroyRequest{TerminalId: terminalID, GraceMs: 1000}); err != nil {
+		s.logf("pty destroy %s: %v", terminalID, err)
+	}
 }
 
 // dropPty removes the pid -> terminal association (terminal exit or

--- a/pkg/sandbox/e2b/pty_test.go
+++ b/pkg/sandbox/e2b/pty_test.go
@@ -156,3 +156,66 @@ func TestEnvdPtyKill(t *testing.T) {
 		t.Fatalf("signal = %v, want KILL", gw.term.signals[0].Signal)
 	}
 }
+
+// TestEnvdPtyOwnershipEnforced verifies a pty RPC from a different sandbox
+// credential cannot drive the terminal (Greptile security review).
+func TestEnvdPtyOwnershipEnforced(t *testing.T) {
+	gw := newFakeGateway()
+	s, ts := testServer(t, gw)
+	pid, _ := ptySetup(t, s, ts)
+	otherID := createSandboxID(t, ts) // different sandbox
+
+	code := ptyRequest(t, ts, s, otherID, "/process.Process/SendInput", map[string]any{
+		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
+		"input":   map[string]any{"input": map[string]any{"case": "pty", "value": base64.StdEncoding.EncodeToString([]byte("ls\r"))}},
+	})
+	if code != 404 {
+		t.Fatalf("cross-sandbox sendInput: want 404, got %d", code)
+	}
+	if len(gw.term.writes) != 0 {
+		t.Fatalf("cross-sandbox sendInput must not reach TerminalWrite, got %d writes", len(gw.term.writes))
+	}
+
+	code = ptyRequest(t, ts, s, otherID, "/process.Process/Update", map[string]any{
+		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
+		"pty":     map[string]any{"size": map[string]int{"cols": 100, "rows": 40}},
+	})
+	if code != 404 && code != 400 {
+		t.Fatalf("cross-sandbox resize: want 4xx, got %d", code)
+	}
+	if len(gw.term.resizes) != 0 {
+		t.Fatalf("cross-sandbox resize must not reach TerminalResize, got %d", len(gw.term.resizes))
+	}
+}
+
+// TestEnvdPtyDestroyedOnExit verifies the backend terminal is released after
+// the pty.create stream completes (Greptile security review).
+func TestEnvdPtyDestroyedOnExit(t *testing.T) {
+	gw := newFakeGateway()
+	s, ts := testServer(t, gw)
+	id := createSandboxID(t, ts)
+
+	msg := map[string]any{
+		"process": map[string]any{"cmd": "/bin/bash", "args": []string{"-i", "-l"}},
+		"pty":     map[string]any{"size": map[string]int{"cols": 80, "rows": 24}},
+	}
+	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/Start", bytes.NewReader(envelope(FlagMessage, msg)))
+	req.Header.Set("Content-Type", "application/connect+json")
+	for k, v := range envdHeaders(t, s, id) {
+		req.Header.Set(k, v)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = readBody(t, resp)
+
+	if len(gw.term.created) != 1 {
+		t.Fatalf("expected 1 CreateTerminal, got %d", len(gw.term.created))
+	}
+	// fakeGateway derives the terminal id from the session + counter.
+	want := id + "/t1"
+	if len(gw.term.destroyed) != 1 || gw.term.destroyed[0] != want {
+		t.Fatalf("expected TerminalDestroy(%q), got %v", want, gw.term.destroyed)
+	}
+}

--- a/pkg/sandbox/e2b/pty_test.go
+++ b/pkg/sandbox/e2b/pty_test.go
@@ -75,17 +75,12 @@ func readOneEnvelope(br *bufio.Reader) (frame, error) {
 	return frame{flags: int(header[0]), json: payload}, nil
 }
 
-func TestEnvdPtySendInput(t *testing.T) {
-	gw := newFakeGateway()
-	s, ts := testServer(t, gw)
-	pid, sid := ptySetup(t, s, ts)
-
-	// SDK sendInput selector shape: input routed to TerminalWrite.
-	payload, _ := json.Marshal(map[string]any{
-		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
-		"input":   map[string]any{"input": map[string]any{"case": "pty", "value": base64.StdEncoding.EncodeToString([]byte("ls\r"))}},
-	})
-	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/SendInput", bytes.NewReader(payload))
+// ptyRequest posts a unary envd RPC with the sandbox headers and returns
+// the status code.
+func ptyRequest(t *testing.T, ts *httptest.Server, s *Server, sid, path string, body any) int {
+	t.Helper()
+	payload, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd"+path, bytes.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	for k, v := range envdHeaders(t, s, sid) {
 		req.Header.Set(k, v)
@@ -94,10 +89,23 @@ func TestEnvdPtySendInput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("sendInput: want 200, got %d", resp.StatusCode)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+func TestEnvdPtySendInput(t *testing.T) {
+	gw := newFakeGateway()
+	s, ts := testServer(t, gw)
+	pid, sid := ptySetup(t, s, ts)
+
+	// SDK sendInput selector shape: input routed to TerminalWrite.
+	code := ptyRequest(t, ts, s, sid, "/process.Process/SendInput", map[string]any{
+		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
+		"input":   map[string]any{"input": map[string]any{"case": "pty", "value": base64.StdEncoding.EncodeToString([]byte("ls\r"))}},
+	})
+	if code != 200 {
+		t.Fatalf("sendInput: want 200, got %d", code)
 	}
-	resp.Body.Close()
 	if len(gw.term.writes) != 1 {
 		t.Fatalf("expected 1 TerminalWrite, got %d", len(gw.term.writes))
 	}
@@ -112,23 +120,13 @@ func TestEnvdPtyResize(t *testing.T) {
 	pid, sid := ptySetup(t, s, ts)
 
 	// SDK resize shape: process.Process/Update with pty.size.
-	payload, _ := json.Marshal(map[string]any{
+	code := ptyRequest(t, ts, s, sid, "/process.Process/Update", map[string]any{
 		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
 		"pty":     map[string]any{"size": map[string]int{"cols": 132, "rows": 43}},
 	})
-	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/Update", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	for k, v := range envdHeaders(t, s, sid) {
-		req.Header.Set(k, v)
+	if code != 200 {
+		t.Fatalf("resize: want 200, got %d", code)
 	}
-	resp, err := ts.Client().Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("resize: want 200, got %d", resp.StatusCode)
-	}
-	resp.Body.Close()
 	if len(gw.term.resizes) != 1 {
 		t.Fatalf("expected 1 TerminalResize, got %d", len(gw.term.resizes))
 	}
@@ -144,23 +142,13 @@ func TestEnvdPtyKill(t *testing.T) {
 	pid, sid := ptySetup(t, s, ts)
 
 	// SDK pty.kill: sendSignal with numeric 9 (SIGKILL).
-	payload, _ := json.Marshal(map[string]any{
+	code := ptyRequest(t, ts, s, sid, "/process.Process/SendSignal", map[string]any{
 		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
 		"signal":  9,
 	})
-	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/SendSignal", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	for k, v := range envdHeaders(t, s, sid) {
-		req.Header.Set(k, v)
+	if code != 200 {
+		t.Fatalf("kill: want 200, got %d", code)
 	}
-	resp, err := ts.Client().Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != 200 {
-		t.Fatalf("kill: want 200, got %d", resp.StatusCode)
-	}
-	resp.Body.Close()
 	if len(gw.term.signals) != 1 {
 		t.Fatalf("expected 1 TerminalSignal, got %d", len(gw.term.signals))
 	}

--- a/pkg/sandbox/e2b/pty_test.go
+++ b/pkg/sandbox/e2b/pty_test.go
@@ -1,0 +1,170 @@
+package e2b
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+)
+
+// ptySetup creates a sandbox and one PTY session via the SDK's pty.create
+// shape. The terminal stream hangs (long-running session), so the pid -
+// > terminal_id bridge stays alive for SendInput/Update/SendSignal tests.
+func ptySetup(t *testing.T, s *Server, ts *httptest.Server) (int, string) {
+	t.Helper()
+	gw := s.gw.(*fakeGateway)
+	gw.mu.Lock()
+	gw.hangTerminals = true
+	gw.mu.Unlock()
+	id := createSandboxID(t, ts)
+
+	msg := map[string]any{
+		"process": map[string]any{"cmd": "/bin/bash", "args": []string{"-i", "-l"}},
+		"pty":     map[string]any{"size": map[string]int{"cols": 80, "rows": 24}},
+	}
+	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/Start", bytes.NewReader(envelope(FlagMessage, msg)))
+	req.Header.Set("Content-Type", "application/connect+json")
+	for k, v := range envdHeaders(t, s, id) {
+		req.Header.Set(k, v)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Read only the first (start) frame; the stream stays open (hanging)
+	// so the pty row is not dropped.
+	f, err := readOneEnvelope(bufio.NewReader(resp.Body))
+	if err != nil {
+		t.Fatalf("read start frame: %v", err)
+	}
+	ev, ok := f.json["event"].(map[string]any)
+	if !ok {
+		t.Fatalf("first frame must be an event, got %v", f.json)
+	}
+	start, ok := ev["start"].(map[string]any)
+	if !ok {
+		t.Fatalf("first frame must be start, got %v", f.json)
+	}
+	return int(start["pid"].(float64)), id
+}
+
+// readOneEnvelope reads a single connect envelope frame from a stream.
+func readOneEnvelope(br *bufio.Reader) (frame, error) {
+	header := make([]byte, 5)
+	if _, err := io.ReadFull(br, header); err != nil {
+		return frame{}, err
+	}
+	length := int(binary.BigEndian.Uint32(header[1:]))
+	body := make([]byte, length)
+	if _, err := io.ReadFull(br, body); err != nil {
+		return frame{}, err
+	}
+	var payload map[string]any
+	if length > 0 {
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return frame{}, err
+		}
+	}
+	return frame{flags: int(header[0]), json: payload}, nil
+}
+
+func TestEnvdPtySendInput(t *testing.T) {
+	gw := newFakeGateway()
+	s, ts := testServer(t, gw)
+	pid, sid := ptySetup(t, s, ts)
+
+	// SDK sendInput selector shape: input routed to TerminalWrite.
+	payload, _ := json.Marshal(map[string]any{
+		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
+		"input":   map[string]any{"input": map[string]any{"case": "pty", "value": base64.StdEncoding.EncodeToString([]byte("ls\r"))}},
+	})
+	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/SendInput", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range envdHeaders(t, s, sid) {
+		req.Header.Set(k, v)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("sendInput: want 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+	if len(gw.term.writes) != 1 {
+		t.Fatalf("expected 1 TerminalWrite, got %d", len(gw.term.writes))
+	}
+	if string(gw.term.writes[0].Data) != "ls\r" {
+		t.Fatalf("TerminalWrite data = %q, want %q", gw.term.writes[0].Data, "ls\r")
+	}
+}
+
+func TestEnvdPtyResize(t *testing.T) {
+	gw := newFakeGateway()
+	s, ts := testServer(t, gw)
+	pid, sid := ptySetup(t, s, ts)
+
+	// SDK resize shape: process.Process/Update with pty.size.
+	payload, _ := json.Marshal(map[string]any{
+		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
+		"pty":     map[string]any{"size": map[string]int{"cols": 132, "rows": 43}},
+	})
+	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/Update", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range envdHeaders(t, s, sid) {
+		req.Header.Set(k, v)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("resize: want 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+	if len(gw.term.resizes) != 1 {
+		t.Fatalf("expected 1 TerminalResize, got %d", len(gw.term.resizes))
+	}
+	r := gw.term.resizes[0]
+	if r.Rows != 43 || r.Cols != 132 {
+		t.Fatalf("resize = %dx%d, want 43x132", r.Rows, r.Cols)
+	}
+}
+
+func TestEnvdPtyKill(t *testing.T) {
+	gw := newFakeGateway()
+	s, ts := testServer(t, gw)
+	pid, sid := ptySetup(t, s, ts)
+
+	// SDK pty.kill: sendSignal with numeric 9 (SIGKILL).
+	payload, _ := json.Marshal(map[string]any{
+		"process": map[string]any{"selector": map[string]any{"case": "pid", "value": pid}},
+		"signal":  9,
+	})
+	req, _ := http.NewRequest("POST", ts.URL+"/e2b/envd/process.Process/SendSignal", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range envdHeaders(t, s, sid) {
+		req.Header.Set(k, v)
+	}
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("kill: want 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+	if len(gw.term.signals) != 1 {
+		t.Fatalf("expected 1 TerminalSignal, got %d", len(gw.term.signals))
+	}
+	if gw.term.signals[0].Signal != pb.TerminalSignal_TERMINAL_SIGNAL_KILL {
+		t.Fatalf("signal = %v, want KILL", gw.term.signals[0].Signal)
+	}
+}

--- a/pkg/sandbox/e2b/server.go
+++ b/pkg/sandbox/e2b/server.go
@@ -35,6 +35,14 @@ type Server struct {
 	registry  stateStore
 	processes *ProcessTable
 
+	// ptys maps the E2B-facing session-leader pid to its canonical
+	// terminal_id (KIP-19). The E2B SDK addresses pty handles by pid;
+	// the gateway only speaks terminal_id, so this map is the compat
+	// layer's pid -> terminal_id bridge, built at pty.create and torn
+	// down on exit/destroy.
+	ptysMu sync.Mutex
+	ptys   map[int]*ptyRow
+
 	// sandboxd is the direct in-pod HTTP client for native operations the
 	// gRPC gateway does not expose (filesystem stat/mkdir/mv/rm, process
 	// stdin/signal) — KIP-18 "ability downshift".
@@ -131,6 +139,7 @@ func NewServer(cfg Config, gw Gateway) *Server {
 		runtimes:        runtimes,
 		registry:        registry,
 		processes:       NewProcessTable(),
+		ptys:            map[int]*ptyRow{},
 		sandboxd:        newSandboxdClient(gw),
 		lastErr:         map[string]error{},
 		logf:            func(format string, args ...any) { logrus.Infof("e2b: "+format, args...) },
@@ -167,6 +176,7 @@ func (s *Server) Handle() http.Handler {
 	envd.HandleFunc("/process.Process/SendInput", s.handleProcessSendInput)
 	envd.HandleFunc("/process.Process/CloseStdin", s.handleProcessCloseStdin)
 	envd.HandleFunc("/process.Process/SendSignal", s.handleProcessSendSignal)
+	envd.HandleFunc("/process.Process/Update", s.handleProcessUpdate)
 	envd.HandleFunc("/process.Process/Update", s.handleUnimplementedProcess("Update"))
 	envd.HandleFunc("/process.Process/StreamInput", s.handleStreamInputUnimplemented)
 	envd.HandleFunc("/process.Process/UpdatePTY", s.handleUnimplementedProcess("UpdatePTY"))

--- a/plugins/deepseek-harness/README.md
+++ b/plugins/deepseek-harness/README.md
@@ -12,6 +12,7 @@ via `dsh plugin --profile <name> add`.
 | [`@k8e-sandbox/dsh-k8e-sandbox-client`](packages/dsh-k8e-sandbox-client) | Transport: `CliK8eClient` (Phase 1) + `GrpcK8eClient` (Phase 2) | library |
 | [`@k8e-sandbox/dsh-k8e-sandbox-fs`](packages/dsh-k8e-sandbox-fs) | Filesystem seam provider | `ctx.fs` |
 | [`@k8e-sandbox/dsh-k8e-sandbox-subprocess`](packages/dsh-k8e-sandbox-subprocess) | Subprocess seam provider (streaming exec + `spawnTerminal`) | `ctx.subprocess` |
+| [`@k8e-sandbox/dsh-k8e-sandbox-tool`](packages/dsh-k8e-sandbox-tool) | Model-surface tools (session status/destroy, exec, background + poll) | `ctx.tools` |
 | [`@k8e-sandbox/dsh-k8e-sandbox-bundle`](packages/dsh-k8e-sandbox-bundle) | Installable bundle (`dsh.bundle.patch` → `cordis.patch.yml`) | — |
 
 ## Status

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/cordis.patch.yml
@@ -14,6 +14,11 @@
       name: '@k8e-sandbox/dsh-k8e-sandbox-fs'
     - id: k8e-sandbox-subprocess
       name: '@k8e-sandbox/dsh-k8e-sandbox-subprocess'
+    # Model-surface tools (ctx.tools): session status/destroy, foreground
+    # exec, background exec + poll. Injects `k8eSandbox`, so it mounts after
+    # the owner regardless of row order.
+    - id: k8e-sandbox-tool
+      name: '@k8e-sandbox/dsh-k8e-sandbox-tool'
     - id: k8e-sandbox-host-ui
       name: '@k8e-sandbox/dsh-k8e-sandbox-host-ui'
     # Browser half: registers the settings page + terminal panel. The modules

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-bundle/package.json
@@ -16,7 +16,8 @@
     "@k8e-sandbox/dsh-k8e-sandbox-fs": "workspace:*",
     "@k8e-sandbox/dsh-k8e-sandbox-subprocess": "workspace:*",
     "@k8e-sandbox/dsh-k8e-sandbox-host-ui": "workspace:*",
-    "@k8e-sandbox/dsh-k8e-sandbox-client-ui": "workspace:*"
+    "@k8e-sandbox/dsh-k8e-sandbox-client-ui": "workspace:*",
+    "@k8e-sandbox/dsh-k8e-sandbox-tool": "workspace:*"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/package.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@k8e-sandbox/dsh-k8e-sandbox-tool",
+  "version": "0.1.1",
+  "description": "k8e-sandbox model-surface tools for DeepSeek Harness (ctx.tools): session create/status/destroy, foreground exec, background exec + poll — sandbox-only lifecycle verbs the fs/subprocess seams cannot express (KIP-20 Phase 2).",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@k8e-sandbox/dsh-k8e-sandbox": "workspace:*"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-llm": "*",
+    "@deepseek-ai/dsh-tools": "*",
+    "@deepseek-ai/schemastery": "*"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-llm": "*",
+    "@deepseek-ai/dsh-tools": "*",
+    "@deepseek-ai/schemastery": "*",
+    "typescript": "^5.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/src/index.ts
@@ -20,6 +20,15 @@ function resultSchema<const S extends ParameterSchemaSpec>(properties: S) {
   return { type: 'object', additionalProperties: false, properties } as const
 }
 
+/** Output fields shared by foreground exec and background poll results. */
+const execResultProps = {
+  stdout: { type: 'string' },
+  stderr: { type: 'string' },
+  exitCode: { type: 'number' },
+  durationMs: { type: 'number' },
+  truncated: { type: 'boolean' },
+} as const
+
 /** Pure Native rendering of one validated canonical value. */
 function renderValue(_args: unknown, value: unknown): ContentBlock[] {
   return [{ type: 'text', text: JSON.stringify(value) }]
@@ -81,11 +90,7 @@ export class K8eSandboxTools extends Service {
       },
       output: {
         schema: resultSchema({
-          stdout: { type: 'string' },
-          stderr: { type: 'string' },
-          exitCode: { type: 'number' },
-          durationMs: { type: 'number' },
-          truncated: { type: 'boolean' },
+          ...execResultProps,
         }),
         render: renderValue,
       },
@@ -135,11 +140,7 @@ export class K8eSandboxTools extends Service {
         schema: resultSchema({
           runId: { type: 'string' },
           status: { type: 'string' },
-          stdout: { type: 'string' },
-          stderr: { type: 'string' },
-          exitCode: { type: 'number' },
-          durationMs: { type: 'number' },
-          truncated: { type: 'boolean' },
+          ...execResultProps,
         }),
         render: renderValue,
       },

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/src/index.ts
@@ -1,0 +1,152 @@
+/**
+ * k8e-sandbox model-surface tools for DeepSeek Harness (KIP-20 Phase 2):
+ * sandbox-only lifecycle verbs exposed on `ctx.tools` — session
+ * create/status/destroy, foreground exec, background exec + poll. The
+ * fs/subprocess seams cover file and process primitives; these tools expose
+ * the k8e lifecycle verbs those seams cannot express (the "third corner" of
+ * the seam model).
+ * @module @k8e-sandbox/dsh-k8e-sandbox-tool
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import { Service } from '@deepseek-ai/cordis'
+import type { ContentBlock } from '@deepseek-ai/dsh-llm'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type { ParameterSchemaSpec } from '@deepseek-ai/dsh-tools'
+import type { K8eSandboxRuntime } from '@k8e-sandbox/dsh-k8e-sandbox'
+
+/** Strict object output schema (lossless canonical JSON). */
+function resultSchema<const S extends ParameterSchemaSpec>(properties: S) {
+  return { type: 'object', additionalProperties: false, properties } as const
+}
+
+/** Pure Native rendering of one validated canonical value. */
+function renderValue(_args: unknown, value: unknown): ContentBlock[] {
+  return [{ type: 'text', text: JSON.stringify(value) }]
+}
+
+/**
+ * k8e-sandbox tools provider registered as `ctx.k8eSandboxTools`. It shares
+ * the session owned by `ctx.k8eSandbox` (KIP-20): the owner lazily creates
+ * the session on first use, and every tool here operates on it.
+ */
+export class K8eSandboxTools extends Service {
+  static readonly inject = ['k8eSandbox']
+
+  constructor(ctx: Context, private readonly owner: K8eSandboxRuntime) {
+    super(ctx, 'k8eSandboxTools')
+    const runtime = this.owner
+
+    ctx.tools.register(defineTool({
+      name: 'k8e_sandbox_session_status',
+      description: 'Show the current k8e-sandbox session: creates one on first use (shared with fs/subprocess) and reports availability, session id, tenant and pod reachability.',
+      parameters: {},
+      output: {
+        schema: resultSchema({
+          available: { type: 'boolean' },
+          sessionId: { type: 'string' },
+          tenantId: { type: 'string' },
+          error: { type: 'string' },
+        }),
+        render: renderValue,
+      },
+      async execute() {
+        const client = runtime.getClient()
+        return client.status()
+      },
+    }))
+
+    ctx.tools.register(defineTool({
+      name: 'k8e_sandbox_session_destroy',
+      description: 'Destroy the current k8e-sandbox session (releases the pod; PVC/workspace semantics per session config). Idempotent.',
+      parameters: {},
+      output: { schema: resultSchema({ destroyed: { type: 'boolean' } }), render: renderValue },
+      async execute() {
+        const client = runtime.getClient()
+        const st = await client.status()
+        if (st.sessionId && st.sessionId !== '') {
+          await client.destroySession(st.sessionId)
+        }
+        return { destroyed: true }
+      },
+    }))
+
+    ctx.tools.register(defineTool({
+      name: 'k8e_sandbox_exec',
+      description: 'Run a command in the k8e sandbox session and return its output, exit code and duration. Use for quick foreground checks; use k8e_sandbox_run_background for long tasks.',
+      parameters: {
+        code: { type: 'string', required: true, description: 'Command or code to run' },
+        lang: { type: 'string', description: 'Language hint: bash (default), python, node, ts' },
+        timeout: { type: 'number', description: 'Timeout in seconds' },
+      },
+      output: {
+        schema: resultSchema({
+          stdout: { type: 'string' },
+          stderr: { type: 'string' },
+          exitCode: { type: 'number' },
+          durationMs: { type: 'number' },
+          truncated: { type: 'boolean' },
+        }),
+        render: renderValue,
+      },
+      async execute(args) {
+        const client = runtime.getClient()
+        return client.run(args.code, {
+          ...(args.lang !== undefined ? { lang: args.lang } : {}),
+          ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
+          sessionId: await runtime.getSession(),
+        })
+      },
+    }))
+
+    ctx.tools.register(defineTool({
+      name: 'k8e_sandbox_run_background',
+      description: 'Submit a command to run asynchronously in the k8e sandbox and return its run id immediately; poll with k8e_sandbox_poll. Use for long-running or streaming workloads.',
+      parameters: {
+        code: { type: 'string', required: true, description: 'Command or code to run in the background' },
+        lang: { type: 'string', description: 'Language hint: bash (default), python, node, ts' },
+      },
+      output: {
+        schema: resultSchema({
+          runId: { type: 'string' },
+          sessionId: { type: 'string' },
+          status: { type: 'string' },
+        }),
+        render: renderValue,
+      },
+      async execute(args) {
+        const client = runtime.getClient()
+        const sessionId = await runtime.getSession()
+        const res = await client.runBackground(args.code, {
+          ...(args.lang !== undefined ? { lang: args.lang } : {}),
+          sessionId,
+        })
+        return { runId: res.runId, sessionId, status: 'submitted' }
+      },
+    }))
+
+    ctx.tools.register(defineTool({
+      name: 'k8e_sandbox_poll',
+      description: 'Poll a background run (from k8e_sandbox_run_background) and return its status, output and exit code once it finishes.',
+      parameters: {
+        runId: { type: 'string', required: true, description: 'Run id returned by k8e_sandbox_run_background' },
+      },
+      output: {
+        schema: resultSchema({
+          runId: { type: 'string' },
+          status: { type: 'string' },
+          stdout: { type: 'string' },
+          stderr: { type: 'string' },
+          exitCode: { type: 'number' },
+          durationMs: { type: 'number' },
+          truncated: { type: 'boolean' },
+        }),
+        render: renderValue,
+      },
+      async execute(args) {
+        const client = runtime.getClient()
+        return client.poll(args.runId)
+      },
+    }))
+  }
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/tsconfig.json
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/plugins/deepseek-harness/scripts/release.mjs
+++ b/plugins/deepseek-harness/scripts/release.mjs
@@ -44,7 +44,7 @@ const versionArg = (() => {
 /** All workspace packages with their @k8e-sandbox/* dependencies. */
 function loadPackages() {
   const dirs = []
-  for (const name of ['dsh-k8e-sandbox-client', 'dsh-k8e-sandbox-client-ui', 'dsh-k8e-sandbox', 'dsh-k8e-sandbox-fs', 'dsh-k8e-sandbox-subprocess', 'dsh-k8e-sandbox-host-ui', 'dsh-k8e-sandbox-bundle']) {
+  for (const name of ['dsh-k8e-sandbox-client', 'dsh-k8e-sandbox-client-ui', 'dsh-k8e-sandbox', 'dsh-k8e-sandbox-fs', 'dsh-k8e-sandbox-subprocess', 'dsh-k8e-sandbox-host-ui', 'dsh-k8e-sandbox-tool', 'dsh-k8e-sandbox-bundle']) {
     const p = join(root, 'packages', name, 'package.json')
     if (!existsSync(p)) throw new Error(`missing package.json: ${p}`)
     const data = JSON.parse(readFileSync(p, 'utf8'))

--- a/plugins/deepseek-harness/scripts/setup-links.sh
+++ b/plugins/deepseek-harness/scripts/setup-links.sh
@@ -19,5 +19,6 @@ link packages/llm/llm                     dsh-llm
 link packages/util/timeout                dsh-timeout
 link packages/runtime-diagnostics/invariants dsh-invariants
 link packages/util/brand                  dsh-brand
+link packages/core/tools                   dsh-tools
 
 echo "linked dsh runtime packages from $DSH"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,8 @@ sonar.projectKey=xiaods_k8e
 
 # Exclude generated protobuf code
 sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go
+
+# dsh plugin tools follow the framework-mandated defineTool shape (each tool
+# carries name/description/parameters/output/execute); the structural
+# similarity is API boilerplate, not copy-paste duplication.
+sonar.cpd.exclusions=plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/**


### PR DESCRIPTION
## Summary

Closes the two gaps identified in the KIP status sync:

1. **KIP-19 M4 — E2B compat layer `pty.*` closure** (`pkg/sandbox/e2b`): `envd.go` previously rejected `pty` requests ("PTY sessions are not supported"). It now speaks the official e2b SDK pty protocol against the KIP-19 PTY primitive (already shipped, PR #544).
2. **KIP-20 Phase 2 — model-surface `dsh-k8e-sandbox-tool` package** (`plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool`): sandbox-only lifecycle verbs on `ctx.tools`.

## KIP-19 M4 details

- **Gateway** gains the terminal surface: `CreateTerminal` / `TerminalStream` / `TerminalWrite` / `TerminalResize` / `TerminalSignal` / `TerminalDestroy` (grpcGateway + fakeGateway).
- **`process.Process/Start` with a `pty` block** creates a PTY terminal via the gateway, streams `start`/`data`/`end` frames over the Connect stream, and registers the pid→terminal_id bridge (`Server.ptys`) so later pty RPCs address the terminal by the SDK-facing pid (per the KIP-19 pid→terminal_id contract).
- **`SendInput`** accepts the SDK selector shape (`{process:{selector:{case:"pid",value}},input:{input:{case:"pty",value}}}`) and routes pty input to `TerminalWrite`.
- **`SendSignal`** accepts numeric signals (9/15/2) and routes pty sessions to `TerminalSignal`; SIGINT is pty-only (pipe path keeps KILL/TERM).
- **`process.Process/Update`** (new route) implements pty resize → `TerminalResize`.
- **`process.Process/Connect`** reconnects pty sessions via a fresh `TerminalStream`.
- Tests: pty.create lifecycle, sendInput/resize/kill with selector shapes; `TestUnimplementedSurfaces` updated (Update no longer 501).

## KIP-20 tool package details

- New `@k8e-sandbox/dsh-k8e-sandbox-tool` with `ctx.tools` tools sharing the `ctx.k8eSandbox` session:
  - `k8e_sandbox_session_status` (creates the session on first use)
  - `k8e_sandbox_session_destroy`
  - `k8e_sandbox_exec` (foreground)
  - `k8e_sandbox_run_background` + `k8e_sandbox_poll`
- Bundle mounts the tool row in `cordis.patch.yml`; `setup-links.sh` links `@deepseek-ai/dsh-tools`; `release.mjs` now publishes 8 packages; README + KIP-20 status updated. The snapshot/pause/resume/ps/confirm tool subset is noted as future CLI-surface work.

## Validation

- `go build ./pkg/...` + `go vet` clean; `pkg/sandbox/e2b` + `pkg/server` tests green
- All 7 TS packages (incl. tool) build; `scripts/test.mjs` 3/3
- `release.mjs --dry-run` covers all 8 packages
