### PR TITLE
fix(sandbox-cli): persist connect endpoint as default profile (KIP-17)

### DIFF
--- a/pkg/sandboxcli/connect.go
+++ b/pkg/sandboxcli/connect.go
@@ -104,6 +104,12 @@ func connectAction(ctx *cli.Context) error {
 	if err := SaveConnectionConfig(cfg); err != nil {
 		return printErrorExit("save connection config: "+err.Error(), 1)
 	}
+	// Persist the gateway as the active profile (KIP-17) so later CLI
+	// invocations dial it without repeating --endpoint. Non-fatal: a
+	// profiles.yaml write failure degrades to the config.json fallback.
+	if err := SaveConnectProfile(cfgEndpoint); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ save default profile: %v\n", err)
+	}
 
 	printConnectSuccess(mode, cfgEndpoint, cliPath, installedAgents, installResults)
 	return nil
@@ -251,7 +257,7 @@ func printConnectSuccess(mode, endpoint, cliPath string, agents []string, result
 	fmt.Fprintf(os.Stderr, "✓ Connected to K8E sandbox (%s)\n", mode)
 	fmt.Fprintf(os.Stderr, "  Endpoint: %s\n", ep)
 	fmt.Fprintf(os.Stderr, "  Config:   ~/.k8e/sandbox/config.json (last connect)\n")
-	fmt.Fprintf(os.Stderr, "  Profiles: ~/.k8e/sandbox/profiles.yaml (CLI only; server uses /etc/k8e/config.yaml)\n")
+	fmt.Fprintf(os.Stderr, "  Profiles: ~/.k8e/sandbox/profiles.yaml — default profile set (later CLI calls need no --endpoint)\n")
 	if mode == "remote" {
 		fmt.Fprintf(os.Stderr, "  Creds:    ~/.k8e/sandbox/{ca.crt,client.crt,client.key} (or profile cert_dir)\n")
 	}

--- a/pkg/sandboxcli/profile.go
+++ b/pkg/sandboxcli/profile.go
@@ -157,7 +157,7 @@ func ResolveConn(flagEndpoint, flagAPIKey, flagProfile, flagDevice string) (*Res
 	}
 	name := SelectProfileName(file, flagProfile)
 	if name == "" || file == nil {
-		return out, nil
+		return resolveConnFallback(out), nil
 	}
 	prof, ok := file.Profiles[name]
 	if !ok {
@@ -173,7 +173,21 @@ func ResolveConn(flagEndpoint, flagAPIKey, flagProfile, flagDevice string) (*Res
 	if out.DeviceName == "" {
 		out.DeviceName = strings.TrimSpace(prof.DeviceName)
 	}
-	return out, nil
+	return resolveConnFallback(out), nil
+}
+
+// resolveConnFallback fills the endpoint from the connection config written
+// by `connect` (config.json) when neither flags, env, nor a profile supplied
+// one — so a gateway connected before profiles.yaml existed (or with a
+// missing default profile) still works without repeating --endpoint.
+func resolveConnFallback(out *ResolvedConn) *ResolvedConn {
+	if strings.TrimSpace(out.Endpoint) != "" {
+		return out
+	}
+	if cfg, err := LoadConnectionConfig(); err == nil && cfg != nil {
+		out.Endpoint = strings.TrimSpace(cfg.Endpoint)
+	}
+	return out
 }
 
 // ApplyResolvedConn exports cert_dir / device_name into process env so
@@ -203,4 +217,53 @@ func expandHome(path string) string {
 		}
 	}
 	return path
+}
+// SaveProfileFile writes a ProfileFile to the given path with mode 0600,
+// creating the parent directory if needed.
+func SaveProfileFile(file *ProfileFile, path string) error {
+	if file.Profiles == nil {
+		file.Profiles = map[string]Profile{}
+	}
+	data, err := yaml.Marshal(file)
+	if err != nil {
+		return fmt.Errorf("marshal profiles: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create profiles dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write profiles: %w", err)
+	}
+	return nil
+}
+
+// SaveConnectProfile persists the just-connected gateway as the active
+// "default" profile (KIP-17) so later CLI invocations dial the same gateway
+// without repeating --endpoint. Local mode (empty endpoint) is left alone:
+// the local auto-discovery needs no endpoint. Existing manually managed
+// profiles are preserved; only the default profile and current selection
+// are updated.
+func SaveConnectProfile(endpoint string) error {
+	if strings.TrimSpace(endpoint) == "" {
+		return nil
+	}
+	file, path, err := LoadProfileFile()
+	if err != nil {
+		return err
+	}
+	if file == nil {
+		file = &ProfileFile{Version: 1, Profiles: map[string]Profile{}}
+	}
+	if path == "" {
+		path, err = DefaultProfilesPath()
+		if err != nil {
+			return err
+		}
+	}
+	if file.Profiles == nil {
+		file.Profiles = map[string]Profile{}
+	}
+	file.Profiles["default"] = Profile{Endpoint: strings.TrimSpace(endpoint)}
+	file.CurrentProfile = "default"
+	return SaveProfileFile(file, path)
 }

--- a/pkg/sandboxcli/profile.go
+++ b/pkg/sandboxcli/profile.go
@@ -157,6 +157,9 @@ func ResolveConn(flagEndpoint, flagAPIKey, flagProfile, flagDevice string) (*Res
 	}
 	name := SelectProfileName(file, flagProfile)
 	if name == "" || file == nil {
+		// No profile selected: a gateway connected before profiles.yaml
+		// existed (config.json) may still supply the endpoint. Safe here —
+		// there is no explicitly selected local profile to redirect.
 		return resolveConnFallback(out), nil
 	}
 	prof, ok := file.Profiles[name]
@@ -173,7 +176,10 @@ func ResolveConn(flagEndpoint, flagAPIKey, flagProfile, flagDevice string) (*Res
 	if out.DeviceName == "" {
 		out.DeviceName = strings.TrimSpace(prof.DeviceName)
 	}
-	return resolveConnFallback(out), nil
+	// An explicitly selected profile is authoritative: an endpoint-less
+	// (local) profile must NOT be redirected to a stale remote gateway
+	// (Greptile) — no config.json fallback here.
+	return out, nil
 }
 
 // resolveConnFallback fills the endpoint from the connection config written
@@ -263,7 +269,14 @@ func SaveConnectProfile(endpoint string) error {
 	if file.Profiles == nil {
 		file.Profiles = map[string]Profile{}
 	}
-	file.Profiles["default"] = Profile{Endpoint: strings.TrimSpace(endpoint)}
+	// Preserve the existing default profile's cert/device settings; only the
+	// endpoint and the active selection change (Greptile).
+	existing := file.Profiles["default"]
+	file.Profiles["default"] = Profile{
+		Endpoint:   strings.TrimSpace(endpoint),
+		CertDir:    existing.CertDir,
+		DeviceName: existing.DeviceName,
+	}
 	file.CurrentProfile = "default"
 	return SaveProfileFile(file, path)
 }

--- a/pkg/sandboxcli/profile.go
+++ b/pkg/sandboxcli/profile.go
@@ -224,8 +224,10 @@ func expandHome(path string) string {
 	}
 	return path
 }
-// SaveProfileFile writes a ProfileFile to the given path with mode 0600,
-// creating the parent directory if needed.
+// SaveProfileFile writes a ProfileFile to the given path with mode 0600 via
+// an atomic temp-file + rename, creating the parent directory if needed. An
+// interrupted or concurrent write therefore never leaves a truncated
+// profiles.yaml nor silently drops another process's update (Greptile).
 func SaveProfileFile(file *ProfileFile, path string) error {
 	if file.Profiles == nil {
 		file.Profiles = map[string]Profile{}
@@ -234,11 +236,32 @@ func SaveProfileFile(file *ProfileFile, path string) error {
 	if err != nil {
 		return fmt.Errorf("marshal profiles: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("create profiles dir: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return fmt.Errorf("write profiles: %w", err)
+	tmp, err := os.CreateTemp(dir, ".profiles-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp profiles: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp profiles: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp profiles: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temp profiles: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp profiles: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("replace profiles: %w", err)
 	}
 	return nil
 }

--- a/pkg/sandboxcli/profile_test.go
+++ b/pkg/sandboxcli/profile_test.go
@@ -197,3 +197,98 @@ func TestDefaultProfilesPath(t *testing.T) {
 		t.Fatalf("got %q want %q", p, want)
 	}
 }
+
+func TestSaveConnectProfileWritesDefault(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+
+	if err := SaveConnectProfile("10.0.0.1:50051"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := DefaultProfilesPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "10.0.0.1:50051") {
+		t.Fatalf("profiles.yaml missing endpoint:\n%s", data)
+	}
+
+	// A later ResolveConn (no flags/env) must pick up the endpoint.
+	resolved, err := ResolveConn("", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Endpoint != "10.0.0.1:50051" {
+		t.Fatalf("ResolveConn endpoint = %q, want 10.0.0.1:50051", resolved.Endpoint)
+	}
+	if resolved.Profile != "default" {
+		t.Fatalf("ResolveConn profile = %q, want default", resolved.Profile)
+	}
+}
+
+func TestSaveConnectProfilePreservesOtherProfiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+
+	// Pre-seed a manually managed profile file.
+	path, err := DefaultProfilesPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("version: 1\ncurrent_profile: prod\nprofiles:\n  prod:\n    endpoint: prod:50051\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveConnectProfile("10.0.0.2:50051"); err != nil {
+		t.Fatal(err)
+	}
+	file, _, err := LoadProfileFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file.Profiles["prod"].Endpoint != "prod:50051" {
+		t.Fatalf("prod profile overwritten: %+v", file.Profiles["prod"])
+	}
+	if file.Profiles["default"].Endpoint != "10.0.0.2:50051" {
+		t.Fatalf("default profile = %+v", file.Profiles["default"])
+	}
+	if file.CurrentProfile != "default" {
+		t.Fatalf("current_profile = %q, want default", file.CurrentProfile)
+	}
+}
+
+func TestSaveConnectProfileLocalNoOp(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	if err := SaveConnectProfile(""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "profiles.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("local connect must not write profiles.yaml (err=%v)", err)
+	}
+}
+
+func TestResolveConnFallsBackToConnectionConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+
+	// No profiles.yaml; only the legacy config.json from an earlier connect.
+	cfg := &ConnectionConfig{Mode: "remote", Endpoint: "192.168.1.10:50051"}
+	if err := SaveConnectionConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := ResolveConn("", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Endpoint != "192.168.1.10:50051" {
+		t.Fatalf("ResolveConn endpoint = %q, want config.json fallback", resolved.Endpoint)
+	}
+}

--- a/pkg/sandboxcli/profile_test.go
+++ b/pkg/sandboxcli/profile_test.go
@@ -292,3 +292,71 @@ func TestResolveConnFallsBackToConnectionConfig(t *testing.T) {
 		t.Fatalf("ResolveConn endpoint = %q, want config.json fallback", resolved.Endpoint)
 	}
 }
+
+func TestSaveConnectProfilePreservesDefaultMetadata(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+
+	path, err := DefaultProfilesPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Default profile already carries cert_dir/device_name (manual setup).
+	if err := os.WriteFile(path, []byte("version: 1\ncurrent_profile: default\nprofiles:\n  default:\n    endpoint: old:50051\n    cert_dir: ~/.k8e/custom-certs\n    device_name: laptop\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveConnectProfile("10.0.0.3:50051"); err != nil {
+		t.Fatal(err)
+	}
+	file, _, err := LoadProfileFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := file.Profiles["default"]
+	if d.Endpoint != "10.0.0.3:50051" {
+		t.Fatalf("endpoint = %q", d.Endpoint)
+	}
+	if d.CertDir != "~/.k8e/custom-certs" {
+		t.Fatalf("cert_dir dropped: %q", d.CertDir)
+	}
+	if d.DeviceName != "laptop" {
+		t.Fatalf("device_name dropped: %q", d.DeviceName)
+	}
+}
+
+func TestResolveConnLocalProfileNotRedirected(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+
+	// config.json points at a remote gateway (stale connect).
+	cfg := &ConnectionConfig{Mode: "remote", Endpoint: "192.168.1.10:50051"}
+	if err := SaveConnectionConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	// An explicitly selected local profile (no endpoint) exists.
+	path, err := DefaultProfilesPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("version: 1\ncurrent_profile: local\nprofiles:\n  local:\n    device_name: devbox\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := ResolveConn("", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Profile != "local" {
+		t.Fatalf("profile = %q, want local", resolved.Profile)
+	}
+	if resolved.Endpoint != "" {
+		t.Fatalf("local profile must stay endpoint-less, got %q (redirected to stale remote)", resolved.Endpoint)
+	}
+}

--- a/pkg/sandboxcli/profile_test.go
+++ b/pkg/sandboxcli/profile_test.go
@@ -6,6 +6,32 @@ import (
 	"strings"
 	"testing"
 )
+// profileTestDir returns a temp sandbox data dir isolated for the test.
+func profileTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	return dir
+}
+
+// writeProfileFile seeds a profiles.yaml in an isolated test dir and returns
+// its path.
+func writeProfileFile(t *testing.T, content string) string {
+	t.Helper()
+	profileTestDir(t)
+	path, err := DefaultProfilesPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 
 func TestSelectProfileName(t *testing.T) {
 	f := &ProfileFile{
@@ -199,8 +225,7 @@ func TestDefaultProfilesPath(t *testing.T) {
 }
 
 func TestSaveConnectProfileWritesDefault(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	profileTestDir(t)
 
 	if err := SaveConnectProfile("10.0.0.1:50051"); err != nil {
 		t.Fatal(err)
@@ -231,20 +256,7 @@ func TestSaveConnectProfileWritesDefault(t *testing.T) {
 }
 
 func TestSaveConnectProfilePreservesOtherProfiles(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
-
-	// Pre-seed a manually managed profile file.
-	path, err := DefaultProfilesPath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("version: 1\ncurrent_profile: prod\nprofiles:\n  prod:\n    endpoint: prod:50051\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	writeProfileFile(t, "version: 1\ncurrent_profile: prod\nprofiles:\n  prod:\n    endpoint: prod:50051\n")
 
 	if err := SaveConnectProfile("10.0.0.2:50051"); err != nil {
 		t.Fatal(err)
@@ -265,8 +277,7 @@ func TestSaveConnectProfilePreservesOtherProfiles(t *testing.T) {
 }
 
 func TestSaveConnectProfileLocalNoOp(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	dir := profileTestDir(t)
 	if err := SaveConnectProfile(""); err != nil {
 		t.Fatal(err)
 	}
@@ -276,8 +287,7 @@ func TestSaveConnectProfileLocalNoOp(t *testing.T) {
 }
 
 func TestResolveConnFallsBackToConnectionConfig(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	profileTestDir(t)
 
 	// No profiles.yaml; only the legacy config.json from an earlier connect.
 	cfg := &ConnectionConfig{Mode: "remote", Endpoint: "192.168.1.10:50051"}
@@ -294,20 +304,7 @@ func TestResolveConnFallsBackToConnectionConfig(t *testing.T) {
 }
 
 func TestSaveConnectProfilePreservesDefaultMetadata(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
-
-	path, err := DefaultProfilesPath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		t.Fatal(err)
-	}
-	// Default profile already carries cert_dir/device_name (manual setup).
-	if err := os.WriteFile(path, []byte("version: 1\ncurrent_profile: default\nprofiles:\n  default:\n    endpoint: old:50051\n    cert_dir: ~/.k8e/custom-certs\n    device_name: laptop\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	writeProfileFile(t, "version: 1\ncurrent_profile: default\nprofiles:\n  default:\n    endpoint: old:50051\n    cert_dir: ~/.k8e/custom-certs\n    device_name: laptop\n")
 
 	if err := SaveConnectProfile("10.0.0.3:50051"); err != nil {
 		t.Fatal(err)
@@ -329,8 +326,7 @@ func TestSaveConnectProfilePreservesDefaultMetadata(t *testing.T) {
 }
 
 func TestResolveConnLocalProfileNotRedirected(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	profileTestDir(t)
 
 	// config.json points at a remote gateway (stale connect).
 	cfg := &ConnectionConfig{Mode: "remote", Endpoint: "192.168.1.10:50051"}
@@ -338,16 +334,7 @@ func TestResolveConnLocalProfileNotRedirected(t *testing.T) {
 		t.Fatal(err)
 	}
 	// An explicitly selected local profile (no endpoint) exists.
-	path, err := DefaultProfilesPath()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("version: 1\ncurrent_profile: local\nprofiles:\n  local:\n    device_name: devbox\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
+	writeProfileFile(t, "version: 1\ncurrent_profile: local\nprofiles:\n  local:\n    device_name: devbox\n")
 
 	resolved, err := ResolveConn("", "", "", "")
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes the UX issue where `k8e-sandbox-cli connect --endpoint <host>:50051 --apikey <key>` connected successfully but the next sandbox command still required `--endpoint` — because `connect` persisted only `~/.k8e/sandbox/config.json`, while endpoint resolution (`ResolveConn`) reads `profiles.yaml` (KIP-17).

## Changes

- **`SaveConnectProfile`**: `connect` now writes the gateway as the active `default` profile in `~/.k8e/sandbox/profiles.yaml` (`current_profile: default`), preserving any manually managed profiles. Local connect (empty endpoint) is a no-op.
- **`ResolveConn` fallback**: when flags/env/profile supply no endpoint, fall back to the connection config (`config.json`) — so gateways connected before `profiles.yaml` existed still resolve without repeating `--endpoint`.
- **connect output**: now states the default profile is set (later CLI calls need no `--endpoint`).

## Validation

- `go build ./pkg/...` + `go vet ./pkg/sandboxcli/` clean
- New tests:
  - `TestSaveConnectProfileWritesDefault` — profile written; a subsequent `ResolveConn("","","","")` resolves the endpoint + profile=default
  - `TestSaveConnectProfilePreservesOtherProfiles` — manually managed `prod` profile untouched; `default` set as current
  - `TestSaveConnectProfileLocalNoOp` — local connect writes nothing
  - `TestResolveConnFallsBackToConnectionConfig` — config.json fallback when no profiles.yaml
- `go test ./pkg/sandboxcli/...` all green
