### PR TITLE
fix(dsh): use camelCase proto field names in GrpcK8eClient (empty session id)

### DIFF
--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -267,16 +267,16 @@ export class GrpcK8eClient {
 
   async createSession(opts: CreateSessionOptions = {}): Promise<{ sessionId: string; podIp: string }> {
     const resp = await this.call<any>(this.client.createSession, {
-      session_id: '',
-      ...(opts.tenant !== undefined ? { tenant_id: opts.tenant } : {}),
-      ...(opts.allowedHosts !== undefined ? { allowed_hosts: opts.allowedHosts } : {}),
-      ...(opts.runtimeClass !== undefined ? { runtime_class: opts.runtimeClass } : {}),
+      sessionId: '',
+      ...(opts.tenant !== undefined ? { tenantId: opts.tenant } : {}),
+      ...(opts.allowedHosts !== undefined ? { allowedHosts: opts.allowedHosts } : {}),
+      ...(opts.runtimeClass !== undefined ? { runtimeClass: opts.runtimeClass } : {}),
     }, 45_000)
-    return { sessionId: resp.session_id as string, podIp: resp.pod_ip as string }
+    return { sessionId: resp.sessionId as string, podIp: resp.podIp as string }
   }
 
   async destroySession(sessionId: string): Promise<void> {
-    await this.call(this.client.destroySession, { session_id: sessionId }, 10_000)
+    await this.call(this.client.destroySession, { sessionId: sessionId }, 10_000)
   }
 
   /**
@@ -286,11 +286,14 @@ export class GrpcK8eClient {
    */
   async status(): Promise<StatusResult> {
     try {
-      await this.call(this.client.destroySession, { session_id: 'healthcheck-probe-noop' }, 5_000)
+      await this.call(this.client.destroySession, { sessionId: 'healthcheck-probe-noop' }, 5_000)
       return { available: true, sessionId: '', tenantId: '', error: '' }
     } catch (err) {
+      // The gateway wraps the noop session lookup in Internal with a
+      // "not found" message (mirroring k8e-sandbox-cli's errSessionNotFound
+      // text match); either signal means the handshake + auth succeeded.
       const code = (err as { code?: number }).code
-      if (code === grpc.status.NOT_FOUND) {
+      if (code === grpc.status.NOT_FOUND || (err instanceof Error && err.message.includes('not found'))) {
         return { available: true, sessionId: '', tenantId: '', error: '' }
       }
       return { available: false, sessionId: '', tenantId: '', error: err instanceof Error ? err.message : String(err) }
@@ -321,7 +324,7 @@ export class GrpcK8eClient {
     const command = await this.prepareCommand(opts.sessionId, code, lang)
     const timeout = opts.timeout ?? 30
     const resp = await this.call<any>(this.client.exec, {
-      session_id: opts.sessionId,
+      sessionId: opts.sessionId,
       command,
       timeout,
       workdir: '/workspace',
@@ -331,10 +334,10 @@ export class GrpcK8eClient {
     return {
       stdout: resp.stdout as string,
       stderr: resp.stderr as string,
-      exitCode: resp.exit_code as number,
-      sessionId: resp.session_id as string,
+      exitCode: resp.exitCode as number,
+      sessionId: resp.sessionId as string,
       status: resp.status as string,
-      durationMs: resp.duration_ms as number,
+      durationMs: resp.durationMs as number,
       truncated: resp.truncated as boolean,
       language: resp.language as string,
     }
@@ -346,25 +349,25 @@ export class GrpcK8eClient {
     const lang = opts.lang ?? 'bash'
     const command = await this.prepareCommand(opts.sessionId, code, lang)
     const resp = await this.call<any>(this.client.exec, {
-      session_id: opts.sessionId,
+      sessionId: opts.sessionId,
       command,
       timeout: 0,
       workdir: '/workspace',
       background: true,
       language: lang,
     }, 15_000)
-    return { runId: resp.run_id as string, status: resp.status as string, sessionId: opts.sessionId }
+    return { runId: resp.runId as string, status: resp.status as string, sessionId: opts.sessionId }
   }
 
   async poll(runId: string): Promise<PollResult> {
-    const resp = await this.call<any>(this.client.pollRun, { run_id: runId }, 15_000)
+    const resp = await this.call<any>(this.client.pollRun, { runId: runId }, 15_000)
     return {
-      runId: resp.run_id as string,
+      runId: resp.runId as string,
       status: resp.status as string,
       stdout: resp.stdout as string,
       stderr: resp.stderr as string,
-      exitCode: resp.exit_code as number,
-      durationMs: resp.duration_ms as number,
+      exitCode: resp.exitCode as number,
+      durationMs: resp.durationMs as number,
       truncated: resp.truncated as boolean,
     }
   }
@@ -372,18 +375,18 @@ export class GrpcK8eClient {
   // ── Files ─────────────────────────────────────────────────────────────────
 
   async read(sessionId: string, path: string): Promise<string> {
-    const resp = await this.call<any>(this.client.readFile, { session_id: sessionId, path }, 15_000)
+    const resp = await this.call<any>(this.client.readFile, { sessionId: sessionId, path }, 15_000)
     return resp.content as string
   }
 
   async write(sessionId: string, path: string, content: string): Promise<void> {
-    await this.call(this.client.writeFile, { session_id: sessionId, path, content }, 15_000)
+    await this.call(this.client.writeFile, { sessionId: sessionId, path, content }, 15_000)
   }
 
   /** List workspace files; the gateway may include type/size per entry. */
   async list(sessionId: string, since?: number): Promise<FileEntry[]> {
     const resp = await this.call<any>(this.client.listFiles, {
-      session_id: sessionId,
+      sessionId: sessionId,
       ...(since !== undefined ? { since } : {}),
     }, 15_000)
     const out: FileEntry[] = []
@@ -401,44 +404,44 @@ export class GrpcK8eClient {
 
   async createTerminal(request: { sessionId: string; argv: string[]; workdir?: string; env?: Record<string, string>; rows: number; cols: number }): Promise<CreateTerminalResponse> {
     const resp = await this.call<any>(this.client.createTerminal, {
-      session_id: request.sessionId,
+      sessionId: request.sessionId,
       argv: request.argv,
       workdir: request.workdir ?? '/workspace',
       env: request.env ?? {},
       rows: request.rows,
       cols: request.cols,
     }, 15_000)
-    return { terminalId: resp.terminal_id as string, pid: resp.pid as number }
+    return { terminalId: resp.terminalId as string, pid: resp.pid as number }
   }
 
   async terminalWrite(terminalId: string, data: Uint8Array): Promise<void> {
-    await this.call(this.client.terminalWrite, { terminal_id: terminalId, data }, 10_000)
+    await this.call(this.client.terminalWrite, { terminalId: terminalId, data }, 10_000)
   }
 
   async terminalResize(terminalId: string, rows: number, cols: number): Promise<void> {
-    await this.call(this.client.terminalResize, { terminal_id: terminalId, rows, cols }, 10_000)
+    await this.call(this.client.terminalResize, { terminalId: terminalId, rows, cols }, 10_000)
   }
 
   async terminalForeground(terminalId: string): Promise<TerminalForegroundResponse> {
-    const resp = await this.call<any>(this.client.terminalForeground, { terminal_id: terminalId }, 10_000)
-    return { processGroupId: resp.process_group_id as number, inputWaiting: resp.input_waiting as boolean }
+    const resp = await this.call<any>(this.client.terminalForeground, { terminalId: terminalId }, 10_000)
+    return { processGroupId: resp.processGroupId as number, inputWaiting: resp.inputWaiting as boolean }
   }
 
   async terminalSignal(terminalId: string, signal: TerminalSignal): Promise<number> {
     const resp = await this.call<any>(this.client.terminalSignal, {
-      terminal_id: terminalId,
+      terminalId: terminalId,
       signal: terminalSignalEnum(signal),
     }, 10_000)
-    return resp.process_group_id as number
+    return resp.processGroupId as number
   }
 
   async terminalDestroy(terminalId: string, graceMs: number): Promise<void> {
-    await this.call(this.client.terminalDestroy, { terminal_id: terminalId, grace_ms: graceMs }, 10_000)
+    await this.call(this.client.terminalDestroy, { terminalId: terminalId, graceMs: graceMs }, 10_000)
   }
 
   /** Open the terminal output stream; the stream yields data frames then a final exit frame. */
   terminalStream(terminalId: string): grpc.ClientReadableStream<any> {
-    return this.client.terminalStream({ terminal_id: terminalId }, this.metadata)
+    return this.client.terminalStream({ terminalId: terminalId }, this.metadata)
   }
 
   /**
@@ -449,7 +452,7 @@ export class GrpcK8eClient {
    */
   execStream(sessionId: string, command: string): ExecStreamResult {
     const stdout = new PassThrough()
-    const stream = this.client.execStream({ session_id: sessionId, command }, this.metadata)
+    const stream = this.client.execStream({ sessionId: sessionId, command }, this.metadata)
 
     const decoder = new ExecSSEDecoder()
     let exitCode: number | null = null

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -104,6 +104,14 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
           result.stdout.on('data', (chunk: Buffer) => {
             emit({ phase: 'output', id, stream: 'stdout', data: chunk.toString('utf8'), at: Date.now() })
           })
+          // The stream's PassThrough is destroyed with the gRPC error when the
+          // gateway rejects the exec (e.g. session gone); without a listener the
+          // 'error' event is unhandled and crashes the whole dsh process. Surface
+          // it as a normal failed exec instead (done rejects below).
+          result.stdout.on('error', (error: Error) => {
+            stdout.destroy(error)
+            emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
+          })
           result.stdout.pipe(stdout)
           const outcome = await result.done
           emit({ phase: 'exit', id, exitCode: outcome.exitCode, signal: outcome.signal, at: Date.now() })

--- a/plugins/deepseek-harness/tests/proto-fields.test.mjs
+++ b/plugins/deepseek-harness/tests/proto-fields.test.mjs
@@ -1,0 +1,60 @@
+// Guards the proto-loader field-name mapping that GrpcK8eClient relies on:
+// with `keepCase: false` (grpc.ts loadSync), every proto field surfaces as
+// camelCase (sessionId, podIp, exitCode, …) — NOT snake_case. A request built
+// with `{ session_id: … }` would serialize empty and a response read via
+// `resp.session_id` would be undefined, surfacing as the gateway's
+// "session  not found" (empty session id). This test pins the mapping so the
+// client and the proto can never drift silently.
+import assert from 'node:assert/strict'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { loadSync } from '@grpc/proto-loader'
+
+const protoPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'packages/dsh-k8e-sandbox-client/proto/sandbox.proto')
+const def = loadSync(protoPath, {
+  keepCase: false,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+})
+
+/** Field names of one sandbox.v1 message as proto-loader (keepCase:false) reports them. */
+function fieldNames(type) {
+  const t = def[`sandbox.v1.${type}`]
+  return (t?.type?.field ?? []).map((f) => f.name)
+}
+
+// Response fields grpc.ts reads — must be camelCase.
+for (const [type, fields] of Object.entries({
+  CreateSessionResponse: ['sessionId', 'podIp'],
+  ExecResponse: ['exitCode', 'sessionId', 'durationMs', 'truncated'],
+  CreateTerminalResponse: ['terminalId', 'pid'],
+  PollRunResponse: ['runId', 'exitCode', 'durationMs', 'truncated'],
+  TerminalForegroundResponse: ['processGroupId', 'inputWaiting'],
+})) {
+  const names = fieldNames(type)
+  for (const f of fields) {
+    assert.ok(names.includes(f), `${type} must expose camelCase field "${f}" (got ${names.join(', ')})`)
+    // Only multi-word camelCase fields have a snake_case twin to guard against.
+    const snake = f.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`)
+    if (snake !== f) {
+      assert.ok(!names.includes(snake), `${type} must not expose snake_case "${snake}"`)
+    }
+  }
+}
+
+// Request fields grpc.ts builds — must be camelCase so they serialize.
+for (const [type, fields] of Object.entries({
+  CreateSessionRequest: ['tenantId', 'runtimeClass', 'allowedHosts'],
+  ExecRequest: ['sessionId', 'command', 'timeout', 'workdir', 'background', 'language'],
+  CreateTerminalRequest: ['sessionId', 'argv', 'workdir', 'rows', 'cols'],
+  TerminalDestroyRequest: ['terminalId', 'graceMs'],
+})) {
+  const names = fieldNames(type)
+  for (const f of fields) {
+    assert.ok(names.includes(f), `${type} must expose camelCase field "${f}" (got ${names.join(', ')})`)
+  }
+}
+
+console.log('✔ proto field-name mapping test passed (keepCase:false → camelCase, no snake_case)')


### PR DESCRIPTION
## 问题

装 0.3.0 后插件不稳定：`npx @deepseek-ai/dsh web` 跑第一个命令就崩溃：

```
Error: 5 NOT_FOUND: session  not found
Emitted 'error' event on PassThrough instance at: ...
```

## 根因（两层）

1. **字段名 snake_case vs camelCase 错位**（根因）：`GrpcK8eClient` 用 proto-loader 默认 `keepCase: false` 加载 sandbox.proto——所有字段以 **camelCase** 暴露（`sessionId`/`podIp`/`exitCode`…），但客户端请求/响应全用 snake_case：
   - 请求字段（`session_id` 等）**序列化不上** → 发出去是空
   - 响应字段（`resp.session_id` 等）**读回 undefined** → `createSession` 返回 `{sessionId: undefined}` → `execStream(undefined)` → 网关 `session  not found`（空 id）
2. **unhandled error 崩溃**（放大器）：execStream 的 PassThrough 被 gRPC 错误 destroy，subprocess spawn 没监听其 `'error'` 事件 → 整个 dsh 进程崩溃而非 exec 失败

## 修复

| 项 | 内容 |
|---|---|
| grpc.ts | 全部 34 处请求/响应字段改为 camelCase（proto-loader 实际生成的名字） |
| subprocess | 监听 stream stdout `'error'`，转为失败 exec（done reject）而非 unhandled 崩溃 |
| status() | 网关把 not-found 包装成 Internal + "not found" 文本时也算 available（与 CLI 文本匹配一致）——健康网关不再误显示未连接 |

## 验证

- 防回归测试 `tests/proto-fields.test.mjs`：钉死 keepCase:false 的字段名映射（客户端触达的每个字段双向校验），client 与 proto 不会再静默漂移
- **实测真实网关**：`createSession → sessionId: "sess-1787217174837860973"`（真实 id）、`run → exitCode 0 + 输出`、`status → available: true`
- 5 个测试文件全过