### PR TITLE
fix(dsh): tool output shapes match strict schemas + fs stat mode mask

### DIFF
--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -337,7 +337,7 @@ export class GrpcK8eClient {
       exitCode: resp.exitCode as number,
       sessionId: resp.sessionId as string,
       status: resp.status as string,
-      durationMs: resp.durationMs as number,
+      durationMs: Number(resp.durationMs as string) || 0,
       truncated: resp.truncated as boolean,
       language: resp.language as string,
     }
@@ -367,7 +367,7 @@ export class GrpcK8eClient {
       stdout: resp.stdout as string,
       stderr: resp.stderr as string,
       exitCode: resp.exitCode as number,
-      durationMs: resp.durationMs as number,
+      durationMs: Number(resp.durationMs as string) || 0,
       truncated: resp.truncated as boolean,
     }
   }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-fs/src/index.ts
@@ -175,7 +175,11 @@ export class K8eFileSystem extends FileSystem {
     if (parts.length !== 3) return undefined
     const typeHex = Number.parseInt(parts[0] ?? '', 16)
     const size = Number.parseInt(parts[1] ?? '0', 10)
-    const type: FsInfo['type'] = typeHex === 0x4000 ? 'directory' : typeHex === 0x8000 ? 'file' : 'other'
+    // stat -c '%f' is the full st_mode (type bits + permission bits, e.g. 41ed
+    // for a 0755 dir); mask the type bits instead of strict equality or every
+    // real file/dir parses as 'other' and reads are rejected.
+    const mode = typeHex & 0xF000
+    const type: FsInfo['type'] = mode === 0x4000 ? 'directory' : mode === 0x8000 ? 'file' : 'other'
     const version = FsVersion(`k8e:${parts[2] ?? '0'}:${parts[1] ?? '0'}`)
     return { type, size: Number.isFinite(size) ? size : 0, version }
   }

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/src/index.ts
@@ -106,11 +106,21 @@ export class K8eSandboxTools extends Service {
       },
       async execute(args) {
         const client = runtime().getClient()
-        return client.run(args.code, {
+        const result = await client.run(args.code, {
           ...(args.lang !== undefined ? { lang: args.lang } : {}),
           ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
           sessionId: await runtime().getSession(),
         })
+        // The transport result carries extra fields (sessionId/status/language);
+        // the tool schema is strict (additionalProperties: false), so return
+        // exactly the declared shape.
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          durationMs: Number(result.durationMs) || 0,
+          truncated: result.truncated,
+        }
       },
     }))
 
@@ -156,7 +166,16 @@ export class K8eSandboxTools extends Service {
       },
       async execute(args) {
         const client = runtime().getClient()
-        return client.poll(args.runId)
+        const result = await client.poll(args.runId)
+        return {
+          runId: result.runId,
+          status: result.status,
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+          durationMs: Number(result.durationMs) || 0,
+          truncated: result.truncated,
+        }
       },
     }))
   }

--- a/plugins/deepseek-harness/scripts/test.mjs
+++ b/plugins/deepseek-harness/scripts/test.mjs
@@ -28,6 +28,7 @@ for (const file of files) {
       '@k8e-sandbox/dsh-k8e-sandbox-client': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/index.ts'),
       '@k8e-sandbox/dsh-k8e-sandbox-client/grpc': join(ROOT, 'packages/dsh-k8e-sandbox-client/src/grpc.ts'),
       '@k8e-sandbox/dsh-k8e-sandbox-fs': join(ROOT, 'packages/dsh-k8e-sandbox-fs/src/index.ts'),
+      '@k8e-sandbox/dsh-k8e-sandbox-tool': join(ROOT, 'packages/dsh-k8e-sandbox-tool/src/index.ts'),
       '@k8e-sandbox/dsh-k8e-sandbox-subprocess': join(ROOT, 'packages/dsh-k8e-sandbox-subprocess/src/index.ts'),
     },
   })

--- a/plugins/deepseek-harness/tests/tool.test.mjs
+++ b/plugins/deepseek-harness/tests/tool.test.mjs
@@ -1,0 +1,86 @@
+// Fake-ctx test for the k8e-sandbox tool provider: the tool schemas are strict
+// (additionalProperties: false) and the transport returns extra fields
+// (sessionId/status/language) plus durationMs as a string (proto int64 via
+// longs: String). The tool must return exactly the declared shape with a
+// numeric durationMs, or dsh rejects the tool output.
+import assert from 'node:assert/strict'
+import { K8eSandboxTools } from '@k8e-sandbox/dsh-k8e-sandbox-tool'
+
+function makeOwner() {
+  const calls = []
+  const client = {
+    calls,
+    async run(code, opts) {
+      calls.push(['run', code, opts])
+      // Transport result: extra fields + string durationMs (proto int64).
+      return {
+        stdout: 'hello\n',
+        stderr: '',
+        exitCode: 0,
+        sessionId: 'sess-1',
+        status: 'completed',
+        durationMs: '123',
+        truncated: false,
+        language: 'bash',
+      }
+    },
+    async runBackground(code, opts) {
+      calls.push(['runBackground', code, opts])
+      return { runId: 'bg-1', status: 'started', sessionId: 'sess-1' }
+    },
+    async poll(runId) {
+      calls.push(['poll', runId])
+      return { runId, status: 'completed', stdout: 'out\n', stderr: 'err\n', exitCode: 0, durationMs: '456', truncated: false }
+    },
+  }
+  return { getClient: () => client, getSession: async () => 'sess-1', calls }
+}
+
+function mount() {
+  const owner = makeOwner()
+  const registered = []
+  const ctx = {
+    k8eSandbox: owner,
+    reflect: { provide() { return () => {} } },
+    effect() { return () => {} },
+    tools: { register(def) { registered.push(def) } },
+  }
+  // eslint-disable-next-line no-new
+  new K8eSandboxTools(ctx)
+  const byName = new Map(registered.map((d) => [d.name, d]))
+  return { owner, byName }
+}
+
+// k8e_sandbox_exec returns exactly the declared shape (no sessionId/status/
+// language) with numeric durationMs.
+{
+  const { byName } = mount()
+  const tool = byName.get('k8e_sandbox_exec')
+  assert.ok(tool, 'k8e_sandbox_exec registered')
+  const out = await tool.execute({ code: 'echo hello' })
+  assert.deepEqual(Object.keys(out).sort(), ['durationMs', 'exitCode', 'stderr', 'stdout', 'truncated'])
+  assert.equal(typeof out.durationMs, 'number')
+  assert.equal(out.stdout, 'hello\n')
+  assert.equal(out.exitCode, 0)
+}
+
+// k8e_sandbox_poll returns the declared shape with numeric durationMs.
+{
+  const { byName } = mount()
+  const tool = byName.get('k8e_sandbox_poll')
+  const out = await tool.execute({ runId: 'bg-1' })
+  assert.deepEqual(Object.keys(out).sort(), ['durationMs', 'exitCode', 'runId', 'status', 'stderr', 'stdout', 'truncated'])
+  assert.equal(typeof out.durationMs, 'number')
+  assert.equal(out.stdout, 'out\n')
+}
+
+// k8e_sandbox_run_background keeps its declared shape.
+{
+  const { byName } = mount()
+  const tool = byName.get('k8e_sandbox_run_background')
+  const out = await tool.execute({ code: 'sleep 1' })
+  assert.deepEqual(Object.keys(out).sort(), ['runId', 'sessionId', 'status'])
+  assert.equal(out.runId, 'bg-1')
+}
+
+console.log('✔ tool output-shape test passed (strict schema, numeric durationMs)')


### PR DESCRIPTION
dsh rejected k8e_sandbox_exec/poll outputs (durationMs string from proto int64, extra sessionId/status/language vs additionalProperties:false) and fs reads failed with 'not a regular file' (stat -c '%f' full st_mode, strict === never matched). Fix: Number(durationMs) in client+tool, exact-shape returns, & 0xF000 mode mask. New tool output-shape test.