### PR TITLE
fix(dsh): never crash dsh when the remote gateway is unavailable

### DIFF
--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts
@@ -452,6 +452,9 @@ export class GrpcK8eClient {
    */
   execStream(sessionId: string, command: string): ExecStreamResult {
     const stdout = new PassThrough()
+    // Consume 'error' so an unlistened destroy can never crash the host;
+    // the failure always surfaces through `done`.
+    stdout.on('error', () => { /* failure surfaces via done */ })
     const stream = this.client.execStream({ sessionId: sessionId, command }, this.metadata)
 
     const decoder = new ExecSSEDecoder()

--- a/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
+++ b/plugins/deepseek-harness/packages/dsh-k8e-sandbox-subprocess/src/index.ts
@@ -109,6 +109,18 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
     }
     let settled = false
 
+    // Failures surface through `done` (exitCode 1), never by destroying the
+    // returned streams with the error: callers such as dsh-bash may not listen
+    // for 'error', and the unhandled event crashes the whole dsh process when
+    // the remote gateway is unavailable.
+    const failExec = (cause: unknown): SubprocessOutcome => {
+      const _error = cause instanceof Error ? cause : new Error(String(cause))
+      stdout.end()
+      stderr.end()
+      emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
+      return { exitCode: 1, signal: null }
+    }
+
     const done: Promise<SubprocessOutcome> = (async () => {
       if (grpcClient !== undefined) {
         // Phase 2: streaming exec via gRPC (sandboxd merges stderr into stdout).
@@ -119,22 +131,17 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
             emit({ phase: 'output', id, stream: 'stdout', data: chunk.toString('utf8'), at: Date.now() })
           })
           // The stream's PassThrough is destroyed with the gRPC error when the
-          // gateway rejects the exec (e.g. session gone); without a listener the
-          // 'error' event is unhandled and crashes the whole dsh process. Surface
-          // it as a normal failed exec instead (done rejects below).
-          result.stdout.on('error', (error: Error) => {
-            stdout.destroy(error)
-            emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
+          // gateway rejects the exec (e.g. session gone); consume the 'error'
+          // here and surface the failure as a normal failed exec instead.
+          result.stdout.on('error', () => {
+            failExec(new Error('k8e-sandbox exec stream error'))
           })
           result.stdout.pipe(stdout)
           const outcome = await result.done
           emit({ phase: 'exit', id, exitCode: outcome.exitCode, signal: outcome.signal, at: Date.now() })
           return outcome
         } catch (cause) {
-          const error = cause instanceof Error ? cause : new Error(String(cause))
-          stdout.destroy(error)
-          emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
-          return { exitCode: 1, signal: null }
+          return failExec(cause)
         } finally {
           settled = true
         }
@@ -151,15 +158,16 @@ export class K8eSubprocessRuntime extends SubprocessRuntime {
         emit({ phase: 'exit', id, exitCode: result.exitCode, signal: null, at: Date.now() })
         return { exitCode: result.exitCode, signal: null }
       } catch (cause) {
-        const error = cause instanceof Error ? cause : new Error(String(cause))
-        stdout.destroy(error)
-        stderr.destroy(error)
-        emit({ phase: 'exit', id, exitCode: 1, signal: null, at: Date.now() })
-        return { exitCode: 1, signal: null }
+        return failExec(cause)
       } finally {
         settled = true
       }
     })()
+
+    // Belt-and-suspenders: consume any 'error' on the returned streams so an
+    // unhandled event can never crash the host process.
+    stdout.on('error', () => { /* failure surfaces via done */ })
+    stderr.on('error', () => { /* failure surfaces via done */ })
 
     return {
       pid: -1,

--- a/plugins/deepseek-harness/tests/subprocess.test.mjs
+++ b/plugins/deepseek-harness/tests/subprocess.test.mjs
@@ -191,4 +191,39 @@ function makeCtx(owner) {
   assert.equal(exitEvent.exitCode, 7)
 }
 
+// When the remote gateway is unavailable, getSession() rejects (UNAVAILABLE).
+// spawn must fail the exec through `done` (exitCode 1) WITHOUT emitting an
+// unhandled 'error' on the returned streams — an unlistened destroy used to
+// crash the whole dsh process.
+{
+  const unhandled = []
+  const onUncaught = (e) => { unhandled.push(e) }
+  const onRejection = (e) => { unhandled.push(e) }
+  process.on('uncaughtException', onUncaught)
+  process.on('unhandledRejection', onRejection)
+  try {
+    const grpcClient = makeGrpcClient()
+    const owner = {
+      getClient: () => ({ run: async () => { throw new Error('unreachable') } }),
+      getGrpcClient: () => grpcClient,
+      // Gateway down: session creation fails fast.
+      getSession: async () => { throw new Error('14 UNAVAILABLE: No connection established') },
+      cwd: '/workspace',
+    }
+    const ctx = makeCtx(owner)
+    const runtime = new K8eSubprocessRuntime(ctx)
+    const handle = runtime.spawn({ argv: ['echo', 'hi'], graceMs: 5000 })
+    let streamError = null
+    handle.stdout.on('error', (e) => { streamError = e })
+    const outcome = await handle.done
+    assert.deepEqual(outcome, { exitCode: 1, signal: null }, 'failure surfaces via done')
+    await new Promise((r) => setTimeout(r, 30))
+    assert.equal(unhandled.length, 0, 'no uncaughtException / unhandledRejection')
+    assert.equal(streamError, null, 'returned stdout must not emit error')
+  } finally {
+    process.off('uncaughtException', onUncaught)
+    process.off('unhandledRejection', onRejection)
+  }
+}
+
 console.log('✔ subprocess fake-ctx test passed (spawnTerminal mapping, stream frames, spawn gRPC + CLI fallback)')


### PR DESCRIPTION
E2E failure with gateway down: `dsh web` crashed with `Error: 14 UNAVAILABLE ... Emitted 'error' event on PassThrough`. Chain: spawn/bash → getSession → createSession → unreachable gateway rejects; K8eSubprocessRuntime catch destroyed its returned PassThrough with the error; callers (dsh-bash) don't listen for 'error' → unhandled event kills dsh.

Fix: subprocess failures surface only via `done` (exitCode 1); streams end cleanly; execStream + returned streams consume 'error' as belt-and-suspenders. Regression test asserts no uncaughtException/unhandledRejection and no 'error' on the stream when getSession rejects. 6/6 test files pass.