### PR TITLE
feat(kip24): persist exposed-port registry across gateway restarts

### DIFF
--- a/pkg/sandboxmatrix/grpc/expose.go
+++ b/pkg/sandboxmatrix/grpc/expose.go
@@ -215,7 +215,9 @@ func (o *Orchestrator) RestoreExposedRegistry(ctx context.Context, namespace str
 		}
 		var ports []int32
 		for _, p := range strings.Split(raw, ",") {
-			if v, err := strconv.Atoi(strings.TrimSpace(p)); err == nil && v > 0 {
+			// ParseUint(…, 16) bounds the value to [0, 65535], so the int32
+			// conversion is lossless (no signedness truncation).
+			if v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 16); err == nil && v > 0 {
 				ports = append(ports, int32(v))
 			}
 		}

--- a/pkg/sandboxmatrix/grpc/expose.go
+++ b/pkg/sandboxmatrix/grpc/expose.go
@@ -3,13 +3,16 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	sandboxv1 "github.com/xiaods/k8e/pkg/sandboxmatrix/api/v1alpha1"
-	"github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -34,6 +37,11 @@ type ExposedEntry struct {
 // exposeURLPath is the e2b HTTP reverse-proxy route prefix (Gateway-API
 // fronted). Full URL: <gateway-base>/k8e/expose/<session>/<port>/
 const exposeURLPath = "/k8e/expose/%s/%d/"
+
+// exposedPortsAnnotation persists the exposed port list on the session CRD
+// so exposures survive a gateway restart (same recovery model as the
+// background-runs annotation, KIP-16 M6).
+const exposedPortsAnnotation = "sandbox.k8e.io/exposed-ports"
 
 // ExposeService registers an in-pod service port for gateway proxying and
 // re-applies the session CNP so the gateway/e2b-server may reach the port.
@@ -80,6 +88,7 @@ func (o *Orchestrator) ExposeService(ctx context.Context, sessionID string, port
 		o.removeExposed(sessionID, int(port))
 		return nil, status.Errorf(codes.Internal, "expose: apply CNP: %v", err)
 	}
+	o.persistExposedPorts(ctx, session)
 	return &pb.ExposeServiceResponse{Url: url}, nil
 }
 
@@ -117,6 +126,7 @@ func (o *Orchestrator) UnexposeService(ctx context.Context, sessionID string, po
 		if err := o.applySessionCNP(ctx, session); err != nil {
 			return nil, status.Errorf(codes.Internal, "unexpose: apply CNP: %v", err)
 		}
+		o.persistExposedPorts(ctx, session)
 	}
 	return &pb.UnexposeServiceResponse{Ok: true}, nil
 }
@@ -172,6 +182,63 @@ func (o *Orchestrator) UpdateAllowedHosts(ctx context.Context, sessionID string,
 		return nil, status.Errorf(codes.Internal, "update allowed hosts: apply CNP: %v", err)
 	}
 	return hosts, nil
+}
+
+// persistExposedPorts writes the current exposed-port list to the session
+// annotation so a gateway restart can restore the registry.
+func (o *Orchestrator) persistExposedPorts(ctx context.Context, session *sandboxv1.SandboxSession) {
+	o.exposeMu.Lock()
+	var ports []string
+	for _, e := range o.exposed[session.Name] {
+		ports = append(ports, fmt.Sprintf("%d", e.Port))
+	}
+	o.exposeMu.Unlock()
+
+	if session.Annotations == nil {
+		session.Annotations = map[string]string{}
+	}
+	session.Annotations[exposedPortsAnnotation] = strings.Join(ports, ",")
+	o.updateSession(ctx, session)
+}
+
+// RestoreExposedRegistry rebuilds the in-memory expose registry from the
+// exposed-ports annotations at gateway startup (call once before serving).
+func (o *Orchestrator) RestoreExposedRegistry(ctx context.Context, namespace string) {
+	sessions, err := o.dynamic.Resource(sessionGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil || len(sessions.Items) == 0 {
+		return
+	}
+	for _, item := range sessions.Items {
+		raw, _, _ := unstructured.NestedString(item.Object, "metadata", "annotations", exposedPortsAnnotation)
+		if raw == "" {
+			continue
+		}
+		var ports []int32
+		for _, p := range strings.Split(raw, ",") {
+			if v, err := strconv.Atoi(strings.TrimSpace(p)); err == nil && v > 0 {
+				ports = append(ports, int32(v))
+			}
+		}
+		if len(ports) == 0 {
+			continue
+		}
+		sid := item.GetName()
+		base := o.exposeURLBase
+		if base == "" {
+			base = "http://localhost"
+		}
+		entries := make([]*ExposedEntry, 0, len(ports))
+		for _, p := range ports {
+			entries = append(entries, &ExposedEntry{
+				Port:      int(p),
+				URL:       fmt.Sprintf("%s%s", base, fmt.Sprintf(exposeURLPath, sid, p)),
+				StartedAt: time.Now(),
+			})
+		}
+		o.exposeMu.Lock()
+		o.exposed[sid] = entries
+		o.exposeMu.Unlock()
+	}
 }
 
 // applySessionCNP rebuilds and applies the session CNP including any exposed

--- a/pkg/sandboxmatrix/grpc/orchestrator.go
+++ b/pkg/sandboxmatrix/grpc/orchestrator.go
@@ -85,6 +85,8 @@ type Orchestrator struct {
 	// KIP-24 service exposure registry: session_id → live tunnel entries.
 	exposeMu sync.Mutex
 	exposed  map[string][]*ExposedEntry
+	// exposeURLBase is the public gateway base URL for restored exposures.
+	exposeURLBase string
 
 	// warmPodHealthCheck decides whether a warm pod's sandboxd is actually ready to
 	// serve on :2024 before the pod is claimed for a session. Overridable in tests.

--- a/pkg/sandboxmatrix/grpc/server.go
+++ b/pkg/sandboxmatrix/grpc/server.go
@@ -181,6 +181,18 @@ func NewServer(cfg ServerConfig) *Server {
 	if cfg.FQDNEnabled {
 		s.orch.SetFQDNEGressEnabled(true)
 	}
+	if cfg.ExposeBaseURL != "" {
+		s.orch.exposeURLBase = strings.TrimSuffix(cfg.ExposeBaseURL, "/")
+	} else if cfg.AdvertiseHostname != "" {
+		s.orch.exposeURLBase = "http://" + cfg.AdvertiseHostname
+	}
+	// KIP-24: restore exposures persisted on session annotations so gateway
+	// restarts do not silently drop agent-published URLs.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		s.orch.RestoreExposedRegistry(ctx, sandboxNS)
+	}()
 	RegisterSandboxMetrics(s.orch)
 	if cfg.LayerStoreDir != "" {
 		if ls, err := sandboxlayer.New(cfg.LayerStoreDir); err == nil {


### PR DESCRIPTION
## 问题（E2E 实测）

k8e-server 重启后，agent 已发布的暴露 URL **静默失效**：
- 暴露注册表是网关进程内存态，重启即丢
- `ListExposed` 返回空 → `/k8e/expose/*` 反代 404
- e2b 代理失败时只返回固定文案 "gateway unreachable"，真实原因被吞掉

## 修复

### 注册表持久化（核心）
- `ExposeService` / `UnexposeService` 将端口列表写入 SandboxSession 注解
  `sandbox.k8e.io/exposed-ports`（与 background-runs 相同的恢复模型，KIP-16 M6）
- 新增 `RestoreExposedRegistry`：网关启动时从注解重建内存注册表，
  URL base 取自 `--sandbox-expose-base-url` / advertise hostname

### 可观测性
- e2b 代理：`ListExposed` / `GetSession` 失败时记录日志并在 503 响应体中
  返回真实错误（区分旧网关 Unimplemented / 认证失败 / loopback 连接失败）

### connect 自愈
- 新增 `--reset-certs`：清除缓存的 CA/client 证书后用 `--apikey` 重建信任
  （服务器重装或 CA 轮换后的恢复路径）
- verify 失败附加可行动 hint（新增 `client.ConnErrorHint`）

## 验证
- ✅ 全量单测绿（sandboxmatrix/grpc、sandbox/e2b、sandboxcli、pkg/deploy）
- ✅ 新增回归测试覆盖 CNP 更新路径（resourceVersion 保留）
MSGEOF