### PR TITLE
fix(sandbox-cli): reclaim stale 'creating' session state + bound RPC deadlines

### DIFF
--- a/pkg/sandboxcli/commands.go
+++ b/pkg/sandboxcli/commands.go
@@ -80,10 +80,18 @@ func ensureSession(client *client.Client, ctx *cli.Context) (string, bool, error
 	if raw := ctx.String("allowed-hosts"); raw != "" {
 		hosts = strings.Split(raw, ",")
 	}
-	resp, err := client.SandboxServiceClient.CreateSession(context.Background(), &pb.CreateSessionRequest{
+	// Bound the create RPC: without a deadline a dead gateway hangs the command
+	// and leaves a "creating" placeholder that wedges later runs (session.go
+	// reclaims it only after the stale window).
+	cctx, cancel := context.WithTimeout(context.Background(), sessionCreateTimeout)
+	defer cancel()
+	resp, err := client.SandboxServiceClient.CreateSession(cctx, &pb.CreateSessionRequest{
 		TenantId: ctx.String("tenant"), RuntimeClass: "gvisor", AllowedHosts: hosts,
 	})
 	if err != nil {
+		// Never leave a "creating" placeholder behind on failure: the next run
+		// must be able to retry immediately instead of waiting for stale recovery.
+		_ = clearState(ctx.String("tenant"))
 		return "", false, fmt.Errorf("create session: %w", err)
 	}
 	sid = resp.SessionId
@@ -91,11 +99,13 @@ func ensureSession(client *client.Client, ctx *cli.Context) (string, bool, error
 	manifest, mErr := resolveManifest(ctx)
 	if mErr != nil {
 		client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+		_ = clearState(ctx.String("tenant"))
 		return "", false, fmt.Errorf("manifest: %w", mErr)
 	}
 	if manifest != nil {
 		if err := materializeManifest(client, sid, manifest); err != nil {
 			client.SandboxServiceClient.DestroySession(context.Background(), &pb.DestroySessionRequest{SessionId: sid})
+			_ = clearState(ctx.String("tenant"))
 			return "", false, fmt.Errorf("manifest materialization: %w", err)
 		}
 	}
@@ -178,7 +188,9 @@ func runBackground(cli *client.Client, ctx *cli.Context, code, lang string) erro
 		return printErrorExit(err.Error(), 2)
 	}
 	cmd := buildCommand(lang, code)
-	resp, err := cli.SandboxServiceClient.Exec(context.Background(), &pb.ExecRequest{
+	rctx, cancel := rpcCtx(int32(ctx.Int("timeout")))
+	defer cancel()
+	resp, err := cli.SandboxServiceClient.Exec(rctx, &pb.ExecRequest{
 		SessionId: sid, Command: cmd, Timeout: int32(ctx.Int("timeout")), Workdir: "/workspace", Background: true,
 	})
 	if err != nil {
@@ -261,7 +273,9 @@ func runAction(ctx *cli.Context) error {
 }
 
 func runStream(client *client.Client, req *pb.ExecRequest, sid string, needsFinalize bool, tenant string) (exitCode int, err error) {
-	stream, err := client.SandboxServiceClient.ExecStream(context.Background(), req)
+	rctx, cancel := rpcCtx(req.Timeout)
+	defer cancel()
+	stream, err := client.SandboxServiceClient.ExecStream(rctx, req)
 	if err != nil {
 		if isSessionExpired(err) {
 			return 1, fmt.Errorf("%w: session %s", ErrSessionGone, req.SessionId)
@@ -294,6 +308,17 @@ func runStream(client *client.Client, req *pb.ExecRequest, sid string, needsFina
 	return 0, nil
 }
 
+// rpcCtx returns a context with a deadline for one sandbox RPC: the sandbox
+// command timeout plus dial/connect slack. The CLI previously used
+// context.Background() everywhere, so a dead gateway hung every command and
+// left a stale "creating" session placeholder behind on Ctrl-C.
+func rpcCtx(timeoutSecs int32) (context.Context, context.CancelFunc) {
+	if timeoutSecs <= 0 {
+		timeoutSecs = 30
+	}
+	return context.WithTimeout(context.Background(), time.Duration(timeoutSecs+15)*time.Second)
+}
+
 func isSessionExpired(err error) bool {
 	if err == nil {
 		return false
@@ -317,7 +342,9 @@ func isSessionExpired(err error) bool {
 }
 
 func runJSON(client *client.Client, req *pb.ExecRequest, sid string, needsFinalize bool, tenant string) error {
-	resp, err := client.SandboxServiceClient.Exec(context.Background(), req)
+	rctx, cancel := rpcCtx(req.Timeout)
+	defer cancel()
+	resp, err := client.SandboxServiceClient.Exec(rctx, req)
 	if err != nil {
 		if isSessionExpired(err) {
 			return fmt.Errorf("%w: session %s", ErrSessionGone, sid)
@@ -353,9 +380,12 @@ func StatusCommand() cli.Command {
 			}
 			defer client.Close()
 
-			// lightweight probe
-			_, err := client.SandboxServiceClient.DestroySession(context.Background(),
+			// lightweight probe (5s deadline — a dead gateway must fail fast, not
+			// hang the status command)
+			pctx, pcancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_, err := client.SandboxServiceClient.DestroySession(pctx,
 				&pb.DestroySessionRequest{SessionId: "healthcheck-probe-noop"})
+			pcancel()
 			available := err == nil || strings.Contains(err.Error(), errSessionNotFound)
 			errMsg := ""
 			if !available && err != nil {

--- a/pkg/sandboxcli/session.go
+++ b/pkg/sandboxcli/session.go
@@ -3,9 +3,11 @@ package sandboxcli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
@@ -79,6 +81,59 @@ func clearState(tenant string) error {
 	return os.Remove(statePath(tenant))
 }
 
+// create deadline / stale-creating recovery bounds. The CLI historically used
+// context.Background() (no deadline) for session RPCs, so a hung gateway left
+// a "creating" placeholder behind when the process died; waiters then wedged
+// forever. These constants bound both sides: a placeholder older than
+// creatingStaleAfter (or whose creator process is gone) is reclaimed.
+const (
+	creatingStaleAfter   = 2 * time.Minute
+	creatingPollInterval = 200 * time.Millisecond
+	sessionCreateTimeout = 45 * time.Second
+)
+
+// lockedAt parses the placeholder's RFC3339 stamp; zero time for a missing one.
+func lockedAt(raw string) time.Time {
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// pidAlive reports whether the process is running (signal-0 probe). EPERM means
+// the process exists but belongs to another user — treat it as alive.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if err := p.Signal(syscall.Signal(0)); err != nil {
+		return errors.Is(err, syscall.EPERM)
+	}
+	return true
+}
+
+// creatingPlaceholderStale reports whether a "creating" placeholder may be
+// reclaimed: its creator process is gone (crash / Ctrl-C / OOM), or it outlived
+// creatingStaleAfter (creator hung without an RPC deadline). A live, fresh
+// creator is left alone so concurrent runners still share one session.
+func creatingPlaceholderStale(state *SessionState) bool {
+	if state.PID > 0 {
+		if pidAlive(state.PID) {
+			// Creator still running, but it may be hung on an RPC with no
+			// deadline — reclaim once the stamp is old enough.
+			return time.Since(lockedAt(state.LockedAt)) > creatingStaleAfter
+		}
+		return true // creator process is gone — the placeholder can never finalize
+	}
+	// No PID recorded (older placeholder): give it the same age grace.
+	return time.Since(lockedAt(state.LockedAt)) > creatingStaleAfter
+}
+
 // resolveSession returns an active session ID using the three-tier strategy plus flock locking.
 func resolveSession(ctx context.Context, tenant string, sessionIDOverride string) (string, error) {
 	if sessionIDOverride != "" {
@@ -106,16 +161,19 @@ func resolveSession(ctx context.Context, tenant string, sessionIDOverride string
 		}
 
 		state, _ := loadState(tenant)
-		if state != nil && state.Phase == "creating" {
+		if state != nil && state.Phase == "creating" && !creatingPlaceholderStale(state) {
+			// A live creator is finalizing; wait, but bounded — a creator hung
+			// on an RPC without a deadline must not wedge every later caller.
 			select {
 			case <-ctx.Done():
 				return "", ctx.Err()
-			case <-time.After(200 * time.Millisecond):
+			case <-time.After(creatingPollInterval):
 			}
 			continue
 		}
 
-		// no valid session — claim creator role and return empty (caller creates)
+		// No valid session, or the "creating" placeholder is stale (its creator
+		// crashed or hung): claim the creator role and return empty (caller creates).
 		sid, claimed := claimCreatorRole(lf, tenant)
 		if claimed {
 			return sid, nil

--- a/pkg/sandboxcli/session_test.go
+++ b/pkg/sandboxcli/session_test.go
@@ -1,0 +1,170 @@
+package sandboxcli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/urfave/cli"
+
+	"github.com/xiaods/k8e/pkg/sandbox/client"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc"
+)
+
+// withTempStateDir redirects the sandbox data dir (state/certs) to a temp dir.
+func withTempStateDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", dir)
+	return dir
+}
+
+func writeState(t *testing.T, tenant string, state *SessionState) {
+	t.Helper()
+	dir := stateDir(tenant)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreatingPlaceholderStale(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	old := time.Now().UTC().Add(-3 * time.Minute).Format(time.RFC3339)
+
+	cases := []struct {
+		name  string
+		state *SessionState
+		want  bool
+	}{
+		{"dead pid → stale", &SessionState{Phase: "creating", PID: 999999999, LockedAt: now}, true},
+		{"alive pid + fresh → not stale", &SessionState{Phase: "creating", PID: os.Getpid(), LockedAt: now}, false},
+		{"alive pid + old → stale (hung creator)", &SessionState{Phase: "creating", PID: os.Getpid(), LockedAt: old}, true},
+		{"no pid + old → stale", &SessionState{Phase: "creating", LockedAt: old}, true},
+		{"no pid + fresh → not stale", &SessionState{Phase: "creating", LockedAt: now}, false},
+		{"no pid + no stamp → stale (broken placeholder)", &SessionState{Phase: "creating"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := creatingPlaceholderStale(c.state); got != c.want {
+				t.Fatalf("creatingPlaceholderStale(%+v) = %v, want %v", c.state, got, c.want)
+			}
+		})
+	}
+}
+
+// TestResolveSession_ReclaimsStaleCreating reproduces the tenant bug: a
+// previous run crashed (or was Ctrl-C'd) after writing a "creating" placeholder
+// but before finalizeState. The next run for that tenant used to wait forever;
+// now the stale placeholder is reclaimed and the caller proceeds to create.
+func TestResolveSession_ReclaimsStaleCreating(t *testing.T) {
+	withTempStateDir(t)
+	old := time.Now().UTC().Add(-3 * time.Minute).Format(time.RFC3339)
+	writeState(t, "default", &SessionState{Phase: "creating", PID: 999999999, LockedAt: old})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	sid, err := resolveSession(ctx, "default", "")
+	if err != nil {
+		t.Fatalf("resolveSession: %v", err)
+	}
+	if sid != "" {
+		t.Fatalf("expected empty sid (caller creates), got %q", sid)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("stale-creating reclaim must be immediate, took %v", elapsed)
+	}
+}
+
+// TestResolveSession_WaitsForLiveCreator proves a live creator is not trampled:
+// resolution waits (bounded by ctx) instead of reclaiming a fresh placeholder.
+func TestResolveSession_WaitsForLiveCreator(t *testing.T) {
+	withTempStateDir(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	writeState(t, "default", &SessionState{Phase: "creating", PID: os.Getpid(), LockedAt: now})
+
+	// Short deadline: resolution must NOT return immediately with a claim; it
+	// waits for the creator and only gives up when the context expires.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := resolveSession(ctx, "default", "")
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Fatalf("live-creator wait was trampled after %v", elapsed)
+	}
+	if err == nil {
+		t.Fatal("expected context deadline error after waiting for the live creator")
+	}
+}
+
+// TestResolveSession_ReusesActiveSession verifies the happy path: an active
+// state is returned as-is (the multi-tenant reuse contract).
+func TestResolveSession_ReusesActiveSession(t *testing.T) {
+	withTempStateDir(t)
+	writeState(t, "my-project", &SessionState{SessionID: "sess-1", Phase: "active", TenantID: "my-project"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	sid, err := resolveSession(ctx, "my-project", "")
+	if err != nil {
+		t.Fatalf("resolveSession: %v", err)
+	}
+	if sid != "sess-1" {
+		t.Fatalf("expected sess-1, got %q", sid)
+	}
+}
+
+// TestEnsureSession_ClearStateOnCreateFailure verifies a failed create removes
+// the "creating" placeholder so the next run can retry immediately.
+func TestEnsureSession_ClearStateOnCreateFailure(t *testing.T) {
+	withTempStateDir(t)
+	// Stale placeholder from a previous crashed run — ensureSession reclaims
+	// it, then the create RPC fails (fake client), and the placeholder must be
+	// cleared, not left wedged.
+	old := time.Now().UTC().Add(-3 * time.Minute).Format(time.RFC3339)
+	writeState(t, "default", &SessionState{Phase: "creating", PID: 999999999, LockedAt: old})
+
+	fake := &failCreatePBClient{}
+	realClient := &client.Client{SandboxServiceClient: fake}
+
+	app := cli.NewApp()
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	cctx := cli.NewContext(app, flagSet, nil)
+
+	_, _, err := ensureSession(realClient, cctx)
+	if err == nil {
+		t.Fatal("expected create failure")
+	}
+	state, loadErr := loadState("default")
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if state != nil {
+		t.Fatalf("placeholder must be cleared after failed create, got %+v", state)
+	}
+}
+
+// failCreatePBClient satisfies the pb client surface by embedding the interface;
+// only CreateSession is reachable in this test and fails with a deadline error.
+type failCreatePBClient struct {
+	pb.SandboxServiceClient
+}
+
+func (c *failCreatePBClient) CreateSession(ctx context.Context, req *pb.CreateSessionRequest, _ ...grpc.CallOption) (*pb.CreateSessionResponse, error) {
+	return nil, context.DeadlineExceeded
+}


### PR DESCRIPTION
## 问题

按官方指南 `k8e-sandbox-cli run "echo hello" --tenant my-project`（多租户）成功后，**其他租户任务报"找不到 session"或无限卡死**。

## 根因（已复现）

1. **陈旧 "creating" 状态卡死**：`run` 会先写 `phase=creating` 占位（claimCreatorRole）再调 CreateSession；而 CLI 所有 RPC 都用 `context.Background()`（无 deadline）——网关不可达时 create 挂起，Ctrl-C/崩溃后占位永远残留
2. **resolveSession 无陈旧检测**：遇到任何 `creating` 占位就 200ms 轮询无限等待（`context.Background()` 永不取消）——本机实测对残留占位 `run` 卡死 >15s

本机状态文件佐证：`~/.k8e/sandbox/default/state.json` = `{"session_id":"","phase":"creating","pid":32602}`（死进程残留）。

## 修复

| 项 | 内容 |
|---|---|
| **resolveSession 陈旧恢复** | `creating` 占位：创建进程已死（signal-0 探测）或超过 2 分钟（创建者卡死无 deadline）→ 立即回收重新创建；存活的新创建者仍等待（并发共享单 session 不破坏） |
| **create 失败清理** | CreateSession 加 45s deadline；失败即 `clearState`，下次 run 立即重试而非等陈旧窗口 |
| **Exec/ExecStream/后台提交 deadline** | 沙箱 timeout + 15s（rpcCtx），替代 `context.Background()`——死网关快速失败 |
| **status probe deadline** | 5s |

## 验证

- 5 个回归测试（session_test.go）：陈旧占位立即回收 / 存活创建者不被抢占 / active 复用 / create 失败清占位
- 实测（修复前卡死 >15s → 修复后 ~2s 快速失败）：stale 占位被回收 → create 报 EOF → **state 文件已清除**（运行中轮询确认）

## 关联

- 本机 default 租户的残留 stale state 已被本次实测清掉（`~/.k8e/sandbox/default/state.json`）
- 远端网关 EOF 属环境问题（AWS 实例不可达 / CA 轮换），恢复后需 `k8e sandbox connect` 重引导