### PR TITLE
feat(e2b): load API keys from sandbox-apikeys Secret in embedded server (KIP-18)

### DIFF
--- a/docs/kip-18-sandbox-e2b-compat.md
+++ b/docs/kip-18-sandbox-e2b-compat.md
@@ -19,7 +19,7 @@ application to K8E is configuration, not code:
 import { Sandbox } from 'e2b';
 
 const sbx = await Sandbox.create({
-  apiKey: `e2b_${process.env.K8E_SANDBOX_APIKEY}`, // or bare key / Bearer
+  apiKey: process.env.E2B_API_KEY, // must be e2b_<hex> — SDK validateApiKey rejects a bare hex token
   apiUrl: 'http://127.0.0.1:3676',
   sandboxUrl: 'http://127.0.0.1:3676/e2b/envd',
 });
@@ -478,44 +478,54 @@ Downloads get extension-based `Content-Type` and single-range `Range` support
 - **Control plane**: `X-API-KEY: e2b_<token>` (or bare `X-API-Key` /
   `Authorization: Bearer`). The `e2b_` prefix is the SDK's convention, not a
   secret; the bare token is compared (constant-time) against the API key(s)
-  the e2b server is configured with — same keys the gateway validates
-  (`--apikey` / `K8E_SANDBOX_APIKEY` for `k8e e2b-server`, `--e2b-apikey` /
-  `K8E_E2B_APIKEY` for the embedded server, plus the `sandbox-apikeys` Secret
-  loader when running in-cluster).
+  the e2b server accepts.
+
+  **Embedded k8e-server (default) loads the same `sandbox-apikeys` Secret
+  the gRPC gateway uses**, reloading every 30s. `k8e sandbox-apikey create`
+  is therefore enough — you do **not** also have to set `--e2b-apikey` for
+  official SDK clients to authenticate. The reload keeps the last parsed
+  Secret snapshot and **re-evaluates key expiry every tick even if a later
+  Secret read/parse fails**, so an expired key never stays authenticated
+  just because the Secret became unreadable. Optional extras:
+
+  - `--e2b-apikey` / `K8E_E2B_APIKEY` — extra static token (unioned with the Secret)
+  - `K8E_SANDBOX_APIKEY` — fallback when `--e2b-apikey` is empty (same env the CLI uses)
+  - standalone `k8e e2b-server --apikey` / `K8E_SANDBOX_APIKEY` still needs the
+    token passed explicitly (it is also the gRPC login credential)
 
   **The key is hex-only — by design.** The official `e2b` SDKs validate the
   key client-side (`validateApiKey`, `/^e2b_[0-9a-f]+$/`) *before* any
   request, so a key containing non-hex characters (e.g. an old `k8e-…`
   token) can never be presented by an unmodified SDK — the SDK throws
   `AuthenticationError` locally. K8E's own key generator
-  (`k8e sandbox-apikey create <name>`) therefore emits a bare 64-hex token:
-  **one key serves every role** — the gRPC gateway `sandbox-apikeys` Secret
-  (login), the e2b server's `--apikey` / `K8E_E2B_APIKEY`, and e2b SDK
-  clients (as `e2b_` + key):
+  (`k8e sandbox-apikey create <name>`) therefore emits a bare 64-hex `key`
+  **and** an `e2b_key` (`e2b_` + hex) ready to paste into the SDK:
 
   ```bash
-  export K8E_SANDBOX_APIKEY=$(k8e sandbox-apikey create e2b --ttl never | jq -r .key)
-  # or for the embedded server:
-  export K8E_E2B_APIKEY=$(k8e sandbox-apikey create e2b --ttl never | jq -r .key)
+  k8e sandbox-apikey create e2b --ttl never
+  # { "key": "<64 hex>", "e2b_key": "e2b_<64 hex>", ... }
+
+  export E2B_API_KEY=$(k8e sandbox-apikey create e2b --ttl never | jq -r .e2b_key)
   ```
 
   ```ts
   const sbx = await Sandbox.create({
-    apiKey: `e2b_${process.env.K8E_SANDBOX_APIKEY}`,  // or K8E_E2B_APIKEY
+    apiKey: process.env.E2B_API_KEY, // must be e2b_<hex>, not the bare hex
     apiUrl: 'http://127.0.0.1:3676',
     sandboxUrl: 'http://127.0.0.1:3676/e2b/envd',
   });
   ```
 
-  The server strips the `e2b_` prefix from both the configured key and the
-  presented credential, so configuring the key with or without the prefix is
-  equivalent. `k8e e2b-server` warns at startup when `--apikey` is not
-  hex-compatible (the embedded server warns for `--e2b-apikey`) and still
-  starts: a legacy `k8e-…` key remains valid for the gRPC gateway login,
-  only SDK clients cannot use it — rotate to a hex key
-  (`k8e sandbox-apikey create`) for SDK access. If no key is configured, the
-  control plane rejects every request with 401 (embedded mode logs a warning
-  about this).
+  Passing the bare hex token as `apiKey` fails *inside the SDK* (no HTTP
+  request is sent). Passing `e2b_` + hex to a server with an empty keyring
+  used to 401 even when the Secret held that token; the embedded server now
+  accepts Secret keys. The server strips the `e2b_` prefix from both the
+  configured key and the presented credential. `k8e e2b-server` warns at
+  startup when `--apikey` is not hex-compatible and still starts: a legacy
+  `k8e-…` key remains valid for the gRPC gateway login, only SDK clients
+  cannot use it — rotate with `k8e sandbox-apikey create`. If no key is
+  configured and the Secret is empty/unreadable, the control plane rejects
+  every request with 401.
 - **envd**: `E2b-Sandbox-Id` header + `X-Access-Token`
   `HMAC(signingSecret, "envd:"+sandboxID)` — stateless verify, minted at
   create and echoed in the session view. The signing secret comes from

--- a/docs/kip-18-sandbox-e2b-compat.md
+++ b/docs/kip-18-sandbox-e2b-compat.md
@@ -483,10 +483,12 @@ Downloads get extension-based `Content-Type` and single-range `Range` support
   **Embedded k8e-server (default) loads the same `sandbox-apikeys` Secret
   the gRPC gateway uses**, reloading every 30s. `k8e sandbox-apikey create`
   is therefore enough — you do **not** also have to set `--e2b-apikey` for
-  official SDK clients to authenticate. The reload keeps the last parsed
-  Secret snapshot and **re-evaluates key expiry every tick even if a later
-  Secret read/parse fails**, so an expired key never stays authenticated
-  just because the Secret became unreadable. Optional extras:
+  official SDK clients to authenticate. A successful read installs the
+  current unexpired tokens. A later **failed** Secret read/parse
+  **fail-closes Secret-backed tokens** (keeps only `--e2b-apikey` /
+  `K8E_SANDBOX_APIKEY`): a deleted unexpired key is indistinguishable from
+  a live one without a successful read, so the cache must not keep serving
+  it. Optional extras:
 
   - `--e2b-apikey` / `K8E_E2B_APIKEY` — extra static token (unioned with the Secret)
   - `K8E_SANDBOX_APIKEY` — fallback when `--e2b-apikey` is empty (same env the CLI uses)

--- a/pkg/cli/cmds/server.go
+++ b/pkg/cli/cmds/server.go
@@ -557,9 +557,9 @@ var ServerFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:        "e2b-apikey",
-		Usage:       "(sandbox) API key for the embedded E2B-compatible server (KIP-18). Official e2b SDKs require the key to be \"e2b_\" + hex characters (client-side validateApiKey); configure the bare hex token here (e.g. from `openssl rand -hex 32`) and pass \"e2b_\"+token to the SDK — the server strips the prefix. K8E_E2B_APIKEY",
+		Usage:       "(sandbox) API key for the embedded E2B-compatible server (KIP-18). Official e2b SDKs require \"e2b_\" + hex (client-side validateApiKey); configure the bare hex token (or omit this flag and let the server load keys from the sandbox-apikeys Secret created by `k8e sandbox-apikey create`). Pass the JSON e2b_key field to the SDK. K8E_E2B_APIKEY, K8E_SANDBOX_APIKEY",
 		Destination: &ServerConfig.E2BAPIKey,
-		EnvVar:      "K8E_E2B_APIKEY",
+		EnvVar:      "K8E_E2B_APIKEY,K8E_SANDBOX_APIKEY",
 	},
 	&cli.StringFlag{
 		Name:        "sandbox-default-runtime",

--- a/pkg/daemons/config/types.go
+++ b/pkg/daemons/config/types.go
@@ -214,11 +214,13 @@ type SandboxConfig struct {
 	// Cilium Gateway API (HTTPRoute/TCPRoute), never a direct host port.
 	DisableE2B bool
 	E2BListen  string
-	// E2BAPIKey authenticates control-plane requests to the embedded E2B
-	// server (KIP-18). The official e2b SDKs require "e2b_" + hex characters
-	// (client-side validateApiKey); the bare token must therefore be hex-only
-	// and is compared after stripping the "e2b_" prefix. Empty disables
-	// control-plane auth (every request is rejected with 401).
+	// E2BAPIKey is an optional extra token for the embedded E2B server
+	// (KIP-18). Official e2b SDKs require "e2b_" + hex (client-side
+	// validateApiKey); the bare token is compared after stripping "e2b_".
+	// The embedded server also loads keys from the sandbox-apikeys Secret
+	// (same store as the gRPC gateway), so this flag may be empty when keys
+	// are created with `k8e sandbox-apikey create`. Empty static key plus
+	// empty Secret rejects every control-plane request with 401.
 	E2BAPIKey string
 	// AdvertiseHostname is the external DNS name (or IP) remote clients dial to reach
 	// the sandbox gRPC gateway; it is added to the gateway's server cert SANs. In AWS

--- a/pkg/sandbox/e2b/apikey.go
+++ b/pkg/sandbox/e2b/apikey.go
@@ -58,12 +58,19 @@ func SDKAPIKey(bare string) string {
 }
 
 // SecretKeySet is a parsed snapshot of the sandbox-apikeys Secret. It retains
-// each record's expiry so callers can re-evaluate expiration against the
-// current time even when a later Secret read/parse fails — an expired
-// credential must not stay authenticated just because the Secret became
-// unreadable or corrupt.
+// each record's expiry so Active(now) can drop tokens that have since
+// expired. A failed later Secret read must not keep serving this snapshot
+// (a deleted unexpired key is indistinguishable from a live one without a
+// successful read); the embedded server fail-closes Secret-backed tokens
+// on read errors and keeps only the static --e2b-apikey.
 type SecretKeySet struct {
 	records map[string]apikey.Record
+}
+
+// Empty reports whether the snapshot holds no records (missing Secret or
+// unused cache).
+func (s SecretKeySet) Empty() bool {
+	return len(s.records) == 0
 }
 
 // ParseSecretKeys parses a sandbox-apikeys keys.json payload (v2 records or

--- a/pkg/sandbox/e2b/apikey.go
+++ b/pkg/sandbox/e2b/apikey.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/xiaods/k8e/pkg/sandbox/apikey"
 )
 
 // e2bAPIKeyPattern mirrors the official `e2b` SDK's client-side validation
@@ -41,4 +44,66 @@ func ValidateE2BAPIKey(key string) error {
 		"(validateApiKey: /^e2b_[0-9a-f]+$/), but the bare token %q contains non-hex characters; "+
 		"generate a compatible key with `openssl rand -hex 32` and configure it "+
 		"without the e2b_ prefix (the server strips it; the SDK prepends it)", key, bare)
+}
+
+// SDKAPIKey returns the official-SDK form of a bare token: "e2b_" + hex.
+// The SDK's validateApiKey (/^e2b_[0-9a-f]+$/) rejects a bare hex key
+// before any request, so this is what operators must pass as apiKey.
+func SDKAPIKey(bare string) string {
+	bare = NormalizeE2BAPIKey(bare)
+	if bare == "" {
+		return ""
+	}
+	return "e2b_" + bare
+}
+
+// SecretKeySet is a parsed snapshot of the sandbox-apikeys Secret. It retains
+// each record's expiry so callers can re-evaluate expiration against the
+// current time even when a later Secret read/parse fails — an expired
+// credential must not stay authenticated just because the Secret became
+// unreadable or corrupt.
+type SecretKeySet struct {
+	records map[string]apikey.Record
+}
+
+// ParseSecretKeys parses a sandbox-apikeys keys.json payload (v2 records or
+// legacy flat map) into a SecretKeySet, retaining expiry information.
+func ParseSecretKeys(data []byte) (SecretKeySet, error) {
+	records, err := apikey.Parse(data)
+	if err != nil {
+		return SecretKeySet{}, err
+	}
+	return SecretKeySet{records: records}, nil
+}
+
+// Active returns the bare tokens still valid at now, normalized the same way
+// as a configured --e2b-apikey (trim + strip "e2b_" + dedupe), so a Secret
+// created by `k8e sandbox-apikey create` can authenticate official e2b SDK
+// clients (which present "e2b_"+token). Expired keys are dropped.
+func (s SecretKeySet) Active(now time.Time) []string {
+	secrets := apikey.ActiveSecrets(s.records, now)
+	keys := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		keys = append(keys, secret)
+	}
+	return normalizeKeyList(keys)
+}
+
+// normalizeKeyList trims, strips the SDK prefix, and de-duplicates while
+// preserving first-seen order.
+func normalizeKeyList(keys []string) []string {
+	seen := make(map[string]struct{}, len(keys))
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		k = NormalizeE2BAPIKey(k)
+		if k == "" {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
 }

--- a/pkg/sandbox/e2b/apikey_test.go
+++ b/pkg/sandbox/e2b/apikey_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/xiaods/k8e/pkg/sandbox/apikey"
 )
 
 func TestNormalizeE2BAPIKey(t *testing.T) {
@@ -15,9 +18,9 @@ func TestNormalizeE2BAPIKey(t *testing.T) {
 	}{
 		{"", ""},
 		{"deadbeef", "deadbeef"},
-		{"e2b_deadbeef", "deadbeef"},        // SDK prefix is stripped
-		{" e2b_deadbeef ", "deadbeef"},      // surrounding whitespace trimmed
-		{"E2B_deadbeef", "E2B_deadbeef"},    // prefix match is exact (lowercase only)
+		{"e2b_deadbeef", "deadbeef"},         // SDK prefix is stripped
+		{" e2b_deadbeef ", "deadbeef"},       // surrounding whitespace trimmed
+		{"E2B_deadbeef", "E2B_deadbeef"},     // prefix match is exact (lowercase only)
 		{"e2b_e2b_deadbeef", "e2b_deadbeef"}, // only the first prefix is stripped
 	}
 	for _, tt := range tests {
@@ -105,4 +108,168 @@ func newServerWithKey(t *testing.T, apiKey string) (*Server, *httptest.Server) {
 	ts := httptest.NewServer(s.Handle())
 	t.Cleanup(ts.Close)
 	return s, ts
+}
+
+func TestSDKAPIKey(t *testing.T) {
+	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
+	if got := SDKAPIKey(hex); got != "e2b_"+hex {
+		t.Errorf("SDKAPIKey(%q) = %q", hex, got)
+	}
+	if got := SDKAPIKey("e2b_" + hex); got != "e2b_"+hex {
+		t.Errorf("SDKAPIKey prefixed = %q", got)
+	}
+	if got := SDKAPIKey("  e2b_" + hex + "  "); got != "e2b_"+hex {
+		t.Errorf("SDKAPIKey whitespace = %q", got)
+	}
+	if got := SDKAPIKey(""); got != "" {
+		t.Errorf("SDKAPIKey empty = %q", got)
+	}
+}
+
+func TestParseSecretKeysActive(t *testing.T) {
+	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-time.Hour)
+	live := apikey.NewRecord(hex, 30, false, now)
+	dead := apikey.Record{Key: "cafebabe", ExpiresAt: &expired}
+	data, err := apikey.Encode(map[string]apikey.Record{
+		"e2b":     live,
+		"expired": dead,
+		"legacy":  {Key: "e2b_deadbeef"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := ParseSecretKeys(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := set.Active(now)
+	got := map[string]bool{}
+	for _, k := range keys {
+		got[k] = true
+	}
+	if !got[hex] {
+		t.Errorf("missing live hex key; keys=%v", keys)
+	}
+	if !got["deadbeef"] {
+		t.Errorf("prefixed secret token should be stripped; keys=%v", keys)
+	}
+	if got["cafebabe"] {
+		t.Errorf("expired key should be dropped; keys=%v", keys)
+	}
+
+	legacySet, err := ParseSecretKeys([]byte(`{"agent":"` + hex + `"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := legacySet.Active(now)
+	if len(legacy) != 1 || legacy[0] != hex {
+		t.Errorf("legacy flat map: got %v", legacy)
+	}
+}
+
+// TestSecretKeySetExpiryReevaluatedOnFailedRefresh is the Greptile concern:
+// when a later Secret read/parse fails, the cached SecretKeySet must still
+// drop keys that expired since it was parsed — the keyring must not keep an
+// expired credential authenticated just because the Secret became unreadable.
+func TestSecretKeySetExpiryReevaluatedOnFailedRefresh(t *testing.T) {
+	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
+	t0 := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	shortExp := t0.Add(10 * time.Minute)   // key "short" dies 10 min after parse
+	longExp := t0.Add(30 * 24 * time.Hour) // key "long" stays alive
+	data, err := apikey.Encode(map[string]apikey.Record{
+		"short": {Key: "deadbeef", CreatedAt: t0, ExpiresAt: &shortExp, TTLDays: 30},
+		"long":  {Key: hex, CreatedAt: t0, ExpiresAt: &longExp, TTLDays: 30},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := ParseSecretKeys(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	activeBefore := set.Active(t0)
+	if !containsStr(activeBefore, "deadbeef") || !containsStr(activeBefore, hex) {
+		t.Fatalf("both keys active at parse; got %v", activeBefore)
+	}
+
+	// Simulate a failed refresh long after the short key expired: Active(now)
+	// must drop it even though no new Secret read happened.
+	later := shortExp.Add(time.Hour)
+	activeAfter := set.Active(later)
+	if containsStr(activeAfter, "deadbeef") {
+		t.Errorf("expired key must be re-filtered on a failed refresh; got %v", activeAfter)
+	}
+	if !containsStr(activeAfter, hex) {
+		t.Errorf("long-lived key must survive re-filtering; got %v", activeAfter)
+	}
+}
+
+func containsStr(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServerSecretLoadedKeyAuthenticatesSDKHeader is the production failure
+// mode: --e2b-apikey is unset (embedded default) but sandbox-apikeys holds a
+// hex token. Official JS SDK sends X-API-KEY: e2b_<hex> and used to get 401.
+func TestServerSecretLoadedKeyAuthenticatesSDKHeader(t *testing.T) {
+	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
+	s, ts := newServerWithKey(t, "") // empty static key, as in default embed
+	req, _ := http.NewRequest("POST", ts.URL+"/sandboxes", bytes.NewReader([]byte("{}")))
+	req.Header.Set("X-API-KEY", SDKAPIKey(hex)) // exact official SDK header
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("empty keyring: want 401, got %d", resp.StatusCode)
+	}
+
+	s.ReplaceAPIKeys([]string{hex})
+	for _, presented := range []string{SDKAPIKey(hex), hex} {
+		req, _ := http.NewRequest("POST", ts.URL+"/sandboxes", bytes.NewReader([]byte("{}")))
+		req.Header.Set("X-API-KEY", presented)
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 201 {
+			t.Errorf("presented=%q: want 201 after Secret load, got %d", presented, resp.StatusCode)
+		}
+	}
+
+	req, _ = http.NewRequest("POST", ts.URL+"/sandboxes", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer "+SDKAPIKey(hex))
+	resp, err = ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 201 {
+		t.Errorf("Bearer e2b_<hex>: want 201, got %d", resp.StatusCode)
+	}
+}
+
+func TestReplaceAPIKeysEmptyRejects(t *testing.T) {
+	s, ts := newServerWithKey(t, "deadbeef")
+	s.ReplaceAPIKeys(nil)
+	req, _ := http.NewRequest("POST", ts.URL+"/sandboxes", bytes.NewReader([]byte("{}")))
+	req.Header.Set("X-API-KEY", "e2b_deadbeef")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("empty replace: want 401, got %d", resp.StatusCode)
+	}
 }

--- a/pkg/sandbox/e2b/server.go
+++ b/pkg/sandbox/e2b/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	listen        string
 	nodeID        string
 	signingSecret string
+	apiKeysMu     sync.RWMutex
 	apiKeys       []string
 
 	defaultCPUs     int
@@ -118,11 +119,9 @@ func NewServer(cfg Config, gw Gateway) *Server {
 	// The configured key is normalized to its bare token: the official e2b
 	// SDK always presents the key as "e2b_<token>" (client-side format
 	// validation), so accepting the key with or without that prefix keeps
-	// server config and SDK usage consistent.
-	var apiKeys []string
-	if key := NormalizeE2BAPIKey(cfg.APIKey); key != "" {
-		apiKeys = append(apiKeys, key)
-	}
+	// server config and SDK usage consistent. ReplaceAPIKeys can later
+	// union this with tokens from the sandbox-apikeys Secret.
+	apiKeys := normalizeKeyList([]string{cfg.APIKey})
 	registry := cfg.StateStore
 	if registry == nil {
 		registry = newSandboxRegistry()
@@ -329,12 +328,24 @@ func (s *Server) acceptKey(bare string) bool {
 	if bare == "" {
 		return false
 	}
+	s.apiKeysMu.RLock()
+	defer s.apiKeysMu.RUnlock()
 	for _, k := range s.apiKeys {
 		if constantTimeEqual(k, bare) {
 			return true
 		}
 	}
 	return false
+}
+
+// ReplaceAPIKeys atomically replaces the accepted control-plane tokens.
+// Each entry is normalized (trim + strip "e2b_"). Empty input means every
+// control-plane request is rejected with 401 — same as an empty Config.APIKey.
+func (s *Server) ReplaceAPIKeys(keys []string) {
+	normalized := normalizeKeyList(keys)
+	s.apiKeysMu.Lock()
+	s.apiKeys = normalized
+	s.apiKeysMu.Unlock()
 }
 
 func constantTimeEqual(a, b string) bool {

--- a/pkg/sandboxcli/apikey.go
+++ b/pkg/sandboxcli/apikey.go
@@ -115,7 +115,7 @@ func ApiKeyCommand() cli.Command {
 func apiKeyCreateCommand() cli.Command {
 	return cli.Command{
 		Name:      "create",
-		Usage:     "Create a new API key (default TTL 30 days)",
+		Usage:     "Create a new API key (default TTL 30 days). JSON includes key (bare hex) and e2b_key (official e2b SDK apiKey)",
 		ArgsUsage: "<name>",
 		Flags: []cli.Flag{
 			cli.StringFlag{
@@ -149,6 +149,7 @@ func apiKeyCreateCommand() cli.Command {
 			out := map[string]any{
 				"name":       name,
 				"key":        key,
+				"e2b_key":    "e2b_" + key, // official e2b SDK apiKey (validateApiKey /^e2b_[0-9a-f]+$/)
 				"ttl_days":   rec.TTLDays,
 				"created_at": rec.CreatedAt.UTC().Format(time.RFC3339),
 			}

--- a/pkg/sandboxcli/apikey_test.go
+++ b/pkg/sandboxcli/apikey_test.go
@@ -25,3 +25,11 @@ func TestGenerateAPIKeyHexOnly(t *testing.T) {
 		seen[key] = true
 	}
 }
+
+func TestGenerateAPIKeySDKForm(t *testing.T) {
+	sdk := regexp.MustCompile(`^e2b_[0-9a-f]{64}$`)
+	key := generateAPIKey()
+	if got := "e2b_" + key; !sdk.MatchString(got) {
+		t.Fatalf("official SDK apiKey form %q does not match /^e2b_[0-9a-f]{64}$/", got)
+	}
+}

--- a/pkg/server/e2b_embedded.go
+++ b/pkg/server/e2b_embedded.go
@@ -75,8 +75,9 @@ func runEmbeddedE2B(ctx context.Context, cfg config.SandboxConfig, kubeconfig st
 		StateStore:      store,
 	}, sandboxe2b.GatewayFromClient(c))
 
-	applyE2BAPIKeys(ctx, srv, staticKey, kubeconfig)
-	go reloadE2BAPIKeys(ctx, srv, staticKey, kubeconfig)
+	cache := &e2bAPIKeyCache{static: staticKey}
+	applyE2BAPIKeys(ctx, srv, cache, kubeconfig)
+	go reloadE2BAPIKeys(ctx, srv, cache, kubeconfig)
 
 	if err := sandboxe2b.ValidateE2BAPIKey(staticKey); err != nil {
 		logrus.Warnf("e2b (embedded): %v; official e2b SDK clients will not be able to authenticate — generate a hex key with `k8e sandbox-apikey create <name>` (pass the e2b_key field to the SDK)", err)
@@ -98,48 +99,62 @@ func resolveEmbeddedAPIKey(configured string) string {
 	return strings.TrimSpace(os.Getenv("K8E_SANDBOX_APIKEY"))
 }
 
-func applyE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, static string, kubeconfig string) {
+// e2bAPIKeyCache is the last authoritative sandbox-apikeys snapshot. The
+// reload loop must inherit the startup snapshot: otherwise a failed first
+// refresh leaves haveCache=false and an expired boot-time key stays accepted
+// until a later successful Secret read.
+type e2bAPIKeyCache struct {
+	static    string
+	snapshot  sandboxe2b.SecretKeySet
+	haveCache bool
+}
+
+// refresh updates the snapshot when ok, then returns the merged keyring
+// (static + currently-unexpired Secret tokens). apply=false means there is
+// no snapshot yet, so the caller must leave the current keyring alone.
+func (c *e2bAPIKeyCache) refresh(ok bool, set sandboxe2b.SecretKeySet, now time.Time) (keys []string, apply bool) {
+	if ok {
+		c.snapshot = set
+		c.haveCache = true
+	} else if !c.haveCache {
+		return nil, false
+	}
+	return append([]string{c.static}, c.snapshot.Active(now)...), true
+}
+
+func applyE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, cache *e2bAPIKeyCache, kubeconfig string) {
 	set, ok := loadSandboxAPIKeys(ctx, kubeconfig)
-	if !ok {
-		if static == "" {
+	keys, apply := cache.refresh(ok, set, time.Now())
+	if !apply {
+		if cache.static == "" {
 			logrus.Warnf("e2b (embedded): no --e2b-apikey / K8E_SANDBOX_APIKEY and sandbox-apikeys Secret not readable; official e2b SDK control-plane requests will be rejected (401) — run `k8e sandbox-apikey create <name>` and pass the e2b_key field to the SDK")
 		}
 		return
 	}
-	active := set.Active(time.Now())
-	merged := append([]string{static}, active...)
-	srv.ReplaceAPIKeys(merged)
+	srv.ReplaceAPIKeys(keys)
+	active := cache.snapshot.Active(time.Now())
 	switch {
-	case len(active) == 0 && static == "":
+	case len(active) == 0 && cache.static == "":
 		logrus.Warnf("e2b (embedded): no API keys configured; official e2b SDK control-plane requests will be rejected (401) — run `k8e sandbox-apikey create <name>` and pass the e2b_key field to the SDK")
 	case len(active) > 0:
-		logrus.Infof("e2b (embedded): accepting %d key(s) from sandbox-apikeys Secret (plus static=%t)", len(active), static != "")
+		logrus.Infof("e2b (embedded): accepting %d key(s) from sandbox-apikeys Secret (plus static=%t)", len(active), cache.static != "")
 	}
 }
 
-func reloadE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, static string, kubeconfig string) {
+func reloadE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, cache *e2bAPIKeyCache, kubeconfig string) {
 	ticker := time.NewTicker(e2bAPIKeyReload)
 	defer ticker.Stop()
-	var cached sandboxe2b.SecretKeySet // last parsed Secret snapshot (retains expiry)
-	haveCache := false
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			now := time.Now()
-			if set, ok := loadSandboxAPIKeys(ctx, kubeconfig); ok {
-				cached = set
-				haveCache = true
-			} else if !haveCache {
-				continue // nothing cached to re-filter yet; keep current keyring
+			set, ok := loadSandboxAPIKeys(ctx, kubeconfig)
+			keys, apply := cache.refresh(ok, set, time.Now())
+			if !apply {
+				continue
 			}
-			// Re-evaluate expiration against the current time on every tick —
-			// even when the Secret read/parse failed — so an expired key never
-			// stays authenticated just because the Secret became unreadable.
-			active := cached.Active(now)
-			merged := append([]string{static}, active...)
-			srv.ReplaceAPIKeys(merged)
+			srv.ReplaceAPIKeys(keys)
 		}
 	}
 }

--- a/pkg/server/e2b_embedded.go
+++ b/pkg/server/e2b_embedded.go
@@ -100,31 +100,37 @@ func resolveEmbeddedAPIKey(configured string) string {
 }
 
 // e2bAPIKeyCache is the last authoritative sandbox-apikeys snapshot. The
-// reload loop must inherit the startup snapshot: otherwise a failed first
-// refresh leaves haveCache=false and an expired boot-time key stays accepted
-// until a later successful Secret read.
+// reload loop inherits the startup snapshot so the first failed refresh
+// cannot skip replacement and leave boot-time Secret tokens in the keyring.
 type e2bAPIKeyCache struct {
 	static    string
 	snapshot  sandboxe2b.SecretKeySet
 	haveCache bool
 }
 
-// refresh updates the snapshot when ok, then returns the merged keyring
-// (static + currently-unexpired Secret tokens). apply=false means there is
-// no snapshot yet, so the caller must leave the current keyring alone.
-func (c *e2bAPIKeyCache) refresh(ok bool, set sandboxe2b.SecretKeySet, now time.Time) (keys []string, apply bool) {
+// refresh updates the snapshot when ok. On a failed read:
+//   - no snapshot yet → apply=false (leave NewServer's static keyring)
+//   - snapshot present → fail-closed for Secret-backed tokens (they may have
+//     been deleted). Only the static --e2b-apikey remains until a successful
+//     read. Expiry is still filtered via Active on the success path.
+func (c *e2bAPIKeyCache) refresh(ok bool, set sandboxe2b.SecretKeySet, now time.Time) (keys []string, apply, droppedSecret bool) {
 	if ok {
 		c.snapshot = set
 		c.haveCache = true
-	} else if !c.haveCache {
-		return nil, false
+		return append([]string{c.static}, set.Active(now)...), true, false
 	}
-	return append([]string{c.static}, c.snapshot.Active(now)...), true
+	if !c.haveCache {
+		return nil, false, false
+	}
+	droppedSecret = !c.snapshot.Empty()
+	c.snapshot = sandboxe2b.SecretKeySet{}
+	c.haveCache = false
+	return []string{c.static}, true, droppedSecret
 }
 
 func applyE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, cache *e2bAPIKeyCache, kubeconfig string) {
 	set, ok := loadSandboxAPIKeys(ctx, kubeconfig)
-	keys, apply := cache.refresh(ok, set, time.Now())
+	keys, apply, _ := cache.refresh(ok, set, time.Now())
 	if !apply {
 		if cache.static == "" {
 			logrus.Warnf("e2b (embedded): no --e2b-apikey / K8E_SANDBOX_APIKEY and sandbox-apikeys Secret not readable; official e2b SDK control-plane requests will be rejected (401) — run `k8e sandbox-apikey create <name>` and pass the e2b_key field to the SDK")
@@ -150,9 +156,12 @@ func reloadE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, cache *e2bAPI
 			return
 		case <-ticker.C:
 			set, ok := loadSandboxAPIKeys(ctx, kubeconfig)
-			keys, apply := cache.refresh(ok, set, time.Now())
+			keys, apply, droppedSecret := cache.refresh(ok, set, time.Now())
 			if !apply {
 				continue
+			}
+			if droppedSecret {
+				logrus.Warnf("e2b (embedded): sandbox-apikeys Secret unreadable; dropped cached Secret keys so a revoked token cannot stay authorized (static=%t)", cache.static != "")
 			}
 			srv.ReplaceAPIKeys(keys)
 		}
@@ -161,9 +170,8 @@ func reloadE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, cache *e2bAPI
 
 // loadSandboxAPIKeys reads the sandbox-apikeys Secret snapshot.
 // ok=false means the snapshot is not authoritative (transient API error or
-// corrupt payload); the caller must keep the last parsed set and re-filter it
-// for expiry. ok=true with an empty set is a real empty/missing Secret and may
-// replace the keyring.
+// corrupt payload); the caller fail-closes Secret-backed tokens. ok=true with
+// an empty set is a real empty/missing Secret and may replace the keyring.
 func loadSandboxAPIKeys(ctx context.Context, kubeconfig string) (sandboxe2b.SecretKeySet, bool) {
 	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {

--- a/pkg/server/e2b_embedded.go
+++ b/pkg/server/e2b_embedded.go
@@ -3,14 +3,26 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/xiaods/k8e/pkg/daemons/config"
 	"github.com/xiaods/k8e/pkg/sandbox/client"
 	sandboxe2b "github.com/xiaods/k8e/pkg/sandbox/e2b"
+)
+
+const (
+	e2bAPIKeySecretNS   = "sandbox-matrix"
+	e2bAPIKeySecretName = "sandbox-apikeys"
+	e2bAPIKeyReload     = 30 * time.Second
 )
 
 // runEmbeddedE2B starts the KIP-18 E2B-compatible HTTP server inside the
@@ -52,26 +64,118 @@ func runEmbeddedE2B(ctx context.Context, cfg config.SandboxConfig, kubeconfig st
 		logrus.Warnf("e2b (embedded): CRD state store unavailable (%v); using in-memory (single-node semantics)", err)
 	}
 
+	staticKey := resolveEmbeddedAPIKey(cfg.E2BAPIKey)
 	srv := sandboxe2b.NewServer(sandboxe2b.Config{
 		Listen:          cfg.E2BListen,
 		Endpoint:        gatewayAddr,
-		APIKey:          cfg.E2BAPIKey,
+		APIKey:          staticKey,
 		DefaultCPUs:     1,
 		DefaultMemoryMB: 512,
 		DefaultDiskMB:   10 * 1024,
 		StateStore:      store,
 	}, sandboxe2b.GatewayFromClient(c))
 
-	if cfg.E2BAPIKey == "" {
-		logrus.Warnf("e2b (embedded): no --e2b-apikey configured; control-plane requests from the official e2b SDK will be rejected (401) — set K8E_E2B_APIKEY to a hex token (k8e sandbox-apikey create) and pass e2b_+token to the SDK")
-	} else if err := sandboxe2b.ValidateE2BAPIKey(cfg.E2BAPIKey); err != nil {
-		logrus.Warnf("e2b (embedded): %v; official e2b SDK clients will not be able to authenticate — generate a hex key with `k8e sandbox-apikey create <name>` and set K8E_E2B_APIKEY to it", err)
+	applyE2BAPIKeys(ctx, srv, staticKey, kubeconfig)
+	go reloadE2BAPIKeys(ctx, srv, staticKey, kubeconfig)
+
+	if err := sandboxe2b.ValidateE2BAPIKey(staticKey); err != nil {
+		logrus.Warnf("e2b (embedded): %v; official e2b SDK clients will not be able to authenticate — generate a hex key with `k8e sandbox-apikey create <name>` (pass the e2b_key field to the SDK)", err)
 	}
 
 	logrus.Infof("e2b (embedded): serving on %s via gateway %s (Gateway API fronted; state=%T)", cfg.E2BListen, gatewayAddr, store)
 	if err := srv.Start(ctx); err != nil && ctx.Err() == nil {
 		logrus.Errorf("e2b (embedded): %v", err)
 	}
+}
+
+// resolveEmbeddedAPIKey prefers --e2b-apikey / K8E_E2B_APIKEY, then the
+// shared sandbox CLI env K8E_SANDBOX_APIKEY so a single exported key works
+// for `k8e sandbox`, standalone e2b-server, and the embedded surface.
+func resolveEmbeddedAPIKey(configured string) string {
+	if key := strings.TrimSpace(configured); key != "" {
+		return key
+	}
+	return strings.TrimSpace(os.Getenv("K8E_SANDBOX_APIKEY"))
+}
+
+func applyE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, static string, kubeconfig string) {
+	set, ok := loadSandboxAPIKeys(ctx, kubeconfig)
+	if !ok {
+		if static == "" {
+			logrus.Warnf("e2b (embedded): no --e2b-apikey / K8E_SANDBOX_APIKEY and sandbox-apikeys Secret not readable; official e2b SDK control-plane requests will be rejected (401) — run `k8e sandbox-apikey create <name>` and pass the e2b_key field to the SDK")
+		}
+		return
+	}
+	active := set.Active(time.Now())
+	merged := append([]string{static}, active...)
+	srv.ReplaceAPIKeys(merged)
+	switch {
+	case len(active) == 0 && static == "":
+		logrus.Warnf("e2b (embedded): no API keys configured; official e2b SDK control-plane requests will be rejected (401) — run `k8e sandbox-apikey create <name>` and pass the e2b_key field to the SDK")
+	case len(active) > 0:
+		logrus.Infof("e2b (embedded): accepting %d key(s) from sandbox-apikeys Secret (plus static=%t)", len(active), static != "")
+	}
+}
+
+func reloadE2BAPIKeys(ctx context.Context, srv *sandboxe2b.Server, static string, kubeconfig string) {
+	ticker := time.NewTicker(e2bAPIKeyReload)
+	defer ticker.Stop()
+	var cached sandboxe2b.SecretKeySet // last parsed Secret snapshot (retains expiry)
+	haveCache := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			if set, ok := loadSandboxAPIKeys(ctx, kubeconfig); ok {
+				cached = set
+				haveCache = true
+			} else if !haveCache {
+				continue // nothing cached to re-filter yet; keep current keyring
+			}
+			// Re-evaluate expiration against the current time on every tick —
+			// even when the Secret read/parse failed — so an expired key never
+			// stays authenticated just because the Secret became unreadable.
+			active := cached.Active(now)
+			merged := append([]string{static}, active...)
+			srv.ReplaceAPIKeys(merged)
+		}
+	}
+}
+
+// loadSandboxAPIKeys reads the sandbox-apikeys Secret snapshot.
+// ok=false means the snapshot is not authoritative (transient API error or
+// corrupt payload); the caller must keep the last parsed set and re-filter it
+// for expiry. ok=true with an empty set is a real empty/missing Secret and may
+// replace the keyring.
+func loadSandboxAPIKeys(ctx context.Context, kubeconfig string) (sandboxe2b.SecretKeySet, bool) {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return sandboxe2b.SecretKeySet{}, false
+	}
+	k8s, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return sandboxe2b.SecretKeySet{}, false
+	}
+	secret, err := k8s.CoreV1().Secrets(e2bAPIKeySecretNS).Get(ctx, e2bAPIKeySecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return sandboxe2b.SecretKeySet{}, true
+	}
+	if err != nil {
+		logrus.Debugf("e2b (embedded): sandbox-apikeys Secret: %v", err)
+		return sandboxe2b.SecretKeySet{}, false
+	}
+	data, exists := secret.Data["keys.json"]
+	if !exists {
+		return sandboxe2b.SecretKeySet{}, true
+	}
+	parsed, err := sandboxe2b.ParseSecretKeys(data)
+	if err != nil {
+		logrus.Warnf("e2b (embedded): sandbox-apikeys keys.json corrupted: %v", err)
+		return sandboxe2b.SecretKeySet{}, false
+	}
+	return parsed, true
 }
 
 // newEmbeddedStateStore builds the CRD-backed E2B state store for the

--- a/pkg/server/e2b_embedded_test.go
+++ b/pkg/server/e2b_embedded_test.go
@@ -88,50 +88,80 @@ func mustParseSecretKeys(t *testing.T, records map[string]apikey.Record) sandbox
 	return set
 }
 
-// TestE2BAPIKeyCacheStartupSnapshotUsedOnFailedRefresh is the Greptile
-// finding: reload must inherit the startup Secret snapshot. A failed first
-// refresh after boot still re-filters expiry, so a key that expired after
-// applyE2BAPIKeys cannot stay authorized until a later successful read.
-func TestE2BAPIKeyCacheStartupSnapshotUsedOnFailedRefresh(t *testing.T) {
+// TestE2BAPIKeyCacheFailedRefreshDropsSecretKeys is the Greptile finding:
+// a deleted unexpired Secret token must not stay authorized while later
+// Secret reads fail. Failed refresh fail-closes Secret-backed keys and
+// keeps only the static token.
+func TestE2BAPIKeyCacheFailedRefreshDropsSecretKeys(t *testing.T) {
 	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
 	t0 := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
-	shortExp := t0.Add(10 * time.Minute)
-	longExp := t0.Add(30 * 24 * time.Hour)
 	set := mustParseSecretKeys(t, map[string]apikey.Record{
-		"short": {Key: "deadbeef", CreatedAt: t0, ExpiresAt: &shortExp, TTLDays: 1},
-		"long":  {Key: hex, CreatedAt: t0, ExpiresAt: &longExp, TTLDays: 30},
+		"live": {Key: hex, CreatedAt: t0}, // never-expire — revocation, not TTL
 	})
 
-	cache := &e2bAPIKeyCache{}
-	keys, apply := cache.refresh(true, set, t0) // startup Secret read succeeds
-	if !apply {
-		t.Fatal("startup snapshot must install")
+	cache := &e2bAPIKeyCache{static: "static"}
+	keys, apply, dropped := cache.refresh(true, set, t0)
+	if !apply || dropped {
+		t.Fatalf("startup snapshot: apply=%v dropped=%v", apply, dropped)
 	}
-	if !containsKey(keys, "deadbeef") || !containsKey(keys, hex) {
-		t.Fatalf("both keys live at boot; got %v", keys)
+	if !containsKey(keys, hex) || !containsKey(keys, "static") {
+		t.Fatalf("boot keyring; got %v", keys)
 	}
 	if !cache.haveCache {
-		t.Fatal("startup snapshot must seed haveCache for the reload loop")
+		t.Fatal("startup snapshot must seed haveCache so the first failed refresh can fail-close")
 	}
 
-	later := shortExp.Add(time.Hour)
-	keys, apply = cache.refresh(false, sandboxe2b.SecretKeySet{}, later) // first reload fails
+	keys, apply, dropped = cache.refresh(false, sandboxe2b.SecretKeySet{}, t0.Add(time.Second))
 	if !apply {
-		t.Fatal("failed first refresh must still apply using the startup snapshot")
+		t.Fatal("failed refresh after a snapshot must apply (fail-close), not skip")
+	}
+	if !dropped {
+		t.Fatal("failed refresh must report dropped Secret keys")
+	}
+	if containsKey(keys, hex) {
+		t.Errorf("revoked Secret token must not survive a failed read; got %v", keys)
+	}
+	if !containsKey(keys, "static") {
+		t.Errorf("static --e2b-apikey must remain; got %v", keys)
+	}
+	if cache.haveCache {
+		t.Fatal("fail-close must clear haveCache so later failed ticks leave the static-only keyring")
+	}
+
+	keys, apply, dropped = cache.refresh(false, sandboxe2b.SecretKeySet{}, t0.Add(2*time.Second))
+	if apply || dropped {
+		t.Fatalf("second failed refresh: want apply=false dropped=false, got keys=%v apply=%v dropped=%v", keys, apply, dropped)
+	}
+}
+
+func TestE2BAPIKeyCacheFailedRefreshThenRecovers(t *testing.T) {
+	t0 := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	first := mustParseSecretKeys(t, map[string]apikey.Record{
+		"old": {Key: "deadbeef", CreatedAt: t0},
+	})
+	second := mustParseSecretKeys(t, map[string]apikey.Record{
+		"new": {Key: "cafebabe", CreatedAt: t0},
+	})
+	cache := &e2bAPIKeyCache{static: "static"}
+	cache.refresh(true, first, t0)
+	cache.refresh(false, sandboxe2b.SecretKeySet{}, t0.Add(time.Second))
+	keys, apply, dropped := cache.refresh(true, second, t0.Add(2*time.Second))
+	if !apply || dropped {
+		t.Fatalf("recovering read: apply=%v dropped=%v", apply, dropped)
 	}
 	if containsKey(keys, "deadbeef") {
-		t.Errorf("expired boot-time key must be dropped on failed refresh; got %v", keys)
+		t.Errorf("recovered snapshot must not restore the revoked key; got %v", keys)
 	}
-	if !containsKey(keys, hex) {
-		t.Errorf("unexpired boot-time key must survive; got %v", keys)
+	if !containsKey(keys, "cafebabe") || !containsKey(keys, "static") {
+		t.Errorf("new snapshot + static; got %v", keys)
 	}
 }
 
 func TestE2BAPIKeyCacheNoSnapshotKeepsCurrentKeyring(t *testing.T) {
 	cache := &e2bAPIKeyCache{static: "static-hex"}
-	keys, apply := cache.refresh(false, sandboxe2b.SecretKeySet{}, time.Now())
-	if apply {
-		t.Fatalf("no snapshot: want apply=false so NewServer static keyring is kept, got keys=%v", keys)
+	keys, apply, dropped := cache.refresh(false, sandboxe2b.SecretKeySet{}, time.Now())
+	if apply || dropped {
+		t.Fatalf("no snapshot: want apply=false so NewServer static keyring is kept, got keys=%v apply=%v dropped=%v", keys, apply, dropped)
 	}
 }
 
@@ -144,13 +174,13 @@ func TestE2BAPIKeyCacheSuccessfulReloadReplacesSnapshot(t *testing.T) {
 		"new": {Key: "cafebabe", CreatedAt: t0},
 	})
 	cache := &e2bAPIKeyCache{static: "static"}
-	keys, _ := cache.refresh(true, first, t0)
+	keys, _, _ := cache.refresh(true, first, t0)
 	if !containsKey(keys, "deadbeef") || !containsKey(keys, "static") {
 		t.Fatalf("first snapshot: got %v", keys)
 	}
-	keys, apply := cache.refresh(true, second, t0)
-	if !apply {
-		t.Fatal("successful reload must apply")
+	keys, apply, dropped := cache.refresh(true, second, t0)
+	if !apply || dropped {
+		t.Fatalf("successful reload must apply without dropping; apply=%v dropped=%v", apply, dropped)
 	}
 	if containsKey(keys, "deadbeef") {
 		t.Errorf("replaced snapshot must drop revoked key; got %v", keys)

--- a/pkg/server/e2b_embedded_test.go
+++ b/pkg/server/e2b_embedded_test.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/xiaods/k8e/pkg/daemons/config"
+	"github.com/xiaods/k8e/pkg/sandbox/apikey"
+	sandboxe2b "github.com/xiaods/k8e/pkg/sandbox/e2b"
 )
 
 // TestSandboxConfigCarriesDisableE2B pins the KIP-18 final architecture
@@ -61,4 +64,98 @@ func TestResolveEmbeddedAPIKey(t *testing.T) {
 			t.Fatalf("got %q want empty", got)
 		}
 	})
+}
+
+func containsKey(keys []string, want string) bool {
+	for _, k := range keys {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+func mustParseSecretKeys(t *testing.T, records map[string]apikey.Record) sandboxe2b.SecretKeySet {
+	t.Helper()
+	data, err := apikey.Encode(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	set, err := sandboxe2b.ParseSecretKeys(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return set
+}
+
+// TestE2BAPIKeyCacheStartupSnapshotUsedOnFailedRefresh is the Greptile
+// finding: reload must inherit the startup Secret snapshot. A failed first
+// refresh after boot still re-filters expiry, so a key that expired after
+// applyE2BAPIKeys cannot stay authorized until a later successful read.
+func TestE2BAPIKeyCacheStartupSnapshotUsedOnFailedRefresh(t *testing.T) {
+	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
+	t0 := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	shortExp := t0.Add(10 * time.Minute)
+	longExp := t0.Add(30 * 24 * time.Hour)
+	set := mustParseSecretKeys(t, map[string]apikey.Record{
+		"short": {Key: "deadbeef", CreatedAt: t0, ExpiresAt: &shortExp, TTLDays: 1},
+		"long":  {Key: hex, CreatedAt: t0, ExpiresAt: &longExp, TTLDays: 30},
+	})
+
+	cache := &e2bAPIKeyCache{}
+	keys, apply := cache.refresh(true, set, t0) // startup Secret read succeeds
+	if !apply {
+		t.Fatal("startup snapshot must install")
+	}
+	if !containsKey(keys, "deadbeef") || !containsKey(keys, hex) {
+		t.Fatalf("both keys live at boot; got %v", keys)
+	}
+	if !cache.haveCache {
+		t.Fatal("startup snapshot must seed haveCache for the reload loop")
+	}
+
+	later := shortExp.Add(time.Hour)
+	keys, apply = cache.refresh(false, sandboxe2b.SecretKeySet{}, later) // first reload fails
+	if !apply {
+		t.Fatal("failed first refresh must still apply using the startup snapshot")
+	}
+	if containsKey(keys, "deadbeef") {
+		t.Errorf("expired boot-time key must be dropped on failed refresh; got %v", keys)
+	}
+	if !containsKey(keys, hex) {
+		t.Errorf("unexpired boot-time key must survive; got %v", keys)
+	}
+}
+
+func TestE2BAPIKeyCacheNoSnapshotKeepsCurrentKeyring(t *testing.T) {
+	cache := &e2bAPIKeyCache{static: "static-hex"}
+	keys, apply := cache.refresh(false, sandboxe2b.SecretKeySet{}, time.Now())
+	if apply {
+		t.Fatalf("no snapshot: want apply=false so NewServer static keyring is kept, got keys=%v", keys)
+	}
+}
+
+func TestE2BAPIKeyCacheSuccessfulReloadReplacesSnapshot(t *testing.T) {
+	t0 := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	first := mustParseSecretKeys(t, map[string]apikey.Record{
+		"old": {Key: "deadbeef", CreatedAt: t0},
+	})
+	second := mustParseSecretKeys(t, map[string]apikey.Record{
+		"new": {Key: "cafebabe", CreatedAt: t0},
+	})
+	cache := &e2bAPIKeyCache{static: "static"}
+	keys, _ := cache.refresh(true, first, t0)
+	if !containsKey(keys, "deadbeef") || !containsKey(keys, "static") {
+		t.Fatalf("first snapshot: got %v", keys)
+	}
+	keys, apply := cache.refresh(true, second, t0)
+	if !apply {
+		t.Fatal("successful reload must apply")
+	}
+	if containsKey(keys, "deadbeef") {
+		t.Errorf("replaced snapshot must drop revoked key; got %v", keys)
+	}
+	if !containsKey(keys, "cafebabe") || !containsKey(keys, "static") {
+		t.Errorf("new snapshot + static; got %v", keys)
+	}
 }

--- a/pkg/server/e2b_embedded_test.go
+++ b/pkg/server/e2b_embedded_test.go
@@ -34,3 +34,31 @@ func TestRunEmbeddedE2BListenDefault(t *testing.T) {
 		t.Fatalf("default E2BListen = %q, want 0.0.0.0:3676 (cluster-reachable)", cfg.E2BListen)
 	}
 }
+
+func TestResolveEmbeddedAPIKey(t *testing.T) {
+	hex := "849a5302e66f98d1d5064ef8501703574af4053b7bf9cf5337f9533326ce2bc9"
+	t.Run("configured wins", func(t *testing.T) {
+		t.Setenv("K8E_SANDBOX_APIKEY", "from-env")
+		if got := resolveEmbeddedAPIKey(hex); got != hex {
+			t.Fatalf("got %q want configured", got)
+		}
+	})
+	t.Run("falls back to K8E_SANDBOX_APIKEY", func(t *testing.T) {
+		t.Setenv("K8E_SANDBOX_APIKEY", hex)
+		if got := resolveEmbeddedAPIKey(""); got != hex {
+			t.Fatalf("got %q want env", got)
+		}
+	})
+	t.Run("trims whitespace", func(t *testing.T) {
+		t.Setenv("K8E_SANDBOX_APIKEY", "")
+		if got := resolveEmbeddedAPIKey("  " + hex + "  "); got != hex {
+			t.Fatalf("got %q", got)
+		}
+	})
+	t.Run("all empty", func(t *testing.T) {
+		t.Setenv("K8E_SANDBOX_APIKEY", "")
+		if got := resolveEmbeddedAPIKey(""); got != "" {
+			t.Fatalf("got %q want empty", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The embedded E2B server only accepted a static `--e2b-apikey`, so operators had to configure the same key twice (gRPC gateway's `sandbox-apikeys` Secret + the e2b surface) for official e2b SDK clients to authenticate. This unifies the keyring:

- **Secret loading**: the embedded server now loads active tokens from the `sandbox-apikeys` Secret (same store the gRPC gateway validates), unions them with the static `--e2b-apikey` / `K8E_E2B_APIKEY` / `K8E_SANDBOX_APIKEY` fallback, and **reloads every 30s**. `k8e sandbox-apikey create <name>` alone is enough — no separate `--e2b-apikey`.
- **`e2b_key` output**: `k8e sandbox-apikey create` now emits an `e2b_key` field (`e2b_` + hex) ready to paste into the SDK as `apiKey`. The SDK's `validateApiKey` (`/^e2b_[0-9a-f]+$/`) rejects a bare hex token before any request.
- **Atomic keyring**: `ReplaceAPIKeys` + RWMutex so live rotation never tears the keyring mid-request.
- KIP-18 doc updated.

## Verification

```
go build ./pkg/...
go vet   ./pkg/sandbox/e2b/... ./pkg/sandboxcli/... ./pkg/server/...
go test  ./pkg/sandbox/e2b/... ./pkg/sandboxcli/... ./pkg/server/...
staticcheck / gocyclo: no new issues
```

All green.

## Notes

- One commit (`fa8174b7`), 10 files (+361 / −43).
- Work originally produced by grok; consolidated into this PR.
