### PR TITLE
fix(ci): use GITHUB_TOKEN for ghcr.io login in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Sanitize tag
         id: tag
         run: echo "value=$(echo '${{ github.ref_name }}' | tr '+' '-')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

Release builds `v1.35.5-rc3+k8e1` and `rc4+k8e1` both failed in the **Build sandbox image** job:

```
Error response from daemon: Get "https://ghcr.io/v2/": denied: denied
```

The `docker/login-action` step authenticates with the manually-managed `GHCR_PAT` secret, which is now rejected (expired or missing `write:packages` scope).

## Fix

Switch the login credential to the built-in `GITHUB_TOKEN`. The job already declares:

```yaml
permissions:
  contents: read
  packages: write
```

so no secret configuration is needed and the workflow no longer depends on a manually rotated PAT.

## Follow-up for release

Since this workflow only triggers on `release: published`, re-running the failed runs would use the old commit's workflow file. A new rc (e.g. `rc5+k8e1`) should be published after merging to pick up the fix.
