### PR TITLE
feat(sandbox-cli): install k8e-sandbox skill into dsh (DeepSeek Harness)

### DIFF
--- a/pkg/sandboxcli/connect.go
+++ b/pkg/sandboxcli/connect.go
@@ -23,7 +23,8 @@ const (
 // ConnectCommand returns the "connect" subcommand: authenticate (local or remote),
 // persist connection config, verify the gateway, ensure CLI is on PATH, and install
 // agent skills so harnesses can invoke `/k8e-sandbox <goal>` (Claude),
-// `$k8e-sandbox <goal>` (Codex), or `/skill:k8e-sandbox <goal>` (Pi).
+// `$k8e-sandbox <goal>` (Codex), `/skill:k8e-sandbox <goal>` (Pi), or load the
+// `k8e-sandbox` skill in dsh (DeepSeek Harness) via its `skill` tool.
 func ConnectCommand() cli.Command {
 	return cli.Command{
 		Name:  "connect",
@@ -32,7 +33,7 @@ func ConnectCommand() cli.Command {
 			cli.StringFlag{
 				Name:  flagAgent,
 				Value: "auto",
-				Usage: "Skill install target: auto|claude|codex|pi|all (default: auto-detect)",
+				Usage: "Skill install target: auto|claude|codex|pi|dsh|all (default: auto-detect)",
 			},
 			cli.BoolFlag{
 				Name:  flagSkipSkill,

--- a/pkg/sandboxcli/connect_test.go
+++ b/pkg/sandboxcli/connect_test.go
@@ -73,9 +73,22 @@ func TestResolveSkillTargets(t *testing.T) {
 	if err != nil || len(got) != 1 || got[0] != "claude" {
 		t.Fatalf("claude: %v %v", got, err)
 	}
+	got, err = resolveSkillTargets("dsh")
+	if err != nil || len(got) != 1 || got[0] != "dsh" {
+		t.Fatalf("dsh: %v %v", got, err)
+	}
 	got, err = resolveSkillTargets("all")
-	if err != nil || len(got) != 3 {
+	if err != nil || len(got) != 4 {
 		t.Fatalf("all: %v %v", got, err)
+	}
+	found := false
+	for _, a := range got {
+		if a == "dsh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("all must include dsh: %v", got)
 	}
 	if _, err := resolveSkillTargets("bogus"); err == nil {
 		t.Fatal("expected error for bogus agent")
@@ -150,6 +163,56 @@ func TestInstallSkillMulti_ClaudeWritesGlobalAndAgents(t *testing.T) {
 	agentsDest := filepath.Join(tmp, ".agents", "skills", "k8e-sandbox", "SKILL.md")
 	if _, err := os.Stat(agentsDest); err != nil {
 		t.Fatalf("missing .agents skill path: %v", err)
+	}
+}
+
+func TestInstallSkillMulti_DshPaths(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	dshHome := filepath.Join(tmp, "custom-dsh")
+	t.Setenv("DSH_HOME", dshHome)
+
+	results, err := InstallSkillMulti("dsh", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected >=2 install locations, got %v", results)
+	}
+	// $DSH_HOME/skills is the dsh user-dsh root (higher rank than .agents).
+	dest := filepath.Join(dshHome, "skills", "k8e-sandbox", "SKILL.md")
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("missing dsh global skill: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "dsh (DeepSeek Harness) execution path") {
+		t.Fatal("skill must carry the dsh execution path section")
+	}
+	if !strings.Contains(body, "k8e_sandbox_exec") {
+		t.Fatal("skill must mention the dsh plugin model-surface tools")
+	}
+	// Shared .agents path for cross-harness discovery.
+	agentsDest := filepath.Join(tmp, ".agents", "skills", "k8e-sandbox", "SKILL.md")
+	if _, err := os.Stat(agentsDest); err != nil {
+		t.Fatalf("missing .agents skill path: %v", err)
+	}
+}
+
+func TestInvocationHints_Dsh(t *testing.T) {
+	lines := InvocationHints([]string{"dsh", "claude"})
+	var dshLine, claudeLine bool
+	for _, l := range lines {
+		if strings.HasPrefix(l, "dsh:") {
+			dshLine = true
+		}
+		if strings.HasPrefix(l, "Claude Code:") {
+			claudeLine = true
+		}
+	}
+	if !dshLine || !claudeLine {
+		t.Fatalf("expected dsh + claude hints, got %v", lines)
 	}
 }
 

--- a/pkg/sandboxcli/install.go
+++ b/pkg/sandboxcli/install.go
@@ -26,6 +26,7 @@ const (
 	dirCodex  = ".codex"
 	dirAgents = ".agents"
 	dirPi     = ".pi"
+	dirDsh    = ".dsh"
 )
 
 // skillDest is one filesystem location where the skill should be written.
@@ -36,13 +37,13 @@ type skillDest struct {
 
 // InstallResult records one install destination for user-facing summary.
 type InstallResult struct {
-	Agent string // claude | codex | pi
+	Agent string // claude | codex | pi | dsh
 	Path  string
 	Label string
 }
 
 // InstallSkill installs skill files into the given agent (refresh if content differs).
-// target: "claude", "codex", "pi", or "all"
+// target: "claude", "codex", "pi", "dsh", or "all"
 func InstallSkill(target string) error {
 	_, err := InstallSkillMulti(target, false)
 	return err
@@ -128,8 +129,10 @@ func skillDestsForAgent(agent, home string) ([]skillDest, error) {
 		return codexSkillDests(home), nil
 	case "pi":
 		return piSkillDests(home), nil
+	case "dsh":
+		return dshSkillDests(home), nil
 	default:
-		return nil, fmt.Errorf("unknown target %q (want claude|codex|pi)", agent)
+		return nil, fmt.Errorf("unknown target %q (want claude|codex|pi|dsh)", agent)
 	}
 }
 
@@ -177,6 +180,32 @@ func piSkillDests(home string) []skillDest {
 	return dests
 }
 
+// dshHome returns the DeepSeek Harness config root: $DSH_HOME or ~/.dsh
+// (mirrors @deepseek-ai/dsh-home-paths resolveDshHome).
+func dshHome() string {
+	if h := strings.TrimSpace(os.Getenv("DSH_HOME")); h != "" {
+		return h
+	}
+	return filepath.Join(homeDir(), dirDsh)
+}
+
+// dshSkillDests: $DSH_HOME/skills (default ~/.dsh/skills — the user-dsh root
+// dsh scans at a higher rank than ~/.agents/skills) plus ~/.agents/skills for
+// cross-harness discovery. The model loads the skill via the `skill` tool.
+func dshSkillDests(home string) []skillDest {
+	dests := []skillDest{
+		{"dsh (global)", filepath.Join(dshHome(), "skills")},
+		{"dsh (.agents global)", filepath.Join(home, dirAgents, "skills")},
+	}
+	if pathExists(dirDsh) {
+		dests = append(dests, skillDest{"dsh (workspace)", filepath.Join(dirDsh, "skills")})
+	}
+	if pathExists(dirAgents) {
+		dests = append(dests, skillDest{"dsh (.agents workspace)", filepath.Join(dirAgents, "skills")})
+	}
+	return dests
+}
+
 // resolveSkillTargets expands "auto" / named targets into concrete agent names.
 func resolveSkillTargets(agentFlag string) ([]string, error) {
 	agentFlag = strings.TrimSpace(strings.ToLower(agentFlag))
@@ -184,14 +213,14 @@ func resolveSkillTargets(agentFlag string) ([]string, error) {
 		agentFlag = "auto"
 	}
 	switch agentFlag {
-	case "claude", "codex", "pi":
+	case "claude", "codex", "pi", "dsh":
 		return []string{agentFlag}, nil
 	case "all":
-		return []string{"claude", "codex", "pi"}, nil
+		return []string{"claude", "codex", "pi", "dsh"}, nil
 	case "auto":
 		return detectAvailableAgents(), nil
 	default:
-		return nil, fmt.Errorf("unknown --agent %q (want auto|claude|codex|pi|all)", agentFlag)
+		return nil, fmt.Errorf("unknown --agent %q (want auto|claude|codex|pi|dsh|all)", agentFlag)
 	}
 }
 
@@ -209,6 +238,11 @@ func detectAvailableAgents() []string {
 	if pathExists(dirPi) || pathExists(filepath.Join(home, dirPi)) ||
 		pathExists(filepath.Join(home, dirAgents)) {
 		found = append(found, "pi")
+	}
+	// dsh: ~/.dsh (DeepSeek Harness config root)
+	if pathExists(dirDsh) || pathExists(filepath.Join(home, dirDsh)) ||
+		pathExists(filepath.Join(home, dirAgents)) {
+		found = append(found, "dsh")
 	}
 	if len(found) == 0 {
 		return []string{"claude", "codex", "pi"}
@@ -324,6 +358,8 @@ func InvocationHints(agents []string) []string {
 			lines = append(lines, "Codex:        $k8e-sandbox <goal>   (or /skills → k8e-sandbox)")
 		case "pi":
 			lines = append(lines, "Pi:           /skill:k8e-sandbox <goal>   (or /k8e-sandbox if skill commands enabled)")
+		case "dsh":
+			lines = append(lines, "dsh:          skill tool — the model loads k8e-sandbox by name, or the user names it directly in chat")
 		}
 	}
 	return lines

--- a/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
+++ b/pkg/sandboxcli/skills/k8e-sandbox/SKILL.md
@@ -13,6 +13,7 @@ Treat this as the **k8e-sandbox** skill command.
 - Claude Code: `/k8e-sandbox <goal>`
 - Codex: `$k8e-sandbox <goal>` (or pick from `/skills`)
 - Pi: `/skill:k8e-sandbox <goal>` (or `/k8e-sandbox` when skill commands are enabled)
+- dsh (DeepSeek Harness): the model loads this skill via the `skill` tool (catalog name `k8e-sandbox`), or the user names it directly in chat — see [dsh execution path](#dsh-deepseek-harness-execution-path) below
 
 **Goal from invocation arguments:**
 
@@ -21,6 +22,21 @@ $ARGUMENTS
 ```
 
 If `$ARGUMENTS` is empty and no goal is otherwise provided, ask the user for a sandbox goal and **stop** (do not invent work).
+
+## dsh (DeepSeek Harness) execution path
+
+When running inside dsh with the `dsh-k8e-sandbox` plugin mounted, the harness's fs / subprocess seams are already **replaced by the sandbox** — the model's `read`/`write`/`bash` land in the sandbox `/workspace` automatically. **Do not run `k8e-sandbox-cli` in this harness**: it is not present inside the sandbox, and invoking it would recursively dial the gateway from inside the pod.
+
+Instead use the plugin's model-surface tools (no CLI, no per-op spawn):
+
+- `k8e_sandbox_exec` — foreground command, returns stdout/stderr/exit code (equivalent of `run`)
+- `k8e_sandbox_run_background` + `k8e_sandbox_poll` — long-running / streaming tasks
+- `k8e_sandbox_session_status` / `k8e_sandbox_session_destroy` — session lifecycle
+- fs seam: `read`/`write`/`edit` on paths relative to the sandbox cwd (default `/workspace`); directory listings carry type/size in one RPC
+
+Session, connection, and mTLS are owned by the plugin: it resolves the gateway from config → env → `~/.k8e/sandbox/profiles.yaml` (KIP-17) and reuses one persistent gRPC connection. If the gateway is unreachable, tell the user to run `k8e-sandbox-cli connect` (local) or `k8e-sandbox-cli connect --endpoint <host>:50051 --apikey <key>` (remote) outside dsh, then restart the dsh session.
+
+The CLI-first flow below (`k8e-sandbox-cli run ...`) is for harnesses where the sandbox is *not* mounted (Claude Code / Codex / Pi).
 
 ## Binary naming (read this first)
 
@@ -155,7 +171,7 @@ k8e-sandbox-cli connect --endpoint <server-ip>:50051 --apikey k8e-...
 # Multi-cluster: k8e-sandbox-cli --profile prod connect --apikey k8e-...
 ```
 
-`connect` authenticates (mTLS), verifies the gateway, puts `k8e-sandbox-cli` on PATH when needed (symlink to `~/.local/bin/k8e-sandbox-cli`), and installs this skill into Claude / Codex / Pi discovery paths.
+`connect` authenticates (mTLS), verifies the gateway, puts `k8e-sandbox-cli` on PATH when needed (symlink to `~/.local/bin/k8e-sandbox-cli`), and installs this skill into Claude / Codex / Pi / dsh discovery paths (`--agent dsh` or `--agent all`; dsh reads it from `~/.dsh/skills` or `~/.agents/skills`).
 
 ## Command reference
 


### PR DESCRIPTION
## 背景

`k8e sandbox connect` 会把 k8e-sandbox SKILL.md 装进 claude/codex/pi 的发现路径，但 **dsh（deepseek-harness）不是显式目标**。虽然 dsh 会扫 `~/.agents/skills`（connect --agent all 间接覆盖），但缺三样东西：

1. 显式 `--agent dsh` 目标 → 装到 `$DSH_HOME/skills`（user-dsh root，dsh 优先级高于 .agents）
2. SKILL.md 的调用说明没有 dsh（模型经 `skill` tool 加载 / 用户直接点名）
3. **dsh 专属执行路径缺失**：dsh 插件把 fs/subprocess seam 换成了沙箱，skill 里教的 `k8e-sandbox-cli run` 在 dsh 里会跑在沙箱内部 → 递归拨号网关

## 改动

- **install.go**：`dsh` target（`$DSH_HOME/skills`，默认 `~/.dsh/skills` + `~/.agents/skills`）；`--agent all` 含 dsh；`--agent auto` 检测 `~/.dsh`；`InvocationHints` 加 dsh 行
- **connect.go**：flag 帮助 + doc 提及 dsh
- **SKILL.md**：Invocation 段加 dsh；新增 "dsh (DeepSeek Harness) execution path" 段——dsh 下直接用 `k8e_sandbox_exec` / `k8e_sandbox_run_background` / `k8e_sandbox_poll` / fs seam，**不要执行 k8e-sandbox-cli**（沙箱内不存在且会递归拨号）

## 验证

- 单测：`resolveSkillTargets` 认 dsh / all 含 dsh；dsh 安装写 `$DSH_HOME/skills` + `~/.agents/skills` 且带 dsh 执行段；`InvocationHints` 输出 dsh 行 ✅
- 实测：`k8e-sandbox-cli connect --agent dsh --skill-only` → 装到真实 `~/.dsh/skills/k8e-sandbox/SKILL.md` + `~/.agents/skills`，输出 dsh 调用提示 ✅