### PR TITLE
perf(sandbox, dsh): persistent gRPC transport for fs/exec + fast-fail deadlines

### DIFF
--- a/pkg/sandbox/client/client.go
+++ b/pkg/sandbox/client/client.go
@@ -604,6 +604,16 @@ func dialErr(endpoint string, err error) error {
 	case strings.Contains(msg, "certificate required"),
 		strings.Contains(msg, "bad certificate"):
 		return fmt.Errorf("sandbox client: dial %s: %w\n  hint: client cert rejected — re-run login/connect with --apikey", endpoint, err)
+	case strings.Contains(msg, "EOF"), strings.Contains(msg, "connection reset"), strings.Contains(msg, "connection closed"):
+		// EOF during the TLS handshake almost always means the gateway closed
+		// the connection: it is not running on the endpoint, the port is
+		// firewalled, or the cached CA/client cert belongs to a previous CA
+		// generation (server CA rotated). All three resolve by re-bootstrapping.
+		cacheHint, _ := sandboxCacheDir()
+		if cacheHint == "" {
+			cacheHint = "~/.k8e/sandbox"
+		}
+		return fmt.Errorf("sandbox client: dial %s: %w\n  hint: gateway closed the TLS handshake (EOF) — verify the gateway is running and reachable, then re-run connect/login with --apikey (remove %s/ca.crt if the server CA rotated)", endpoint, err, cacheHint)
 	default:
 		return fmt.Errorf("sandbox client: dial %s: %w", endpoint, err)
 	}

--- a/pkg/sandboxmatrix/grpc/env_test.go
+++ b/pkg/sandboxmatrix/grpc/env_test.go
@@ -424,6 +424,63 @@ func TestListFiles_ForwardsSince(t *testing.T) {
 	}
 }
 
+// TestListFiles_EntryFacts verifies the gateway maps sandboxd's per-entry
+// type/size into the ListFiles RPC (dir→directory normalization, symlink
+// passthrough; old sandboxd without type/size leaves them unset).
+func TestListFiles_EntryFacts(t *testing.T) {
+	s := newTestServer()
+	ctx := context.Background()
+	mustCreateSession(t, s.orch, "list-facts")
+	stubSessionPodIP(ctx, t, s.orch, "list-facts", "127.0.0.1")
+
+	old := sandboxdClient
+	defer func() { sandboxdClient = old }()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files/list" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"files":[
+			{"path":"/workspace/a.txt","modified":1,"type":"file","size":42},
+			{"path":"/workspace/sub","modified":2,"type":"dir","size":4096},
+			{"path":"/workspace/link","modified":3,"type":"symlink","size":10},
+			{"path":"/workspace/legacy","modified":4}
+		]}`))
+	}))
+	ln, err := net.Listen("tcp", "127.0.0.1:2024")
+	if err != nil {
+		t.Fatalf("bind 2024: %v", err)
+	}
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+	sandboxdClient = &http.Client{}
+
+	resp, err := s.ListFiles(ctx, &pb.ListFilesRequest{SessionId: "list-facts"})
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	if len(resp.Files) != 4 {
+		t.Fatalf("unexpected files: %+v", resp.Files)
+	}
+	byPath := map[string]*pb.FileEntry{}
+	for _, f := range resp.Files {
+		byPath[f.Path] = f
+	}
+	if f := byPath["/workspace/a.txt"]; f.Type != "file" || f.Size != 42 {
+		t.Errorf("file entry: %+v", f)
+	}
+	if f := byPath["/workspace/sub"]; f.Type != "directory" || f.Size != 4096 {
+		t.Errorf("dir entry normalized: %+v", f)
+	}
+	if f := byPath["/workspace/link"]; f.Type != "symlink" || f.Size != 10 {
+		t.Errorf("symlink entry: %+v", f)
+	}
+	if f := byPath["/workspace/legacy"]; f.Type != "" || f.Size != 0 {
+		t.Errorf("legacy entry must stay unset: %+v", f)
+	}
+}
+
 // TestSandboxMetricsCollector verifies the Prometheus collector surfaces the
 // orchestrator's counters at scrape time (KIP-16 M5).
 func TestSandboxMetricsCollector(t *testing.T) {

--- a/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
+++ b/pkg/sandboxmatrix/grpc/pb/sandbox/v1/sandbox.pb.go
@@ -1326,9 +1326,14 @@ func (x *ListFilesResponse) GetFiles() []*FileEntry {
 }
 
 type FileEntry struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	Modified      int64                  `protobuf:"varint,2,opt,name=modified,proto3" json:"modified,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Path     string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Modified int64                  `protobuf:"varint,2,opt,name=modified,proto3" json:"modified,omitempty"`
+	// Entry type (file/dir/symlink/other) and size carried by the single
+	// ListFiles RPC so clients can build a directory listing without a
+	// per-entry stat round trip (KIP-20 perf).
+	Type          string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	Size          int64  `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1373,6 +1378,20 @@ func (x *FileEntry) GetPath() string {
 func (x *FileEntry) GetModified() int64 {
 	if x != nil {
 		return x.Modified
+	}
+	return 0
+}
+
+func (x *FileEntry) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *FileEntry) GetSize() int64 {
+	if x != nil {
+		return x.Size
 	}
 	return 0
 }
@@ -3658,10 +3677,12 @@ const file_sandbox_v1_sandbox_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x14\n" +
 	"\x05since\x18\x02 \x01(\x03R\x05since\"@\n" +
 	"\x11ListFilesResponse\x12+\n" +
-	"\x05files\x18\x01 \x03(\v2\x15.sandbox.v1.FileEntryR\x05files\";\n" +
+	"\x05files\x18\x01 \x03(\v2\x15.sandbox.v1.FileEntryR\x05files\"c\n" +
 	"\tFileEntry\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1a\n" +
-	"\bmodified\x18\x02 \x01(\x03R\bmodified\"N\n" +
+	"\bmodified\x18\x02 \x01(\x03R\bmodified\x12\x12\n" +
+	"\x04type\x18\x03 \x01(\tR\x04type\x12\x12\n" +
+	"\x04size\x18\x04 \x01(\x03R\x04size\"N\n" +
 	"\x11PipInstallRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1a\n" +

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -653,12 +653,27 @@ func (s *Server) ListFiles(ctx context.Context, req *pb.ListFilesRequest) (*pb.L
 		Files []struct {
 			Path     string `json:"path"`
 			Modified int64  `json:"modified"`
+			Type     string `json:"type"`
+			Size     int64  `json:"size"`
 		} `json:"files"`
 	}
 	json.NewDecoder(resp.Body).Decode(&result)
 	entries := make([]*pb.FileEntry, len(result.Files))
 	for i, f := range result.Files {
-		entries[i] = &pb.FileEntry{Path: f.Path, Modified: f.Modified}
+		// sandboxd reports dirs as "dir"; the client vocabulary is "directory"
+		// (dsh FsInfo). Old sandboxd omits type/size entirely — leave them unset
+		// and let clients fall back to per-entry stat.
+		e := &pb.FileEntry{Path: f.Path, Modified: f.Modified}
+		switch f.Type {
+		case "file", "symlink", "other":
+			e.Type = f.Type
+		case "dir":
+			e.Type = "directory"
+		}
+		if f.Type != "" {
+			e.Size = f.Size
+		}
+		entries[i] = e
 	}
 	return &pb.ListFilesResponse{Files: entries}, nil
 }

--- a/pkg/sandboxmatrix/grpc/tls_loop_test.go
+++ b/pkg/sandboxmatrix/grpc/tls_loop_test.go
@@ -1,0 +1,107 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/xiaods/k8e/pkg/sandbox/client"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+)
+
+// freePort reserves an ephemeral port by binding :0 and closing; good enough
+// for tests (Start re-checks liveness before binding).
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+func waitForPort(t *testing.T, port int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("gateway did not start listening on %d", port)
+}
+
+// TestTLSGatewayLoop verifies the full mTLS bootstrap + status path over a
+// real gateway: server issues its sandbox CA + server cert, the client
+// bootstraps via Login (insecure) with an API key, then dials with mTLS and
+// the availability probe (DestroySession noop → NotFound) succeeds. This is
+// the exact path `k8e sandbox status` exercises; a regression here means the
+// gateway handshake (currently EOF on remote AWS) is broken server-side.
+func TestTLSGatewayLoop(t *testing.T) {
+	certDir := t.TempDir()
+	o := newTestOrchestrator()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Seed the sandbox-apikeys Secret so Login can authenticate (legacy flat format).
+	keysJSON := []byte(`{"tls-test":"tls-test-key"}`)
+	if _, err := o.k8s.CoreV1().Secrets(apiKeySecretNS).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: apiKeySecretName, Namespace: apiKeySecretNS},
+		Data:       map[string][]byte{"keys.json": keysJSON},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed api key secret: %v", err)
+	}
+
+	port := freePort(t)
+	srv := NewServer(ServerConfig{
+		K8s:               o.k8s,
+		Dyn:               o.dynamic,
+		CACertFile:        filepath.Join(certDir, "ca.crt"),
+		CAKeyFile:         filepath.Join(certDir, "ca.key"),
+		ServerCertFile:    filepath.Join(certDir, "server.crt"),
+		ServerKeyFile:     filepath.Join(certDir, "server.key"),
+		GRPCPort:          port,
+		LocalAuth:         false,
+		AdvertiseHostname: "localhost",
+	})
+	startErr := make(chan error, 1)
+	go func() { startErr <- srv.Start(ctx) }()
+	waitForPort(t, port)
+	defer func() {
+		cancel()
+		select {
+		case <-startErr:
+		case <-time.After(5 * time.Second):
+			t.Error("gateway did not stop after cancel")
+		}
+	}()
+
+	// Client bootstrap into an isolated cert dir (never touch ~/.k8e/sandbox).
+	t.Setenv("K8E_SANDBOX_CERT_DIR", filepath.Join(certDir, "client"))
+	c, err := client.NewClientWithEndpoint(fmt.Sprintf("127.0.0.1:%d", port), "tls-test-key")
+	if err != nil {
+		t.Fatalf("client bootstrap: %v", err)
+	}
+	defer c.Close()
+
+	// Availability probe — the exact shape `k8e sandbox status` uses: the
+	// gateway answers (handshake + auth complete) and the noop destroy fails
+	// only because the session does not exist. The CLI treats the
+	// "not found" text as a healthy gateway (errSessionNotFound).
+	_, err = c.SandboxServiceClient.DestroySession(ctx, &pb.DestroySessionRequest{SessionId: "healthcheck-probe-noop"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("status probe: expected session-not-found response, got %v — gateway TLS handshake broken", err)
+	}
+}

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/index.tsx
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/index.tsx
@@ -20,6 +20,10 @@ const zh = {
   'status.connected': '已连接',
   'status.noGrpc': '未配置 gRPC（终端需要显式 endpoint）',
   'status.cwd': '工作目录',
+  'status.endpointFromProfile': 'connect 地址自动发现自 ~/.k8e/sandbox/profiles.yaml',
+  'status.endpointFromEnv': 'connect 地址来自环境变量 K8E_SANDBOX_ENDPOINT',
+  'status.endpointFromConfig': 'connect 地址来自 dsh profile 的 dsh-k8e-sandbox 配置',
+  'status.noEndpointHint': '未发现 connect 地址 — 运行 k8e sandbox connect --endpoint <addr> --apikey <key> 生成 ~/.k8e/sandbox/profiles.yaml 后重启 dsh',
   'prefs.heading': '终端偏好',
   'prefs.rows': '行数',
   'prefs.cols': '列数',
@@ -27,7 +31,7 @@ const zh = {
   'actions.openTerminal': '打开终端',
   'actions.save': '保存',
   'actions.saved': '已保存',
-  'hint.hostConfig': 'endpoint / runtimeClass 等部署级配置在 profile 的 dsh-k8e-sandbox 行里设置。',
+  'hint.hostConfig': 'endpoint 未显式配置时，插件会自动从 ~/.k8e/sandbox/profiles.yaml 发现（KIP-17）；runtimeClass 等其余配置在 dsh-k8e-sandbox 行里设置。',
 } as const
 
 const en: Record<keyof typeof zh, string> = {
@@ -37,6 +41,10 @@ const en: Record<keyof typeof zh, string> = {
   'status.connected': 'Connected',
   'status.noGrpc': 'gRPC not configured (terminal needs an explicit endpoint)',
   'status.cwd': 'Working directory',
+  'status.endpointFromProfile': 'Connect address auto-discovered from ~/.k8e/sandbox/profiles.yaml',
+  'status.endpointFromEnv': 'Connect address from env K8E_SANDBOX_ENDPOINT',
+  'status.endpointFromConfig': 'Connect address from the dsh-k8e-sandbox profile row',
+  'status.noEndpointHint': 'No connect address found — run k8e sandbox connect --endpoint <addr> --apikey <key> to generate ~/.k8e/sandbox/profiles.yaml, then restart dsh',
   'prefs.heading': 'Terminal preferences',
   'prefs.rows': 'Rows',
   'prefs.cols': 'Columns',
@@ -44,7 +52,7 @@ const en: Record<keyof typeof zh, string> = {
   'actions.openTerminal': 'Open terminal',
   'actions.save': 'Save',
   'actions.saved': 'Saved',
-  'hint.hostConfig': 'Deploy-level config (endpoint / runtimeClass) lives in the dsh-k8e-sandbox profile row.',
+  'hint.hostConfig': 'When endpoint is not configured explicitly, the plugin auto-discovers it from ~/.k8e/sandbox/profiles.yaml (KIP-17); other deploy config (runtimeClass) lives in the dsh-k8e-sandbox profile row.',
 }
 
 /** Client services required before activation. */

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/settings-section.tsx
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client-ui/src/client/settings-section.tsx
@@ -18,6 +18,8 @@ interface Status {
   grpcAvailable: boolean
   cwd?: string
   endpoint?: string
+  endpointSource?: 'config' | 'env' | 'profile'
+  endpointProfile?: string
   runtimeClass?: string
 }
 
@@ -111,6 +113,16 @@ export function K8eSettingsSection(props: K8eSettingsSectionProps): ReactNode {
 
   const connected = status?.grpcAvailable === true
 
+  // Where the connect address came from (KIP-17 auto-discovery).
+  let endpointLabel = ''
+  if (status?.endpointSource === 'profile') {
+    endpointLabel = t('status.endpointFromProfile') + (status.endpointProfile !== undefined ? `（profile: ${status.endpointProfile}）` : '')
+  } else if (status?.endpointSource === 'env') {
+    endpointLabel = t('status.endpointFromEnv')
+  } else if (status?.endpointSource === 'config') {
+    endpointLabel = t('status.endpointFromConfig')
+  }
+
   return createElement('div', { style: { maxWidth: '560px' } },
     createElement('h3', { style: { margin: '0 0 14px', fontSize: '16px', color: 'var(--dsw-alias-label-primary, #eee)' } },
       t('section.title')),
@@ -133,6 +145,14 @@ export function K8eSettingsSection(props: K8eSettingsSectionProps): ReactNode {
       status?.runtimeClass !== undefined
         ? createElement('div', { style: { fontSize: '13px', color: 'var(--dsw-alias-label-secondary, #999)' } },
           'runtimeClass: ' + status.runtimeClass)
+        : null,
+      status?.endpoint !== undefined && status.endpoint !== ''
+        ? createElement('div', { style: { fontSize: '12px', color: 'var(--dsw-alias-label-secondary, #999)', marginTop: '8px' } },
+          endpointLabel)
+        : null,
+      status?.endpoint === undefined || status.endpoint === ''
+        ? createElement('div', { style: { fontSize: '12px', color: '#e5a50a', marginTop: '8px' } },
+          t('status.noEndpointHint'))
         : null,
       createElement('div', { style: { fontSize: '12px', color: 'var(--dsw-alias-label-secondary, #999)', marginTop: '10px' } },
         t('hint.hostConfig')),

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/proto/sandbox.proto
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/proto/sandbox.proto
@@ -145,7 +145,15 @@ message ListFilesRequest  {
   int64  since      = 2;
 }
 message ListFilesResponse { repeated FileEntry files = 1; }
-message FileEntry         { string path = 1; int64 modified = 2; }
+message FileEntry {
+  string path     = 1;
+  int64  modified = 2;
+  // Entry type (file/dir/symlink/other) and size carried by the single
+  // ListFiles RPC so clients can build a directory listing without a
+  // per-entry stat round trip (KIP-20 perf).
+  string type = 3;
+  int64  size = 4;
+}
 
 message PipInstallRequest  { string session_id = 1; repeated string packages = 2; }
 message PipInstallResponse { string output = 1; int32 exit_code = 2; }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -12,6 +12,27 @@
  * @module @k8e-sandbox/dsh-k8e-sandbox-client/grpc
  */
 
+// Op shapes shared with the CLI-backed transport live in the main entry
+// (./index.ts); re-export them here so the gRPC surface stays type-identical
+// with the CLI surface without duplicating the declarations.
+import type {
+  BackgroundResult,
+  CreateSessionOptions,
+  ExecResult,
+  FileEntry,
+  PollResult,
+  RunOptions,
+  StatusResult,
+} from './index.ts'
+export type {
+  BackgroundResult,
+  CreateSessionOptions,
+  ExecResult,
+  FileEntry,
+  PollResult,
+  RunOptions,
+  StatusResult,
+} from './index.ts'
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -48,56 +69,6 @@ export interface ExecStreamResult {
 export interface ExecSSEEvent {
   data?: string
   exit?: number
-}
-
-// ── Shared op shapes (mirror @k8e-sandbox/dsh-k8e-sandbox-client) ────────────
-
-export interface ExecResult {
-  stdout: string
-  stderr: string
-  exitCode: number
-  sessionId: string
-  status: string
-  durationMs: number
-  truncated: boolean
-  language: string
-}
-
-export interface BackgroundResult {
-  runId: string
-  status: string
-  sessionId: string
-}
-
-export interface PollResult {
-  runId: string
-  status: string
-  stdout: string
-  stderr: string
-  exitCode: number
-  durationMs: number
-  truncated: boolean
-}
-
-export interface FileEntry {
-  path: string
-  modified: number
-  /** Present when the gateway's ListFiles reports entry facts (KIP-20 perf). */
-  type?: 'file' | 'directory' | 'symlink' | 'other'
-  size?: number
-}
-
-export interface CreateSessionOptions {
-  runtimeClass?: string
-  tenant?: string
-  allowedHosts?: string[]
-}
-
-export interface StatusResult {
-  available: boolean
-  sessionId: string
-  tenantId: string
-  error: string
 }
 
 /** Default deadline for a unary RPC with no explicit budget (ms). */
@@ -329,18 +300,25 @@ export class GrpcK8eClient {
   // ── Exec ──────────────────────────────────────────────────────────────────
 
   /**
-   * Run one command in the sandbox and collect stdout/stderr/exit code.
-   * Mirrors `k8e-sandbox-cli run`; the RPC deadline covers dial + sandbox
-   * execution (sandbox timeout + 15s slack).
+   * Write multi-line interpreted code to its workspace temp file and return the
+   * shell command to run it (mirrors pkg/sandboxcli writeCodeFile + buildCommand).
    */
-  async run(code: string, opts: { lang?: string; timeout?: number; sessionId?: string; tenant?: string } = {}): Promise<ExecResult> {
+  private async prepareCommand(sessionId: string, code: string, lang: string): Promise<string> {
+    if (isMultiLine(code) && isInterpretedLang(lang)) {
+      await this.write(sessionId, runFileFor(lang), code)
+    }
+    return buildSandboxCommand(lang, code)
+  }
+
+  /**
+   * Execute a command in the sandbox over the shared connection and return the
+   * collected output. Mirrors `k8e-sandbox-cli run`; the deadline covers the
+   * dial plus sandbox execution (sandbox timeout + 15s slack).
+   */
+  async run(code: string, opts: RunOptions = {}): Promise<ExecResult> {
     if (opts.sessionId === undefined) throw new Error('k8e sandbox grpc: run requires a sessionId')
     const lang = opts.lang ?? 'bash'
-    let command = buildSandboxCommand(lang, code)
-    if (isMultiLine(code) && isInterpretedLang(lang)) {
-      await this.write(opts.sessionId, runFileFor(lang), code)
-      command = buildSandboxCommand(lang, code)
-    }
+    const command = await this.prepareCommand(opts.sessionId, code, lang)
     const timeout = opts.timeout ?? 30
     const resp = await this.call<any>(this.client.exec, {
       session_id: opts.sessionId,
@@ -363,14 +341,10 @@ export class GrpcK8eClient {
   }
 
   /** Submit asynchronously; returns a run id to poll. */
-  async runBackground(code: string, opts: { lang?: string; sessionId?: string; tenant?: string } = {}): Promise<BackgroundResult> {
+  async runBackground(code: string, opts: RunOptions = {}): Promise<BackgroundResult> {
     if (opts.sessionId === undefined) throw new Error('k8e sandbox grpc: runBackground requires a sessionId')
     const lang = opts.lang ?? 'bash'
-    let command = buildSandboxCommand(lang, code)
-    if (isMultiLine(code) && isInterpretedLang(lang)) {
-      await this.write(opts.sessionId, runFileFor(lang), code)
-      command = buildSandboxCommand(lang, code)
-    }
+    const command = await this.prepareCommand(opts.sessionId, code, lang)
     const resp = await this.call<any>(this.client.exec, {
       session_id: opts.sessionId,
       command,

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -1,8 +1,14 @@
 /**
- * Phase 2 k8e-sandbox transport: a direct gRPC client (mTLS) for the terminal
- * primitive. Loads the bundled `sandbox.proto` at runtime via
- * @grpc/proto-loader; mTLS material comes from the CLI's cert dir
- * (~/.k8e/sandbox, KIP-14/KIP-17), shared with `k8e-sandbox-cli`.
+ * Phase 2 k8e-sandbox transport: a direct gRPC client (mTLS) for the full
+ * sandbox surface — exec, files, sessions, and the PTY terminal primitive.
+ * Loads the bundled `sandbox.proto` at runtime via @grpc/proto-loader; mTLS
+ * material comes from the CLI's cert dir (~/.k8e/sandbox, KIP-14/KIP-17),
+ * shared with `k8e-sandbox-cli`.
+ *
+ * One `GrpcK8eClient` instance owns one connection: every operation is a gRPC
+ * RPC on that connection instead of spawning a 36MB `k8e-sandbox-cli` process
+ * per call. Every unary call carries a deadline so a dead gateway fails fast
+ * instead of hanging the chat preflight (KIP-20 perf follow-up).
  * @module @k8e-sandbox/dsh-k8e-sandbox-client/grpc
  */
 
@@ -44,6 +50,106 @@ export interface ExecSSEEvent {
   exit?: number
 }
 
+// ── Shared op shapes (mirror @k8e-sandbox/dsh-k8e-sandbox-client) ────────────
+
+export interface ExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+  sessionId: string
+  status: string
+  durationMs: number
+  truncated: boolean
+  language: string
+}
+
+export interface BackgroundResult {
+  runId: string
+  status: string
+  sessionId: string
+}
+
+export interface PollResult {
+  runId: string
+  status: string
+  stdout: string
+  stderr: string
+  exitCode: number
+  durationMs: number
+  truncated: boolean
+}
+
+export interface FileEntry {
+  path: string
+  modified: number
+  /** Present when the gateway's ListFiles reports entry facts (KIP-20 perf). */
+  type?: 'file' | 'directory' | 'symlink' | 'other'
+  size?: number
+}
+
+export interface CreateSessionOptions {
+  runtimeClass?: string
+  tenant?: string
+  allowedHosts?: string[]
+}
+
+export interface StatusResult {
+  available: boolean
+  sessionId: string
+  tenantId: string
+  error: string
+}
+
+/** Default deadline for a unary RPC with no explicit budget (ms). */
+export const DEFAULT_RPC_DEADLINE_MS = 30_000
+
+// ── Language wrapping (mirrors pkg/sandboxcli buildCommand) ──────────────────
+
+function isMultiLine(code: string): boolean {
+  return code.includes('\n')
+}
+
+function isInterpretedLang(lang: string | undefined): boolean {
+  switch ((lang ?? '').toLowerCase()) {
+    case 'python': case 'python3': case 'py':
+    case 'node': case 'nodejs': case 'js': case 'javascript':
+    case 'ts': case 'typescript':
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * Wrap code for a language the same way `k8e-sandbox-cli run` does: bash
+ * passes through; python/node single-line uses `-c`/`-e`, multi-line runs a
+ * workspace temp file written via WriteFile.
+ */
+export function buildSandboxCommand(lang: string | undefined, code: string): string {
+  switch ((lang ?? 'bash').toLowerCase()) {
+    case 'python': case 'python3': case 'py':
+      return isMultiLine(code) ? 'python3 /workspace/_k8e_run.py' : `python3 -c ${JSON.stringify(code)}`
+    case 'node': case 'nodejs': case 'js': case 'javascript':
+      return isMultiLine(code) ? 'node /workspace/_k8e_run.js' : `node -e ${JSON.stringify(code)}`
+    case 'ts': case 'typescript':
+      return 'TMPDIR=/workspace tsx /workspace/_k8e_run.ts'
+    default: // bash / sh
+      return code
+  }
+}
+
+/** Workspace temp file for multi-line interpreted code (mirrors writeCodeFile). */
+function runFileFor(lang: string | undefined): string {
+  switch ((lang ?? '').toLowerCase()) {
+    case 'node': case 'nodejs': case 'js': case 'javascript':
+      return '/workspace/_k8e_run.js'
+    case 'ts': case 'typescript':
+      return '/workspace/_k8e_run.ts'
+    default:
+      return '/workspace/_k8e_run.py'
+  }
+}
+
 /**
  * Incremental decoder for the gateway's /exec/stream SSE framing
  * (`data: {"pid":N}`, `data: <raw>`, `data: {"exit":N}`). Chunks may split an
@@ -82,19 +188,27 @@ export interface GrpcK8eClientOptions {
   certDir?: string
   /** Path to the bundled sandbox.proto. */
   protoPath?: string
+  /** Default deadline for unary RPCs (ms); dial/reconnect hangs are bounded by this. */
+  deadlineMs?: number
 }
 
 // Dynamic client surface produced by proto-loader; typed loosely here.
 interface SandboxServiceClient {
-  createTerminal(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
-  terminalWrite(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
-  terminalResize(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
-  terminalForeground(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
-  terminalSignal(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
-  terminalDestroy(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  createSession(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  destroySession(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  exec(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  pollRun(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  readFile(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  writeFile(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  listFiles(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  createTerminal(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalWrite(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalResize(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalForeground(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalSignal(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
+  terminalDestroy(request: unknown, metadata: grpc.Metadata, options: grpc.CallOptions, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
   terminalStream(request: unknown, metadata: grpc.Metadata): grpc.ClientReadableStream<any>
   execStream(request: unknown, metadata: grpc.Metadata): grpc.ClientReadableStream<any>
-  exec(request: unknown, metadata: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void): grpc.ClientUnaryCall
 }
 
 function defaultCertDir(): string {
@@ -131,13 +245,22 @@ function terminalSignalEnum(signal: TerminalSignal): number {
   }
 }
 
+type UnaryMethod = (
+  request: unknown,
+  metadata: grpc.Metadata,
+  options: grpc.CallOptions,
+  cb: (err: grpc.ServiceError | null, resp: any) => void,
+) => grpc.ClientUnaryCall
+
 /**
- * Direct gRPC client for the sandbox gateway's PTY terminal primitive. Phase 2
- * uses this for `spawnTerminal`; Phase 1 shells out to the CLI for the rest.
+ * Direct gRPC client for the sandbox gateway. One instance owns one
+ * connection; all fs/exec/session ops are RPCs on it (no per-op CLI spawn).
+ * Every unary call carries a deadline so a dead gateway fails fast.
  */
 export class GrpcK8eClient {
   private readonly client: SandboxServiceClient
   private readonly metadata = new grpc.Metadata()
+  private readonly deadlineMs: number
 
   constructor(private readonly opts: GrpcK8eClientOptions) {
     const protoPath = opts.protoPath ?? join(import.meta.dirname, '..', 'proto', 'sandbox.proto')
@@ -150,20 +273,157 @@ export class GrpcK8eClient {
     })
     const pkg = grpc.loadPackageDefinition(definition) as any
     const SandboxService = pkg.sandbox.v1.SandboxService
-    this.client = new SandboxService(opts.endpoint, createCredentials(opts.certDir ?? defaultCertDir())) as SandboxServiceClient
+    this.deadlineMs = opts.deadlineMs ?? DEFAULT_RPC_DEADLINE_MS
+    // Fast-fail reconnect: a dead endpoint must surface a per-call deadline
+    // quickly instead of sitting in grpc-js exponential backoff.
+    this.client = new SandboxService(opts.endpoint, createCredentials(opts.certDir ?? defaultCertDir()), {
+      'grpc.initial_reconnect_backoff_ms': 200,
+      'grpc.max_reconnect_backoff_ms': 2_000,
+    }) as SandboxServiceClient
   }
 
-  private call<T>(
-    method: (req: unknown, md: grpc.Metadata, cb: (err: grpc.ServiceError | null, resp: any) => void) => grpc.ClientUnaryCall,
-    request: unknown,
-  ): Promise<T> {
+  private call<T>(method: UnaryMethod, request: unknown, deadlineMs?: number): Promise<T> {
     return new Promise((resolve, reject) => {
-      method.call(this.client, request, this.metadata, (err, resp) => {
+      const deadline = Date.now() + (deadlineMs ?? this.deadlineMs)
+      method.call(this.client, request, this.metadata, { deadline }, (err, resp) => {
         if (err !== null) reject(err)
         else resolve(resp as T)
       })
     })
   }
+
+  // ── Sessions ──────────────────────────────────────────────────────────────
+
+  async createSession(opts: CreateSessionOptions = {}): Promise<{ sessionId: string; podIp: string }> {
+    const resp = await this.call<any>(this.client.createSession, {
+      session_id: '',
+      ...(opts.tenant !== undefined ? { tenant_id: opts.tenant } : {}),
+      ...(opts.allowedHosts !== undefined ? { allowed_hosts: opts.allowedHosts } : {}),
+      ...(opts.runtimeClass !== undefined ? { runtime_class: opts.runtimeClass } : {}),
+    }, 45_000)
+    return { sessionId: resp.session_id as string, podIp: resp.pod_ip as string }
+  }
+
+  async destroySession(sessionId: string): Promise<void> {
+    await this.call(this.client.destroySession, { session_id: sessionId }, 10_000)
+  }
+
+  /**
+   * Lightweight availability probe (mirrors `k8e-sandbox-cli status`): a noop
+   * DestroySession RPC that completes the handshake; NotFound means the
+   * gateway is up (unknown id), any other error means unavailable.
+   */
+  async status(): Promise<StatusResult> {
+    try {
+      await this.call(this.client.destroySession, { session_id: 'healthcheck-probe-noop' }, 5_000)
+      return { available: true, sessionId: '', tenantId: '', error: '' }
+    } catch (err) {
+      const code = (err as { code?: number }).code
+      if (code === grpc.status.NOT_FOUND) {
+        return { available: true, sessionId: '', tenantId: '', error: '' }
+      }
+      return { available: false, sessionId: '', tenantId: '', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  // ── Exec ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Run one command in the sandbox and collect stdout/stderr/exit code.
+   * Mirrors `k8e-sandbox-cli run`; the RPC deadline covers dial + sandbox
+   * execution (sandbox timeout + 15s slack).
+   */
+  async run(code: string, opts: { lang?: string; timeout?: number; sessionId?: string; tenant?: string } = {}): Promise<ExecResult> {
+    if (opts.sessionId === undefined) throw new Error('k8e sandbox grpc: run requires a sessionId')
+    const lang = opts.lang ?? 'bash'
+    let command = buildSandboxCommand(lang, code)
+    if (isMultiLine(code) && isInterpretedLang(lang)) {
+      await this.write(opts.sessionId, runFileFor(lang), code)
+      command = buildSandboxCommand(lang, code)
+    }
+    const timeout = opts.timeout ?? 30
+    const resp = await this.call<any>(this.client.exec, {
+      session_id: opts.sessionId,
+      command,
+      timeout,
+      workdir: '/workspace',
+      background: false,
+      language: lang,
+    }, timeout * 1000 + 15_000)
+    return {
+      stdout: resp.stdout as string,
+      stderr: resp.stderr as string,
+      exitCode: resp.exit_code as number,
+      sessionId: resp.session_id as string,
+      status: resp.status as string,
+      durationMs: resp.duration_ms as number,
+      truncated: resp.truncated as boolean,
+      language: resp.language as string,
+    }
+  }
+
+  /** Submit asynchronously; returns a run id to poll. */
+  async runBackground(code: string, opts: { lang?: string; sessionId?: string; tenant?: string } = {}): Promise<BackgroundResult> {
+    if (opts.sessionId === undefined) throw new Error('k8e sandbox grpc: runBackground requires a sessionId')
+    const lang = opts.lang ?? 'bash'
+    let command = buildSandboxCommand(lang, code)
+    if (isMultiLine(code) && isInterpretedLang(lang)) {
+      await this.write(opts.sessionId, runFileFor(lang), code)
+      command = buildSandboxCommand(lang, code)
+    }
+    const resp = await this.call<any>(this.client.exec, {
+      session_id: opts.sessionId,
+      command,
+      timeout: 0,
+      workdir: '/workspace',
+      background: true,
+      language: lang,
+    }, 15_000)
+    return { runId: resp.run_id as string, status: resp.status as string, sessionId: opts.sessionId }
+  }
+
+  async poll(runId: string): Promise<PollResult> {
+    const resp = await this.call<any>(this.client.pollRun, { run_id: runId }, 15_000)
+    return {
+      runId: resp.run_id as string,
+      status: resp.status as string,
+      stdout: resp.stdout as string,
+      stderr: resp.stderr as string,
+      exitCode: resp.exit_code as number,
+      durationMs: resp.duration_ms as number,
+      truncated: resp.truncated as boolean,
+    }
+  }
+
+  // ── Files ─────────────────────────────────────────────────────────────────
+
+  async read(sessionId: string, path: string): Promise<string> {
+    const resp = await this.call<any>(this.client.readFile, { session_id: sessionId, path }, 15_000)
+    return resp.content as string
+  }
+
+  async write(sessionId: string, path: string, content: string): Promise<void> {
+    await this.call(this.client.writeFile, { session_id: sessionId, path, content }, 15_000)
+  }
+
+  /** List workspace files; the gateway may include type/size per entry. */
+  async list(sessionId: string, since?: number): Promise<FileEntry[]> {
+    const resp = await this.call<any>(this.client.listFiles, {
+      session_id: sessionId,
+      ...(since !== undefined ? { since } : {}),
+    }, 15_000)
+    const out: FileEntry[] = []
+    for (const f of (resp.files as any[]) ?? []) {
+      const entry: FileEntry = { path: f.path as string, modified: Number(f.modified ?? 0) }
+      const rawType = f.type as FileEntry['type'] | undefined
+      if (rawType !== undefined) entry.type = rawType
+      if (f.size !== undefined) entry.size = Number(f.size)
+      out.push(entry)
+    }
+    return out
+  }
+
+  // ── Terminal ──────────────────────────────────────────────────────────────
 
   async createTerminal(request: { sessionId: string; argv: string[]; workdir?: string; env?: Record<string, string>; rows: number; cols: number }): Promise<CreateTerminalResponse> {
     const resp = await this.call<any>(this.client.createTerminal, {
@@ -173,20 +433,20 @@ export class GrpcK8eClient {
       env: request.env ?? {},
       rows: request.rows,
       cols: request.cols,
-    })
+    }, 15_000)
     return { terminalId: resp.terminal_id as string, pid: resp.pid as number }
   }
 
   async terminalWrite(terminalId: string, data: Uint8Array): Promise<void> {
-    await this.call(this.client.terminalWrite, { terminal_id: terminalId, data })
+    await this.call(this.client.terminalWrite, { terminal_id: terminalId, data }, 10_000)
   }
 
   async terminalResize(terminalId: string, rows: number, cols: number): Promise<void> {
-    await this.call(this.client.terminalResize, { terminal_id: terminalId, rows, cols })
+    await this.call(this.client.terminalResize, { terminal_id: terminalId, rows, cols }, 10_000)
   }
 
   async terminalForeground(terminalId: string): Promise<TerminalForegroundResponse> {
-    const resp = await this.call<any>(this.client.terminalForeground, { terminal_id: terminalId })
+    const resp = await this.call<any>(this.client.terminalForeground, { terminal_id: terminalId }, 10_000)
     return { processGroupId: resp.process_group_id as number, inputWaiting: resp.input_waiting as boolean }
   }
 
@@ -194,12 +454,12 @@ export class GrpcK8eClient {
     const resp = await this.call<any>(this.client.terminalSignal, {
       terminal_id: terminalId,
       signal: terminalSignalEnum(signal),
-    })
+    }, 10_000)
     return resp.process_group_id as number
   }
 
   async terminalDestroy(terminalId: string, graceMs: number): Promise<void> {
-    await this.call(this.client.terminalDestroy, { terminal_id: terminalId, grace_ms: graceMs })
+    await this.call(this.client.terminalDestroy, { terminal_id: terminalId, grace_ms: graceMs }, 10_000)
   }
 
   /** Open the terminal output stream; the stream yields data frames then a final exit frame. */

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
@@ -74,14 +74,22 @@ export interface CliK8eClientOptions {
   timeoutMs?: number
 }
 
+/** Options for a sandbox `run`/`runBackground` call (shared transport contract). */
+export interface RunOptions {
+  lang?: string
+  timeout?: number
+  sessionId?: string
+  tenant?: string
+}
+
 /**
  * Shared op surface implemented by both transports (CLI-backed and direct
  * gRPC). `K8eSandboxRuntime.getClient()` returns whichever is active; the fs
  * / tool / subprocess providers call only these methods.
  */
 export interface SandboxTransport {
-  run(code: string, opts?: { lang?: string; timeout?: number; sessionId?: string; tenant?: string }): Promise<ExecResult>
-  runBackground(code: string, opts?: { lang?: string; sessionId?: string; tenant?: string }): Promise<BackgroundResult>
+  run(code: string, opts?: RunOptions): Promise<ExecResult>
+  runBackground(code: string, opts?: RunOptions): Promise<BackgroundResult>
   poll(runId: string): Promise<PollResult>
   read(sessionId: string, path: string): Promise<string>
   write(sessionId: string, path: string, content: string): Promise<void>
@@ -258,7 +266,7 @@ export class CliK8eClient implements SandboxTransport {
   constructor(private readonly opts: CliK8eClientOptions = {}) {}
 
   /** Run one command in the sandbox and collect stdout/stderr/exit code. */
-  async run(code: string, opts: { lang?: string; timeout?: number; sessionId?: string; tenant?: string } = {}): Promise<ExecResult> {
+  async run(code: string, opts: RunOptions = {}): Promise<ExecResult> {
     const args = ['run', code]
     if (opts.lang) args.push('--lang', opts.lang)
     if (opts.timeout !== undefined) args.push('--timeout', String(opts.timeout))
@@ -271,7 +279,7 @@ export class CliK8eClient implements SandboxTransport {
   }
 
   /** Submit asynchronously; returns a run id to poll. */
-  async runBackground(code: string, opts: { lang?: string; sessionId?: string; tenant?: string } = {}): Promise<BackgroundResult> {
+  async runBackground(code: string, opts: RunOptions = {}): Promise<BackgroundResult> {
     const args = ['run', code, '--background']
     if (opts.lang) args.push('--lang', opts.lang)
     if (opts.sessionId) args.push('--session-id', opts.sessionId)

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
@@ -168,10 +168,13 @@ function parseProfilesYaml(text: string): SandboxProfileFile {
  */
 export function resolveSandboxTransport(
   explicit?: { endpoint?: string; certDir?: string; profile?: string },
-): { endpoint: string; certDir?: string } | undefined {
+): { endpoint: string; certDir?: string; source: 'config' | 'env' | 'profile'; profile?: string } | undefined {
   const endpoint = explicit?.endpoint ?? process.env.K8E_SANDBOX_ENDPOINT
   if (endpoint !== undefined && endpoint !== '') {
-    const out: { endpoint: string; certDir?: string } = { endpoint }
+    const out: { endpoint: string; certDir?: string; source: 'config' | 'env' | 'profile'; profile?: string } = {
+      endpoint,
+      source: explicit?.endpoint !== undefined && explicit.endpoint !== '' ? 'config' : 'env',
+    }
     const certDir = explicit?.certDir ?? process.env.K8E_SANDBOX_CERT_DIR
     if (certDir !== undefined && certDir !== '') out.certDir = certDir
     return out
@@ -191,7 +194,11 @@ export function resolveSandboxTransport(
   if (selected === undefined) return undefined
   const profile = file.profiles?.[selected]
   if (profile === undefined || profile.endpoint === undefined || profile.endpoint === '') return undefined
-  const out: { endpoint: string; certDir?: string } = { endpoint: profile.endpoint }
+  const out: { endpoint: string; certDir?: string; source: 'config' | 'env' | 'profile'; profile?: string } = {
+    endpoint: profile.endpoint,
+    source: 'profile',
+    ...(selected !== undefined ? { profile: selected } : {}),
+  }
   if (profile.certDir !== undefined && profile.certDir !== '') out.certDir = profile.certDir
   return out
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
@@ -7,6 +7,9 @@
  */
 
 import { spawn } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 /** Result of a single-shot sandbox exec (`k8e-sandbox-cli run`). */
 export interface ExecResult {
@@ -41,6 +44,9 @@ export interface PollResult {
 export interface FileEntry {
   path: string
   modified: number
+  /** Present when the gateway's ListFiles reports entry facts (KIP-20 perf). */
+  type?: 'file' | 'directory' | 'symlink' | 'other'
+  size?: number
 }
 
 export interface CreateSessionOptions {
@@ -64,6 +70,130 @@ export interface CliK8eClientOptions {
   profile?: string
   /** gRPC gateway endpoint override. */
   endpoint?: string
+  /** Default wall-clock budget for one CLI invocation (ms); the child is killed on expiry. */
+  timeoutMs?: number
+}
+
+/**
+ * Shared op surface implemented by both transports (CLI-backed and direct
+ * gRPC). `K8eSandboxRuntime.getClient()` returns whichever is active; the fs
+ * / tool / subprocess providers call only these methods.
+ */
+export interface SandboxTransport {
+  run(code: string, opts?: { lang?: string; timeout?: number; sessionId?: string; tenant?: string }): Promise<ExecResult>
+  runBackground(code: string, opts?: { lang?: string; sessionId?: string; tenant?: string }): Promise<BackgroundResult>
+  poll(runId: string): Promise<PollResult>
+  read(sessionId: string, path: string): Promise<string>
+  write(sessionId: string, path: string, content: string): Promise<void>
+  list(sessionId: string, since?: number): Promise<FileEntry[]>
+  createSession(opts?: CreateSessionOptions): Promise<{ sessionId: string; podIp: string }>
+  destroySession(sessionId: string): Promise<void>
+  status(): Promise<StatusResult>
+  close?(): void
+}
+
+// ── Profile resolution (mirrors pkg/sandboxcli/profile.go) ───────────────────
+
+interface SandboxProfile {
+  endpoint: string
+  certDir: string
+  deviceName: string
+}
+
+interface SandboxProfileFile {
+  currentProfile: string
+  profiles: Record<string, SandboxProfile>
+}
+
+/** Candidate profile file paths in CLI priority order. */
+function profileConfigPaths(): string[] {
+  const paths: string[] = []
+  const explicit = process.env.K8E_SANDBOX_CONFIG
+  if (explicit !== undefined && explicit !== '') paths.push(explicit)
+  const certDir = process.env.K8E_SANDBOX_CERT_DIR
+  const defaultDir = join(homedir(), '.k8e', 'sandbox')
+  paths.push(join(certDir ?? defaultDir, 'profiles.yaml'))
+  if (certDir === undefined) paths.push(join(defaultDir, 'profiles.yaml'))
+  return [...new Set(paths)]
+}
+
+/**
+ * Parse the k8e profiles.yaml subset (KIP-17): scalar `key: value` lines plus
+ * one level of 2-space-indented maps. Avoids a YAML dependency for a file
+ * whose shape the CLI writes.
+ *
+ *   version: 1
+ *   current_profile: default
+ *   profiles:
+ *     default:
+ *       endpoint: host:50051
+ *       cert_dir: ""
+ */
+function parseProfilesYaml(text: string): SandboxProfileFile {
+  const result: SandboxProfileFile = { currentProfile: '', profiles: {} }
+  let current: SandboxProfile | undefined
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) continue
+    const indent = line.length - line.trimStart().length
+    const m = /^([A-Za-z0-9_-]+):\s*(.*)$/.exec(trimmed)
+    if (m === null) continue
+    // Indent 0: top-level scalars (`current_profile`, `version`, `profiles:`).
+    if (indent === 0) {
+      if (m[1] === 'current_profile') result.currentProfile = m[2]!.trim()
+      continue
+    }
+    // Indent 2 with empty value: a profile name opens a new profile map.
+    if (indent === 2 && m[2] === '') {
+      current = { endpoint: '', certDir: '', deviceName: '' }
+      result.profiles[m[1]!] = current
+      continue
+    }
+    // Indent 4+: profile fields.
+    if (current === undefined) continue
+    const value = m[2]!.replace(/^"(.*)"$/, '$1').trim()
+    if (m[1] === 'endpoint') current.endpoint = value
+    else if (m[1] === 'cert_dir') current.certDir = value
+    else if (m[1] === 'device_name') current.deviceName = value
+  }
+  return result
+}
+
+/**
+ * Resolve the effective endpoint + cert dir for the sandbox gateway
+ * (explicit → env → profile → undefined), mirroring `k8e-sandbox-cli`
+ * (KIP-17). Returns undefined when no endpoint can be resolved (local
+ * auto-discovery territory).
+ */
+export function resolveSandboxTransport(
+  explicit?: { endpoint?: string; certDir?: string; profile?: string },
+): { endpoint: string; certDir?: string } | undefined {
+  const endpoint = explicit?.endpoint ?? process.env.K8E_SANDBOX_ENDPOINT
+  if (endpoint !== undefined && endpoint !== '') {
+    const out: { endpoint: string; certDir?: string } = { endpoint }
+    const certDir = explicit?.certDir ?? process.env.K8E_SANDBOX_CERT_DIR
+    if (certDir !== undefined && certDir !== '') out.certDir = certDir
+    return out
+  }
+  const profileName = explicit?.profile ?? process.env.K8E_SANDBOX_PROFILE
+  let file: SandboxProfileFile | undefined
+  for (const path of profileConfigPaths()) {
+    try {
+      file = parseProfilesYaml(readFileSync(path, 'utf8'))
+      break
+    } catch {
+      // missing / invalid profile file → try the next candidate
+    }
+  }
+  if (file === undefined) return undefined
+  const selected = profileName ?? file.currentProfile ?? (file.profiles?.default !== undefined ? 'default' : undefined)
+  if (selected === undefined) return undefined
+  const profile = file.profiles?.[selected]
+  if (profile === undefined || profile.endpoint === undefined || profile.endpoint === '') return undefined
+  const out: { endpoint: string; certDir?: string } = { endpoint: profile.endpoint }
+  if (profile.certDir !== undefined && profile.certDir !== '') out.certDir = profile.certDir
+  return out
 }
 
 interface CliResult {
@@ -72,7 +202,7 @@ interface CliResult {
   exitCode: number
 }
 
-function runCli(args: string[], opts: CliK8eClientOptions, stdin?: string): Promise<CliResult> {
+function runCli(args: string[], opts: CliK8eClientOptions, stdin?: string, timeoutMs?: number): Promise<CliResult> {
   return new Promise((resolve, reject) => {
     const full: string[] = []
     if (opts.profile) full.push('--profile', opts.profile)
@@ -82,10 +212,19 @@ function runCli(args: string[], opts: CliK8eClientOptions, stdin?: string): Prom
     const child = spawn(opts.bin ?? 'k8e-sandbox-cli', full, { stdio: ['pipe', 'pipe', 'pipe'] })
     let stdout = ''
     let stderr = ''
+    const budget = timeoutMs ?? opts.timeoutMs ?? 90_000
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`k8e-sandbox-cli ${args[0] ?? ''} timed out after ${Math.round(budget / 1000)}s (dial + RPC deadline)`))
+    }, budget)
+    timer.unref?.()
     child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString() })
     child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString() })
-    child.on('error', reject)
-    child.on('close', (code) => { resolve({ stdout, stderr, exitCode: code ?? -1 }) })
+    child.on('error', (err) => { clearTimeout(timer); reject(err) })
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ stdout, stderr, exitCode: code ?? -1 })
+    })
     if (stdin !== undefined) child.stdin.write(stdin)
     child.stdin.end()
   })
@@ -103,7 +242,7 @@ function parseJSON<T>(result: CliResult, what: string): T {
 }
 
 /** CLI-backed k8e-sandbox client. */
-export class CliK8eClient {
+export class CliK8eClient implements SandboxTransport {
   constructor(private readonly opts: CliK8eClientOptions = {}) {}
 
   /** Run one command in the sandbox and collect stdout/stderr/exit code. */
@@ -113,7 +252,10 @@ export class CliK8eClient {
     if (opts.timeout !== undefined) args.push('--timeout', String(opts.timeout))
     if (opts.sessionId) args.push('--session-id', opts.sessionId)
     if (opts.tenant) args.push('--tenant', opts.tenant)
-    return parseJSON<ExecResult>(await runCli(args, this.opts), 'run')
+    // Wall-clock budget = sandbox timeout + dial/RPC slack, so a dead gateway
+    // fails fast instead of hanging forever on context.Background().
+    const budgetMs = (opts.timeout !== undefined ? opts.timeout : 30) * 1000 + 20_000
+    return parseJSON<ExecResult>(await runCli(args, this.opts, undefined, budgetMs), 'run')
   }
 
   /** Submit asynchronously; returns a run id to poll. */
@@ -122,7 +264,7 @@ export class CliK8eClient {
     if (opts.lang) args.push('--lang', opts.lang)
     if (opts.sessionId) args.push('--session-id', opts.sessionId)
     if (opts.tenant) args.push('--tenant', opts.tenant)
-    return parseJSON<BackgroundResult>(await runCli(args, this.opts), 'run --background')
+    return parseJSON<BackgroundResult>(await runCli(args, this.opts, undefined, 20_000), 'run --background')
   }
 
   async poll(runId: string): Promise<PollResult> {

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/index.ts
@@ -141,7 +141,7 @@ function parseProfilesYaml(text: string): SandboxProfileFile {
     if (m === null) continue
     // Indent 0: top-level scalars (`current_profile`, `version`, `profiles:`).
     if (indent === 0) {
-      if (m[1] === 'current_profile') result.currentProfile = m[2]!.trim()
+      if (m[1] === 'current_profile') result.currentProfile = m[2]!.replace(/^"(.*)"$/, '$1').trim()
       continue
     }
     // Indent 2 with empty value: a profile name opens a new profile map.
@@ -190,7 +190,12 @@ export function resolveSandboxTransport(
     }
   }
   if (file === undefined) return undefined
-  const selected = profileName ?? file.currentProfile ?? (file.profiles?.default !== undefined ? 'default' : undefined)
+  // Mirror pkg/sandboxcli SelectProfileName: explicit → env → current_profile
+  // (trimmed, empty treated as unset) → "default" when present. An empty
+  // current_profile must NOT short-circuit the documented default fallback.
+  const explicitProfile = profileName !== undefined && profileName.trim() !== '' ? profileName.trim() : undefined
+  const currentProfile = file.currentProfile !== undefined && file.currentProfile.trim() !== '' ? file.currentProfile.trim() : undefined
+  const selected = explicitProfile ?? currentProfile ?? (file.profiles?.default !== undefined ? 'default' : undefined)
   if (selected === undefined) return undefined
   const profile = file.profiles?.[selected]
   if (profile === undefined || profile.endpoint === undefined || profile.endpoint === '') return undefined

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
@@ -1,11 +1,23 @@
 /**
- * k8e-sandbox Service Provider for the filesystem capability seam. Paths and
- * contents live in the sandbox workspace; operations shell out to
- * `k8e-sandbox-cli` in Phase 1 (KIP-20).
+ * k8e-sandbox Service Provider for the filesystem capability seam.
+ *
+ * Two path worlds, one provider:
+ * - Workspace paths (relative, or under the sandbox root e.g. `/workspace`)
+ *   live in the sandbox pod and go through the shared transport (persistent
+ *   gRPC when an endpoint is resolved — no per-op CLI spawn).
+ * - Host-absolute paths outside the sandbox root (e.g. `/Users/...` used by
+ *   agent-instructions / skill discovery preflight) stay on the local disk:
+ *   AGENTS.md / skills discovery must not pay a pod round trip before the
+ *   first model request (KIP-20 perf follow-up).
+ *
+ * listDir uses the gateway's ListFiles entry facts (type/size) when present —
+ * no per-child stat — and falls back to a single exec probe per child only
+ * when the gateway predates entry facts.
  * @module @k8e-sandbox/dsh-k8e-sandbox-fs
  */
 
 import { Buffer } from 'node:buffer'
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { posix } from 'node:path'
 import { Context } from '@deepseek-ai/cordis'
 import { FileSystem, FsError, FsTargetKey, FsVersion } from '@deepseek-ai/dsh-fs'
@@ -28,6 +40,10 @@ interface StatFacts {
   version: ReturnType<typeof FsVersion>
 }
 
+function hostType(info: { isFile(): boolean; isDirectory(): boolean; isSymbolicLink(): boolean }): FsInfo['type'] {
+  return info.isDirectory() ? 'directory' : info.isFile() ? 'file' : 'other'
+}
+
 /** Remote filesystem backend sharing the session owned by `ctx.k8eSandbox`. */
 export class K8eFileSystem extends FileSystem {
   static inject = ['k8eSandbox']
@@ -42,6 +58,17 @@ export class K8eFileSystem extends FileSystem {
 
   private display(path: string, cwd?: string): string {
     return posix.resolve(cwd ?? this.ctx.k8eSandbox.cwd, path)
+  }
+
+  /**
+   * True when the path lives in the sandbox workspace. Relative paths resolve
+   * under the sandbox root; absolute paths must be under it. Host-absolute
+   * paths (preflight: AGENTS.md / skills discovery) stay on the local disk.
+   */
+  private isSandboxPath(path: string): boolean {
+    if (!posix.isAbsolute(path)) return true
+    const root = this.ctx.k8eSandbox.cwd
+    return path === root || path.startsWith(`${root}/`)
   }
 
   private shellQuote(value: string): string {
@@ -69,6 +96,59 @@ export class K8eFileSystem extends FileSystem {
     return relative === '' || (relative !== '..' && !relative.startsWith('../') && !posix.isAbsolute(relative))
   }
 
+  // ── Local (host) implementation for preflight paths ────────────────────────
+
+  private async localStat(path: string): Promise<StatFacts | undefined> {
+    try {
+      const info = await stat(path)
+      return {
+        type: hostType(info),
+        size: info.size,
+        version: FsVersion(`host:${Math.trunc(info.mtimeMs)}:${info.size}`),
+      }
+    } catch {
+      return undefined
+    }
+  }
+
+  private async localListDir(path: string): Promise<FsDirEntry[]> {
+    const entries: FsDirEntry[] = []
+    const dirents = await readdir(path, { withFileTypes: true })
+    for (const dirent of dirents) {
+      const childPath = posix.join(path, dirent.name)
+      const type: FsInfo['type'] = dirent.isDirectory() ? 'directory' : dirent.isFile() ? 'file' : 'other'
+      let size: number | undefined
+      let version: ReturnType<typeof FsVersion> | undefined
+      if (type === 'file') {
+        try {
+          const info = await stat(childPath)
+          size = info.size
+          version = FsVersion(`host:${Math.trunc(info.mtimeMs)}:${info.size}`)
+        } catch {
+          // vanished between readdir and stat → skip entry facts
+        }
+      }
+      entries.push({
+        name: dirent.name,
+        type,
+        target: { targetKey: FsTargetKey(childPath), displayPath: childPath },
+        ...(size !== undefined ? { size } : {}),
+        ...(version !== undefined ? { version } : {}),
+      })
+    }
+    return entries.sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  private async localReadText(path: string): Promise<string> {
+    return readFile(path, 'utf8')
+  }
+
+  private async localWriteText(path: string, content: string): Promise<void> {
+    await writeFile(path, content, 'utf8')
+  }
+
+  // ── Sandbox (remote) implementation ───────────────────────────────────────
+
   private async probe(path: string): Promise<StatFacts | undefined> {
     const client = (await this.runtime()).getClient()
     const sid = await this.session()
@@ -87,7 +167,13 @@ export class K8eFileSystem extends FileSystem {
   }
 
   override async stat(target: FsTarget, signal?: AbortSignal): Promise<FsInfo | undefined> {
-    const facts = await this.probe(this.processPath(target))
+    const path = this.processPath(target)
+    if (!this.isSandboxPath(path)) {
+      const facts = await this.localStat(path)
+      if (facts === undefined) return undefined
+      return { version: facts.version, type: facts.type, ...(facts.type === 'file' ? { size: facts.size } : {}) }
+    }
+    const facts = await this.probe(path)
     if (facts === undefined) return undefined
     return { version: facts.version, type: facts.type, ...(facts.type === 'file' ? { size: facts.size } : {}) }
   }
@@ -100,10 +186,12 @@ export class K8eFileSystem extends FileSystem {
   }
 
   override async readText(target: FsTarget, signal?: AbortSignal): Promise<string> {
-    const client = (await this.runtime()).getClient()
-    const sid = await this.session()
+    const path = this.processPath(target)
     try {
-      return await client.read(sid, this.processPath(target))
+      if (!this.isSandboxPath(path)) return await this.localReadText(path)
+      const client = (await this.runtime()).getClient()
+      const sid = await this.session()
+      return await client.read(sid, path)
     } catch (cause) {
       throw new FsError(`cannot read "${target.displayPath}": ${String(cause)}`, 'FS_IO_ERROR', { cause })
     }
@@ -128,18 +216,25 @@ export class K8eFileSystem extends FileSystem {
   }
 
   override async listDir(target: FsTarget, signal?: AbortSignal): Promise<FsDirEntry[]> {
+    const path = this.processPath(target)
+    if (!this.isSandboxPath(path)) return this.localListDir(path)
+
     const client = (await this.runtime()).getClient()
     const sid = await this.session()
-    const parent = this.processPath(target)
+    const prefix = path === '/' ? '/' : `${path}/`
     const files = await client.list(sid)
-    const prefix = parent === '/' ? '/' : `${parent}/`
     const entries: FsDirEntry[] = []
     for (const file of files) {
       if (!file.path.startsWith(prefix)) continue
       const rest = file.path.slice(prefix.length)
       if (rest.length === 0 || rest.includes('/')) continue // only direct children
       const childPath = file.path
-      const facts = await this.probe(childPath)
+      // Entry facts (type/size) come from the single ListFiles RPC when the
+      // gateway reports them; only legacy gateways pay a per-child probe.
+      // dsh's FsInfo has no 'symlink' kind, so symlinks surface as 'other'.
+      const facts: StatFacts | undefined = file.type !== undefined
+        ? { type: file.type === 'symlink' ? 'other' : file.type, size: file.size ?? 0, version: FsVersion(`k8e:${file.modified}:${file.size ?? 0}`) }
+        : await this.probe(childPath)
       entries.push({
         name: rest,
         type: facts?.type ?? 'other',
@@ -157,18 +252,30 @@ export class K8eFileSystem extends FileSystem {
     expected?: FsWriteIntent,
     signal?: AbortSignal,
   ): Promise<FsWriteOutcome> {
+    const path = this.processPath(target)
+    const local = !this.isSandboxPath(path)
     if (expected?.kind === 'createIfAbsent') {
       const existing = await this.stat(target, signal)
       if (existing !== undefined) {
         throw new FsError(`cannot overwrite existing "${target.displayPath}" without reading it first`, 'FS_NOT_OBSERVED')
       }
     }
-    const client = (await this.runtime()).getClient()
-    const sid = await this.session()
     const existing = await this.stat(target, signal)
     const before = existing === undefined ? null : await this.readText(target, signal)
-    await client.write(sid, this.processPath(target), content)
-    const facts = await this.probe(this.processPath(target))
+    if (local) {
+      await this.localWriteText(path, content)
+      const facts = await this.localStat(path)
+      return {
+        operation: existing === undefined ? 'create' : 'update',
+        version: facts?.version ?? FsVersion('host:unknown'),
+        before,
+        after: content,
+      }
+    }
+    const client = (await this.runtime()).getClient()
+    const sid = await this.session()
+    await client.write(sid, path, content)
+    const facts = await this.probe(path)
     return {
       operation: existing === undefined ? 'create' : 'update',
       version: facts?.version ?? FsVersion('k8e:unknown'),
@@ -202,7 +309,10 @@ export class K8eFileSystem extends FileSystem {
     }
     const after = edit.replaceAll ? before.split(oldString).join(edit.newString) : before.replace(oldString, edit.newString)
     await this.writeText(target, after, undefined, signal)
-    const version = (await this.probe(this.processPath(target)))?.version ?? FsVersion('k8e:unknown')
+    const path = this.processPath(target)
+    const version = this.isSandboxPath(path)
+      ? (await this.probe(path))?.version ?? FsVersion('k8e:unknown')
+      : (await this.localStat(path))?.version ?? FsVersion('host:unknown')
     return { version, before, after }
   }
 }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-host-ui/src/index.ts
@@ -271,6 +271,11 @@ export function apply(ctx: Context): void {
           grpcAvailable,
           cwd: ctx.k8eSandbox.cwd,
           endpoint: ctx.k8eSandbox.endpoint,
+          // Where the connect address came from: auto-discovered from
+          // ~/.k8e/sandbox/profiles.yaml (KIP-17) when not configured
+          // explicitly in the dsh profile row / environment.
+          endpointSource: ctx.k8eSandbox.endpointSource,
+          endpointProfile: ctx.k8eSandbox.endpointProfile,
           certDir: ctx.k8eSandbox.certDir,
           runtimeClass: ctx.k8eSandbox.runtimeClass,
         })

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -139,11 +139,15 @@ export class K8eSandboxRuntime extends Service {
 
     ctx.effect(() => async () => {
       this.disposed = true
-      if (this.sessionId === undefined) return
-      try {
-        await this.transport.destroySession(this.sessionId)
-      } catch (_destroyFailure) {
-        // Best-effort: the session pod is also reclaimed by the warm-pool GC.
+      // Always release the persistent gRPC connection, even when no session
+      // was ever assigned (disposal before first use must not leak the
+      // channel; the session pod is also reclaimed by the warm-pool GC).
+      if (this.sessionId !== undefined) {
+        try {
+          await this.transport.destroySession(this.sessionId)
+        } catch (_destroyFailure) {
+          // Best-effort: the session pod is also reclaimed by the warm-pool GC.
+        }
       }
       this.transport.close?.()
     }, 'k8e sandbox teardown')

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -2,17 +2,24 @@
  * Shared ownership of one k8e-sandbox session. Capability adapters await the
  * same session handle, so filesystem and process operations inhabit one remote
  * Linux world (mirrors the E2B POC's `ctx.e2b` owner).
+ *
+ * Transport: when an endpoint is configured (explicit, env, or the CLI
+ * profiles.yaml KIP-17), a persistent `GrpcK8eClient` owns one connection and
+ * every fs/exec op is a gRPC RPC on it — no per-op `k8e-sandbox-cli` spawn.
+ * Without an endpoint the CLI-backed transport is used (local auto-discovery).
+ * Session creation is single-flighted and failures are negatively cached so a
+ * dead gateway cannot cause a getSession() storm.
  * @module @k8e-sandbox/dsh-k8e-sandbox
  */
 
 import { Context, Service } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
-import { CliK8eClient } from '@k8e-sandbox/dsh-k8e-sandbox-client'
+import { CliK8eClient, resolveSandboxTransport, type SandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
 import { GrpcK8eClient } from '@k8e-sandbox/dsh-k8e-sandbox-client/grpc'
 
 /** Configuration for the shared k8e-sandbox owner. */
 export interface Config {
-  /** gRPC gateway endpoint; omission uses the CLI's local auto-discovery. */
+  /** gRPC gateway endpoint; unset resolves via env → ~/.k8e/sandbox/profiles.yaml (KIP-17). */
   endpoint?: string
   /** Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17). */
   profile?: string
@@ -28,6 +35,8 @@ export interface Config {
   allowedHosts?: string[]
   /** Dispose by pausing instead of destroying (PVC retained); Phase 1 destroy-only. */
   pauseOnDispose?: boolean
+  /** How long a failed session creation stays negatively cached (ms). */
+  sessionFailureTtlMs?: number
 }
 
 interface ResolvedConfig {
@@ -36,6 +45,7 @@ interface ResolvedConfig {
   tenant?: string
   allowedHosts?: string[]
   pauseOnDispose: boolean
+  sessionFailureTtlMs: number
 }
 
 interface SchemaResolvedConfig extends Config {
@@ -61,6 +71,7 @@ export class K8eSandboxRuntime extends Service {
     tenant: z.string(),
     allowedHosts: z.array(z.string()),
     pauseOnDispose: z.boolean().default(false),
+    sessionFailureTtlMs: z.number().default(10_000),
   })
 
   /** Validated remote working directory shared by provider adapters. */
@@ -73,9 +84,11 @@ export class K8eSandboxRuntime extends Service {
   readonly runtimeClass: string
 
   private readonly config: ResolvedConfig
-  private readonly client: CliK8eClient
+  private readonly transport: SandboxTransport
   private readonly grpcClient: GrpcK8eClient | undefined
   private sessionId: string | undefined
+  private sessionInFlight: Promise<string> | undefined
+  private sessionUnavailableUntil = 0
   private disposed = false
 
   constructor(ctx: Context, config: Config) {
@@ -88,64 +101,102 @@ export class K8eSandboxRuntime extends Service {
       ...(config.tenant !== undefined ? { tenant: config.tenant } : {}),
       ...(config.allowedHosts !== undefined ? { allowedHosts: config.allowedHosts } : {}),
       pauseOnDispose: resolved.pauseOnDispose,
+      sessionFailureTtlMs: resolved.sessionFailureTtlMs ?? 10_000,
     }
     this.cwd = this.config.cwd
-    this.endpoint = config.endpoint
-    this.certDir = config.certDir
     this.runtimeClass = this.config.runtimeClass
-    this.client = new CliK8eClient({
-      ...(process.env.K8E_SANDBOX_CLI_BIN !== undefined ? { bin: process.env.K8E_SANDBOX_CLI_BIN } : {}),
-      ...(config.profile !== undefined ? { profile: config.profile } : {}),
+
+    // Resolve the gateway: explicit config → env → CLI profiles.yaml (KIP-17).
+    const transportCfg = resolveSandboxTransport({
       ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
+      ...(config.certDir !== undefined ? { certDir: config.certDir } : {}),
+      ...(config.profile !== undefined ? { profile: config.profile } : {}),
     })
-    this.grpcClient = config.endpoint !== undefined
-      ? new GrpcK8eClient({ endpoint: config.endpoint, ...(config.certDir !== undefined ? { certDir: config.certDir } : {}) })
-      : undefined
+    this.endpoint = transportCfg?.endpoint
+    this.certDir = transportCfg?.certDir
+
+    if (transportCfg !== undefined) {
+      // Persistent gRPC connection: fs/exec ops become RPCs, no per-op CLI spawn.
+      this.grpcClient = new GrpcK8eClient({
+        endpoint: transportCfg.endpoint,
+        ...(transportCfg.certDir !== undefined ? { certDir: transportCfg.certDir } : {}),
+      })
+      this.transport = this.grpcClient
+    } else {
+      this.grpcClient = undefined
+      this.transport = new CliK8eClient({
+        ...(process.env.K8E_SANDBOX_CLI_BIN !== undefined ? { bin: process.env.K8E_SANDBOX_CLI_BIN } : {}),
+        ...(config.profile !== undefined ? { profile: config.profile } : {}),
+        ...(config.endpoint !== undefined ? { endpoint: config.endpoint } : {}),
+      })
+    }
 
     ctx.effect(() => async () => {
       this.disposed = true
       if (this.sessionId === undefined) return
       try {
-        await this.client.destroySession(this.sessionId)
+        await this.transport.destroySession(this.sessionId)
       } catch (_destroyFailure) {
         // Best-effort: the session pod is also reclaimed by the warm-pool GC.
       }
+      this.transport.close?.()
     }, 'k8e sandbox teardown')
   }
 
   /**
    * Return the live session id, creating the sandbox session on first use.
-   * @throws when the service is disposing.
+   * Concurrent callers share one in-flight creation; a failed creation is
+   * negatively cached for `sessionFailureTtlMs` so a dead gateway fails fast
+   * on subsequent probes instead of re-dialing create every time.
+   * @throws when the service is disposing or the gateway is unreachable.
    */
   async getSession(): Promise<string> {
     if (this.disposed) throw new Error('k8e sandbox service is disposing')
     if (this.sessionId !== undefined) return this.sessionId
-    const created = await this.client.createSession({
-      runtimeClass: this.config.runtimeClass,
-      ...(this.config.tenant !== undefined ? { tenant: this.config.tenant } : {}),
-      ...(this.config.allowedHosts !== undefined ? { allowedHosts: this.config.allowedHosts } : {}),
-    })
-    if (this.disposed) {
-      await this.client.destroySession(created.sessionId).catch(() => undefined)
-      throw new Error('k8e sandbox service is disposing')
+    const now = Date.now()
+    if (this.sessionUnavailableUntil > now) {
+      const retryIn = Math.ceil((this.sessionUnavailableUntil - now) / 1000)
+      throw new Error(`k8e sandbox: session unavailable (gateway unreachable), retry in ${retryIn}s`)
     }
-    this.sessionId = created.sessionId
-    return this.sessionId
+    if (this.sessionInFlight !== undefined) return this.sessionInFlight
+    this.sessionInFlight = this.createSessionOnce().finally(() => {
+      this.sessionInFlight = undefined
+    })
+    return this.sessionInFlight
   }
 
-  /** Return the shared transport client. */
-  getClient(): CliK8eClient {
-    return this.client
+  private async createSessionOnce(): Promise<string> {
+    try {
+      const created = await this.transport.createSession({
+        runtimeClass: this.config.runtimeClass,
+        ...(this.config.tenant !== undefined ? { tenant: this.config.tenant } : {}),
+        ...(this.config.allowedHosts !== undefined ? { allowedHosts: this.config.allowedHosts } : {}),
+      })
+      if (this.disposed) {
+        await this.transport.destroySession(created.sessionId).catch(() => undefined)
+        throw new Error('k8e sandbox service is disposing')
+      }
+      this.sessionId = created.sessionId
+      return this.sessionId
+    } catch (err) {
+      this.sessionUnavailableUntil = Date.now() + this.config.sessionFailureTtlMs
+      throw err
+    }
+  }
+
+  /** Return the shared transport client (persistent gRPC when an endpoint is resolved). */
+  getClient(): SandboxTransport {
+    return this.transport
   }
 
   /**
-   * Return the direct gRPC client for the terminal primitive. Requires an
-   * explicit `endpoint` (the gRPC client does no local auto-discovery).
+   * Return the direct gRPC client for the terminal primitive. Requires a
+   * resolved endpoint (explicit, env, or profile).
    * @throws when no endpoint is configured.
    */
   getGrpcClient(): GrpcK8eClient {
     if (this.grpcClient === undefined) {
-      throw new Error('k8e sandbox: gRPC terminal requires an explicit `endpoint` config')
+      throw new Error('k8e sandbox: gRPC terminal requires an endpoint (config, K8E_SANDBOX_ENDPOINT, or profiles.yaml)')
     }
     return this.grpcClient
   }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox/src/index.ts
@@ -78,6 +78,10 @@ export class K8eSandboxRuntime extends Service {
   readonly cwd: string
   /** gRPC gateway endpoint (undefined = CLI local auto-discovery). */
   readonly endpoint: string | undefined
+  /** Where the endpoint came from: config | env | profile | undefined. */
+  readonly endpointSource: 'config' | 'env' | 'profile' | undefined
+  /** Selected profile name when the endpoint came from profiles.yaml (KIP-17). */
+  readonly endpointProfile: string | undefined
   /** mTLS material dir for the direct gRPC terminal client. */
   readonly certDir: string | undefined
   /** RuntimeClass for the session pod. */
@@ -113,6 +117,8 @@ export class K8eSandboxRuntime extends Service {
       ...(config.profile !== undefined ? { profile: config.profile } : {}),
     })
     this.endpoint = transportCfg?.endpoint
+    this.endpointSource = transportCfg?.source
+    this.endpointProfile = transportCfg?.profile
     this.certDir = transportCfg?.certDir
 
     if (transportCfg !== undefined) {

--- a/plugins/deepseek-harness/tests/client.test.mjs
+++ b/plugins/deepseek-harness/tests/client.test.mjs
@@ -58,19 +58,30 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
       process.env.K8E_SANDBOX_CERT_DIR = dir
       process.env.K8E_SANDBOX_CONFIG = profilesPath
 
-      // current_profile default wins
+      // current_profile default wins (auto-discovery source recorded)
       const viaDefault = resolveSandboxTransport()
       assert.deepEqual(viaDefault, {
         endpoint: 'ec2-3-37-16-143.ap-northeast-2.compute.amazonaws.com:50051',
+        source: 'profile',
+        profile: 'default',
       })
 
       // explicit profile wins
       const viaProfile = resolveSandboxTransport({ profile: 'local' })
-      assert.deepEqual(viaProfile, { endpoint: '127.0.0.1:50051', certDir: '/tmp/certs' })
+      assert.deepEqual(viaProfile, {
+        endpoint: '127.0.0.1:50051',
+        certDir: '/tmp/certs',
+        source: 'profile',
+        profile: 'local',
+      })
 
       // explicit endpoint beats profile entirely (env cert dir still honored)
       const viaExplicit = resolveSandboxTransport({ endpoint: 'gw.example.com:50051', profile: 'local' })
-      assert.deepEqual(viaExplicit, { endpoint: 'gw.example.com:50051', certDir: dir })
+      assert.deepEqual(viaExplicit, {
+        endpoint: 'gw.example.com:50051',
+        certDir: dir,
+        source: 'config',
+      })
     } finally {
       if (prevConfig !== undefined) process.env.K8E_SANDBOX_CONFIG = prevConfig
       else delete process.env.K8E_SANDBOX_CONFIG

--- a/plugins/deepseek-harness/tests/client.test.mjs
+++ b/plugins/deepseek-harness/tests/client.test.mjs
@@ -1,0 +1,89 @@
+// Unit tests for the k8e-sandbox client transport helpers: language command
+// wrapping (mirrors pkg/sandboxcli buildCommand) and profile resolution
+// (mirrors pkg/sandboxcli/profile.go KIP-17).
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { buildSandboxCommand } from '@k8e-sandbox/dsh-k8e-sandbox-client/grpc'
+import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
+
+// ---- buildSandboxCommand (language wrapping) ---------------------------
+{
+  // bash passes through
+  assert.equal(buildSandboxCommand('bash', 'echo hi'), 'echo hi')
+  assert.equal(buildSandboxCommand(undefined, 'stat -c %s /x'), 'stat -c %s /x')
+
+  // python single-line wraps with -c; multi-line uses the temp file
+  assert.equal(buildSandboxCommand('python', 'print(1)'), 'python3 -c "print(1)"')
+  assert.equal(buildSandboxCommand('python', 'a = 1\nprint(a)'), 'python3 /workspace/_k8e_run.py')
+
+  // node single-line uses -e; multi-line uses the temp file
+  assert.equal(buildSandboxCommand('node', 'console.log(1)'), 'node -e "console.log(1)"')
+  assert.equal(buildSandboxCommand('js', 'const a = 1\nconsole.log(a)'), 'node /workspace/_k8e_run.js')
+
+  // ts always uses the temp file with TMPDIR redirect
+  assert.equal(buildSandboxCommand('ts', 'const x = 1'), 'TMPDIR=/workspace tsx /workspace/_k8e_run.ts')
+
+  // embedded quotes survive the JSON stringify wrapper
+  assert.equal(buildSandboxCommand('python', `print('a"b')`), 'python3 -c "print(\'a\\\"b\')"')
+}
+
+// ---- resolveSandboxTransport (profiles.yaml KIP-17) --------------------
+{
+  const dir = mkdtempSync(join(tmpdir(), 'k8e-profiles-'))
+  const profilesPath = join(dir, 'profiles.yaml')
+  try {
+    writeFileSync(profilesPath, [
+      'version: 1',
+      'current_profile: default',
+      'profiles:',
+      '  default:',
+      '    endpoint: ec2-3-37-16-143.ap-northeast-2.compute.amazonaws.com:50051',
+      '    cert_dir: ""',
+      '    device_name: ""',
+      '  local:',
+      '    endpoint: 127.0.0.1:50051',
+      '    cert_dir: /tmp/certs',
+      '',
+    ].join('\n'), 'utf8')
+
+    const prevConfig = process.env.K8E_SANDBOX_CONFIG
+    const prevCertDir = process.env.K8E_SANDBOX_CERT_DIR
+    const prevEndpoint = process.env.K8E_SANDBOX_ENDPOINT
+    const prevProfile = process.env.K8E_SANDBOX_PROFILE
+    try {
+      delete process.env.K8E_SANDBOX_ENDPOINT
+      delete process.env.K8E_SANDBOX_PROFILE
+      process.env.K8E_SANDBOX_CERT_DIR = dir
+      process.env.K8E_SANDBOX_CONFIG = profilesPath
+
+      // current_profile default wins
+      const viaDefault = resolveSandboxTransport()
+      assert.deepEqual(viaDefault, {
+        endpoint: 'ec2-3-37-16-143.ap-northeast-2.compute.amazonaws.com:50051',
+      })
+
+      // explicit profile wins
+      const viaProfile = resolveSandboxTransport({ profile: 'local' })
+      assert.deepEqual(viaProfile, { endpoint: '127.0.0.1:50051', certDir: '/tmp/certs' })
+
+      // explicit endpoint beats profile entirely (env cert dir still honored)
+      const viaExplicit = resolveSandboxTransport({ endpoint: 'gw.example.com:50051', profile: 'local' })
+      assert.deepEqual(viaExplicit, { endpoint: 'gw.example.com:50051', certDir: dir })
+    } finally {
+      if (prevConfig !== undefined) process.env.K8E_SANDBOX_CONFIG = prevConfig
+      else delete process.env.K8E_SANDBOX_CONFIG
+      if (prevCertDir !== undefined) process.env.K8E_SANDBOX_CERT_DIR = prevCertDir
+      else delete process.env.K8E_SANDBOX_CERT_DIR
+      if (prevEndpoint !== undefined) process.env.K8E_SANDBOX_ENDPOINT = prevEndpoint
+      else delete process.env.K8E_SANDBOX_ENDPOINT
+      if (prevProfile !== undefined) process.env.K8E_SANDBOX_PROFILE = prevProfile
+      else delete process.env.K8E_SANDBOX_PROFILE
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+console.log('✔ client transport helpers test passed (buildSandboxCommand, resolveSandboxTransport)')

--- a/plugins/deepseek-harness/tests/client.test.mjs
+++ b/plugins/deepseek-harness/tests/client.test.mjs
@@ -29,11 +29,34 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
   assert.equal(buildSandboxCommand('python', `print('a"b')`), 'python3 -c "print(\'a\\\"b\')"')
 }
 
+const SANDBOX_ENV_KEYS = ['K8E_SANDBOX_CONFIG', 'K8E_SANDBOX_CERT_DIR', 'K8E_SANDBOX_ENDPOINT', 'K8E_SANDBOX_PROFILE']
+
+/**
+ * Run fn with a scoped set of K8E_SANDBOX_* env vars, restoring the previous
+ * values (or deleting them) afterwards — shared by every profile-resolution test.
+ */
+async function withSandboxEnv(env, fn) {
+  const saved = {}
+  for (const key of SANDBOX_ENV_KEYS) {
+    saved[key] = process.env[key]
+    if (env[key] === undefined) delete process.env[key]
+    else process.env[key] = env[key]
+  }
+  try {
+    await fn()
+  } finally {
+    for (const key of SANDBOX_ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key]
+      else process.env[key] = saved[key]
+    }
+  }
+}
+
 // ---- resolveSandboxTransport (profiles.yaml KIP-17) --------------------
 {
   const dir = mkdtempSync(join(tmpdir(), 'k8e-profiles-'))
-  const profilesPath = join(dir, 'profiles.yaml')
   try {
+    const profilesPath = join(dir, 'profiles.yaml')
     writeFileSync(profilesPath, [
       'version: 1',
       'current_profile: default',
@@ -48,16 +71,7 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
       '',
     ].join('\n'), 'utf8')
 
-    const prevConfig = process.env.K8E_SANDBOX_CONFIG
-    const prevCertDir = process.env.K8E_SANDBOX_CERT_DIR
-    const prevEndpoint = process.env.K8E_SANDBOX_ENDPOINT
-    const prevProfile = process.env.K8E_SANDBOX_PROFILE
-    try {
-      delete process.env.K8E_SANDBOX_ENDPOINT
-      delete process.env.K8E_SANDBOX_PROFILE
-      process.env.K8E_SANDBOX_CERT_DIR = dir
-      process.env.K8E_SANDBOX_CONFIG = profilesPath
-
+    await withSandboxEnv({ K8E_SANDBOX_CERT_DIR: dir, K8E_SANDBOX_CONFIG: profilesPath }, async () => {
       // current_profile default wins (auto-discovery source recorded)
       const viaDefault = resolveSandboxTransport()
       assert.deepEqual(viaDefault, {
@@ -82,16 +96,7 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
         certDir: dir,
         source: 'config',
       })
-    } finally {
-      if (prevConfig !== undefined) process.env.K8E_SANDBOX_CONFIG = prevConfig
-      else delete process.env.K8E_SANDBOX_CONFIG
-      if (prevCertDir !== undefined) process.env.K8E_SANDBOX_CERT_DIR = prevCertDir
-      else delete process.env.K8E_SANDBOX_CERT_DIR
-      if (prevEndpoint !== undefined) process.env.K8E_SANDBOX_ENDPOINT = prevEndpoint
-      else delete process.env.K8E_SANDBOX_ENDPOINT
-      if (prevProfile !== undefined) process.env.K8E_SANDBOX_PROFILE = prevProfile
-      else delete process.env.K8E_SANDBOX_PROFILE
-    }
+    })
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -101,8 +106,8 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
 // SelectProfileName parity): a blank value is "unset", not a valid selection.
 {
   const dir = mkdtempSync(join(tmpdir(), 'k8e-profiles-empty-'))
-  const profilesPath = join(dir, 'profiles.yaml')
   try {
+    const profilesPath = join(dir, 'profiles.yaml')
     writeFileSync(profilesPath, [
       'version: 1',
       'current_profile: ""',
@@ -112,32 +117,14 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
       '',
     ].join('\n'), 'utf8')
 
-    const prevConfig = process.env.K8E_SANDBOX_CONFIG
-    const prevCertDir = process.env.K8E_SANDBOX_CERT_DIR
-    const prevEndpoint = process.env.K8E_SANDBOX_ENDPOINT
-    const prevProfile = process.env.K8E_SANDBOX_PROFILE
-    try {
-      delete process.env.K8E_SANDBOX_ENDPOINT
-      delete process.env.K8E_SANDBOX_PROFILE
-      process.env.K8E_SANDBOX_CERT_DIR = dir
-      process.env.K8E_SANDBOX_CONFIG = profilesPath
-
+    await withSandboxEnv({ K8E_SANDBOX_CERT_DIR: dir, K8E_SANDBOX_CONFIG: profilesPath }, async () => {
       const viaEmptyCurrent = resolveSandboxTransport()
       assert.deepEqual(viaEmptyCurrent, {
         endpoint: '127.0.0.1:50051',
         source: 'profile',
         profile: 'default',
       })
-    } finally {
-      if (prevConfig !== undefined) process.env.K8E_SANDBOX_CONFIG = prevConfig
-      else delete process.env.K8E_SANDBOX_CONFIG
-      if (prevCertDir !== undefined) process.env.K8E_SANDBOX_CERT_DIR = prevCertDir
-      else delete process.env.K8E_SANDBOX_CERT_DIR
-      if (prevEndpoint !== undefined) process.env.K8E_SANDBOX_ENDPOINT = prevEndpoint
-      else delete process.env.K8E_SANDBOX_ENDPOINT
-      if (prevProfile !== undefined) process.env.K8E_SANDBOX_PROFILE = prevProfile
-      else delete process.env.K8E_SANDBOX_PROFILE
-    }
+    })
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/plugins/deepseek-harness/tests/client.test.mjs
+++ b/plugins/deepseek-harness/tests/client.test.mjs
@@ -97,4 +97,50 @@ import { resolveSandboxTransport } from '@k8e-sandbox/dsh-k8e-sandbox-client'
   }
 }
 
+// Empty current_profile must fall back to the "default" profile (CLI
+// SelectProfileName parity): a blank value is "unset", not a valid selection.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'k8e-profiles-empty-'))
+  const profilesPath = join(dir, 'profiles.yaml')
+  try {
+    writeFileSync(profilesPath, [
+      'version: 1',
+      'current_profile: ""',
+      'profiles:',
+      '  default:',
+      '    endpoint: 127.0.0.1:50051',
+      '',
+    ].join('\n'), 'utf8')
+
+    const prevConfig = process.env.K8E_SANDBOX_CONFIG
+    const prevCertDir = process.env.K8E_SANDBOX_CERT_DIR
+    const prevEndpoint = process.env.K8E_SANDBOX_ENDPOINT
+    const prevProfile = process.env.K8E_SANDBOX_PROFILE
+    try {
+      delete process.env.K8E_SANDBOX_ENDPOINT
+      delete process.env.K8E_SANDBOX_PROFILE
+      process.env.K8E_SANDBOX_CERT_DIR = dir
+      process.env.K8E_SANDBOX_CONFIG = profilesPath
+
+      const viaEmptyCurrent = resolveSandboxTransport()
+      assert.deepEqual(viaEmptyCurrent, {
+        endpoint: '127.0.0.1:50051',
+        source: 'profile',
+        profile: 'default',
+      })
+    } finally {
+      if (prevConfig !== undefined) process.env.K8E_SANDBOX_CONFIG = prevConfig
+      else delete process.env.K8E_SANDBOX_CONFIG
+      if (prevCertDir !== undefined) process.env.K8E_SANDBOX_CERT_DIR = prevCertDir
+      else delete process.env.K8E_SANDBOX_CERT_DIR
+      if (prevEndpoint !== undefined) process.env.K8E_SANDBOX_ENDPOINT = prevEndpoint
+      else delete process.env.K8E_SANDBOX_ENDPOINT
+      if (prevProfile !== undefined) process.env.K8E_SANDBOX_PROFILE = prevProfile
+      else delete process.env.K8E_SANDBOX_PROFILE
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
 console.log('✔ client transport helpers test passed (buildSandboxCommand, resolveSandboxTransport)')

--- a/plugins/deepseek-harness/tests/fs.test.mjs
+++ b/plugins/deepseek-harness/tests/fs.test.mjs
@@ -1,7 +1,11 @@
 // Fake-ctx runtime test for the filesystem provider: mount K8eFileSystem on a
-// fake ctx with a fake owner + fake CliK8eClient (an in-memory file map), then
-// assert resolve/read/write/edit/list map correctly.
+// fake ctx with a fake owner + fake transport (an in-memory file map), then
+// assert resolve/read/write/edit/list map correctly, listDir uses entry facts
+// (no per-child stat), and host-absolute paths stay on the local disk.
 import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { K8eFileSystem } from '@k8e-sandbox/dsh-k8e-sandbox-fs'
 
 function makeCliClient(files) {
@@ -19,7 +23,13 @@ function makeCliClient(files) {
     },
     async list(sid) {
       calls.push(['list', sid])
-      return [...files.keys()].map((path) => ({ path, modified: 0 }))
+      // Gateway entry facts: type/size arrive with the single ListFiles RPC.
+      return [...files.keys()].map((path) => ({
+        path,
+        modified: 0,
+        type: 'file',
+        size: files.get(path).length,
+      }))
     },
     async run(code, opts) {
       calls.push(['run', code, opts])
@@ -99,15 +109,55 @@ function makeCtx(owner) {
   assert.equal(editOutcome.after, 'hello there')
   assert.equal(files.get('/workspace/hello.txt'), 'hello there')
 
-  // listDir returns only direct-child files (k8e ListFiles lists files, not dirs)
+  // listDir returns only direct-child files; entry facts (type/size) arrive in
+  // the single ListFiles RPC — no per-child `run` stat (KIP-20 perf).
   files.set('/workspace/sub/a.txt', 'a')
   files.set('/workspace/root.txt', 'r')
+  const runCallsBeforeList = client.calls.filter(([op]) => op === 'run').length
   const entries = await fs.listDir(await fs.resolve('.'))
+  const runCallsAfterList = client.calls.filter(([op]) => op === 'run').length
+  assert.equal(runCallsAfterList, runCallsBeforeList, 'listDir must not spawn per-child stat probes')
   const names = entries.map((e) => e.name).sort()
   assert.deepEqual(names, ['hello.txt', 'new.txt', 'root.txt'])
   const txt = entries.find((e) => e.name === 'root.txt')
   assert.equal(txt.type, 'file')
-  assert.equal(txt.size, 1, 'size carried from the stat probe')
+  assert.equal(txt.size, 1, 'size carried from ListFiles entry facts')
 }
 
-console.log('✔ fs fake-ctx test passed (path primitives, read/write/edit/list)')
+// ---- host-absolute paths stay on the local disk (preflight local) ----
+{
+  const hostDir = mkdtempSync(join(tmpdir(), 'k8e-fs-host-'))
+  try {
+    writeFileSync(join(hostDir, 'AGENTS.md'), '# local instructions\n', 'utf8')
+    writeFileSync(join(hostDir, 'nested.txt'), 'n', 'utf8')
+    const files = new Map()
+    const client = makeCliClient(files)
+    const owner = { getClient: () => client, getSession: async () => 's1', cwd: '/workspace' }
+    const fs = new K8eFileSystem(makeCtx(owner))
+
+    // stat reads host metadata without touching the sandbox transport
+    const info = await fs.stat(await fs.resolve(join(hostDir, 'AGENTS.md')))
+    assert.equal(info.type, 'file')
+    assert.equal(info.size, 21)
+
+    // readText reads the local file
+    assert.equal(await fs.readText(await fs.resolve(join(hostDir, 'AGENTS.md'))), '# local instructions\n')
+
+    // listDir reads the local directory
+    const entries = await fs.listDir(await fs.resolve(hostDir))
+    assert.deepEqual(entries.map((e) => e.name).sort(), ['AGENTS.md', 'nested.txt'])
+    assert.equal(entries.find((e) => e.name === 'AGENTS.md').type, 'file')
+
+    // none of the host ops may touch the sandbox transport at all
+    assert.equal(client.calls.length, 0, 'host-absolute paths must not hit the sandbox transport')
+
+    // writeText on a host path writes locally
+    const outcome = await fs.writeText(await fs.resolve(join(hostDir, 'new.md')), 'hello')
+    assert.equal(outcome.operation, 'create')
+    assert.equal(readFileSync(join(hostDir, 'new.md'), 'utf8'), 'hello')
+  } finally {
+    rmSync(hostDir, { recursive: true, force: true })
+  }
+}
+
+console.log('✔ fs fake-ctx test passed (path primitives, read/write/edit/list, host-local preflight)')

--- a/plugins/deepseek-harness/tests/fs.test.mjs
+++ b/plugins/deepseek-harness/tests/fs.test.mjs
@@ -52,6 +52,12 @@ function makeCtx(owner) {
   return ctx
 }
 
+/** Fresh sandbox owner whose transport is an in-memory file map. */
+function makeSandboxOwner(files) {
+  const client = makeCliClient(files)
+  return { getClient: () => client, getSession: async () => 's1', cwd: '/workspace' }
+}
+
 // ---- pure path primitives ------------------------------------------
 {
   const files = new Map()
@@ -73,8 +79,8 @@ function makeCtx(owner) {
 // ---- readText / writeText (create + update) / editText / listDir ----
 {
   const files = new Map([['/workspace/hello.txt', 'hello world']])
-  const client = makeCliClient(files)
-  const owner = { getClient: () => client, getSession: async () => 's1', cwd: '/workspace' }
+  const owner = makeSandboxOwner(files)
+  const client = owner.getClient()
   const fs = new K8eFileSystem(makeCtx(owner))
 
   // readText
@@ -131,8 +137,8 @@ function makeCtx(owner) {
     writeFileSync(join(hostDir, 'AGENTS.md'), '# local instructions\n', 'utf8')
     writeFileSync(join(hostDir, 'nested.txt'), 'n', 'utf8')
     const files = new Map()
-    const client = makeCliClient(files)
-    const owner = { getClient: () => client, getSession: async () => 's1', cwd: '/workspace' }
+    const owner = makeSandboxOwner(files)
+    const client = owner.getClient()
     const fs = new K8eFileSystem(makeCtx(owner))
 
     // stat reads host metadata without touching the sandbox transport

--- a/proto/sandbox/v1/sandbox.proto
+++ b/proto/sandbox/v1/sandbox.proto
@@ -145,7 +145,15 @@ message ListFilesRequest  {
   int64  since      = 2;
 }
 message ListFilesResponse { repeated FileEntry files = 1; }
-message FileEntry         { string path = 1; int64 modified = 2; }
+message FileEntry {
+  string path     = 1;
+  int64  modified = 2;
+  // Entry type (file/dir/symlink/other) and size carried by the single
+  // ListFiles RPC so clients can build a directory listing without a
+  // per-entry stat round trip (KIP-20 perf).
+  string type = 3;
+  int64  size = 4;
+}
 
 message PipInstallRequest  { string session_id = 1; repeated string packages = 2; }
 message PipInstallResponse { string output = 1; int32 exit_code = 2; }

--- a/sandboxd/src/files.zig
+++ b/sandboxd/src/files.zig
@@ -131,7 +131,7 @@ pub fn handleList(allocator: std.mem.Allocator, client_fd: i32, query: []const u
         first = false;
         const escaped = try exec.jsonEscape(allocator, e.path);
         defer allocator.free(escaped);
-        const item = try std.fmt.allocPrint(allocator, "{{\"path\":\"{s}\",\"modified\":{d}}}", .{ escaped, e.modified });
+        const item = try std.fmt.allocPrint(allocator, "{{\"path\":\"{s}\",\"modified\":{d},\"type\":\"{s}\",\"size\":{d}}}", .{ escaped, e.modified, e.type, e.size });
         defer allocator.free(item);
         try json_buf.appendSlice(item);
     }
@@ -184,15 +184,20 @@ fn listDirRecursive(allocator: std.mem.Allocator, entries: *std.array_list.Manag
             }
 
             // Modification time via statx (real mtime, not 0 — KIP-16 M2
-            // enables diff/since-based incremental snapshots).
-            const mtime = fileMtime(entry_path) orelse 0;
+            // enables diff/since-based incremental snapshots). Type/size ride
+            // the same single list RPC so clients skip per-entry stats
+            // (KIP-20 perf).
+            const facts = fileFacts(entry_path, dent.type) orelse {
+                allocator.free(entry_path);
+                continue;
+            };
 
-            if (since > 0 and mtime < since) {
+            if (since > 0 and facts.mtime < since) {
                 allocator.free(entry_path);
                 continue;
             }
 
-            try entries.append(.{ .path = entry_path, .modified = mtime });
+            try entries.append(.{ .path = entry_path, .modified = facts.mtime, .type = facts.type, .size = facts.size });
         }
     }
 }
@@ -200,7 +205,42 @@ fn listDirRecursive(allocator: std.mem.Allocator, entries: *std.array_list.Manag
 const FileEntry = struct {
     path: []u8,
     modified: i64,
+    type: []const u8,
+    size: i64,
 };
+
+/// fileFacts returns the entry's mtime (unix seconds), size, and type via the
+/// statx syscall (or dent type fallback). size is 0 for directories; type is
+/// one of "file" / "dir" / "symlink" / "other". Returns null on any error.
+pub fn fileFacts(path: []const u8, dent_type: u8) ?struct { mtime: i64, size: i64, type: []const u8 } {
+    var path_z_buf: [4096]u8 = undefined;
+    if (path.len >= path_z_buf.len) return null;
+    @memcpy(path_z_buf[0..path.len], path);
+    path_z_buf[path.len] = 0;
+    const path_z: [*:0]const u8 = @ptrCast(&path_z_buf);
+
+    var stx: std.os.linux.Statx = undefined;
+    const rc = std.os.linux.statx(
+        std.os.linux.AT.FDCWD,
+        path_z,
+        0, // follow symlinks like read does
+        std.os.linux.STATX.BASIC_STATS,
+        &stx,
+    );
+    if (rc != 0) return null;
+    // Check the mask actually reports mtime (varies by kernel/filesystem).
+    // STATX_MTIME = 0x40 = bit 6.
+    const stx_mask: u32 = @bitCast(stx.mask);
+    const mtime_bit: u32 = 1 << 6;
+    if (stx_mask & mtime_bit == 0) return null;
+    const ftype: []const u8 = switch (dent_type) {
+        std.os.linux.DT.DIR => "dir",
+        std.os.linux.DT.REG => "file",
+        std.os.linux.DT.LNK => "symlink",
+        else => "other",
+    };
+    return .{ .mtime = stx.mtime.sec, .size = @intCast(stx.size), .type = ftype };
+}
 
 /// fileMtime returns the file's last-modification time (unix seconds) via the
 /// statx syscall, or null on any error. statx works on Linux targets; the

--- a/sandboxd/src/files_test.zig
+++ b/sandboxd/src/files_test.zig
@@ -74,6 +74,51 @@ test "fileMtime: existing file returns non-zero mtime" {
     _ = a;
 }
 
+// fileFacts returns mtime + size + a type label derived from the dent type
+// (Linux-only; uses the statx syscall which is unavailable on macOS hosts).
+test "fileFacts: regular file reports file type and size" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+
+    const path = "/tmp/k8e-files-facts-test.txt";
+    const fd = std.os.linux.open(path, std.os.linux.O{ .CREAT = true, .ACCMODE = .WRONLY, .TRUNC = true }, 0o644);
+    if (fd < 0) return error.TestUnexpectedResult;
+    _ = std.os.linux.write(@intCast(fd), "hello", 5);
+    _ = std.os.linux.close(@intCast(fd));
+    defer _ = std.os.linux.unlink(path);
+
+    const facts = (files.fileFacts(path, std.os.linux.DT.REG) orelse return error.TestUnexpectedResult);
+    try std.testing.expectEqualStrings("file", facts.type);
+    try std.testing.expectEqual(@as(i64, 5), facts.size);
+    try std.testing.expect(facts.mtime > 1_500_000_000);
+}
+
+test "fileFacts: symlink dent reports symlink type" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+
+    const path = "/tmp/k8e-files-facts-link";
+    const target = "/tmp/k8e-files-facts-target";
+    const tfd = std.os.linux.open(target, std.os.linux.O{ .CREAT = true, .ACCMODE = .WRONLY, .TRUNC = true }, 0o644);
+    if (tfd < 0) return error.TestUnexpectedResult;
+    _ = std.os.linux.close(@intCast(tfd));
+    defer _ = std.os.linux.unlink(target);
+
+    var path_buf: [512]u8 = undefined;
+    @memcpy(path_buf[0..path.len], path);
+    path_buf[path.len] = 0;
+    const path_z: [*:0]const u8 = @ptrCast(&path_buf);
+    var target_buf: [512]u8 = undefined;
+    @memcpy(target_buf[0..target.len], target);
+    target_buf[target.len] = 0;
+    const target_z: [*:0]const u8 = @ptrCast(&target_buf);
+    _ = std.os.linux.unlink(path_z);
+    const rc = std.os.linux.symlink(target_z, path_z);
+    if (rc != 0) return error.TestUnexpectedResult;
+    defer _ = std.os.linux.unlink(path_z);
+
+    const facts = (files.fileFacts(path, std.os.linux.DT.LNK) orelse return error.TestUnexpectedResult);
+    try std.testing.expectEqualStrings("symlink", facts.type);
+}
+
 test "removeRecursive: removes nested dir tree" {
     if (builtin.os.tag != .linux) return error.SkipZigTest;
 


### PR DESCRIPTION
## 背景

在 deepseek harness 挂载 `dsh-k8e-sandbox` 后聊天显著变慢。排查确认根因：

- bundle 的 `cordis.patch.yml` 把本地 fs/subprocess 换成 k8e 实现，而 **每个 fs 操作都 spawn 一次 36MB `k8e-sandbox-cli`**（mTLS 拨号 + pod exec）
- dsh 在**第一条模型请求前**要做 30+ 次 fs 预检（AGENTS.md / skill 发现），网关慢时单轮预检 ≈ 150s，网关不可达时无任何 deadline 直接挂死
- listDir 是 N+1（1 次 list + 每子项 1 次 stat）；`getSession()` 失败不缓存 → create 风暴

## 改动

**插件侧（不依赖网关健康即可提速）：**
- `GrpcK8eClient` 补齐完整操作面（exec / poll / read / write / list / create/destroy session / status），一个连接复用，零 CLI spawn
- 全部 unary RPC 带 deadline，channel 快速失败退避（200ms/2s）
- `K8eSandboxRuntime` 自解析 endpoint（config → env → profiles.yaml KIP-17），失败负缓存 10s + 单飞
- `listDir` 直接用 ListFiles entry facts（type/size），禁 per-child stat
- **宿主绝对路径（AGENTS.md / skills 预检）走本地盘**，只有 workspace 路径进沙箱

**网关/协议侧：**
- proto `FileEntry` + `type/size`（pb 已重新生成）
- sandboxd `/files/list` 用原生 statx 一次带出 mtime+size+type（无 shell、无 N+1）
- 网关归一化 `dir→directory`；旧 sandboxd 自动回退
- 客户端 `dialErr` 补 EOF/连接关闭恢复提示（CA 轮换 → 重跑 connect）

## 验证

| 套件 | 结果 |
|---|---|
| TS 插件测试（client/fs/grpc-sse/subprocess 4 文件） | ✅ |
| Go（sandboxmatrix / client / e2b） | ✅ |
| sandboxd zig tests + 3 目标交叉编译 | ✅ |
| `TestTLSGatewayLoop`（真实 mTLS 引导 + status probe 环回） | ✅ |

## 遗留

AWS 远端网关的 `handshake EOF` 为环境问题（实例当前不可达 / 缓存证书可能属旧 CA 代）。实例恢复后需重跑 `k8e sandbox connect --apikey ...` 重新引导客户端证书。