### PR TITLE
fix(sandboxd): reassemble HTTP bodies split across TCP reads (thread panic)

### DIFF
--- a/sandboxd/src/httpio.zig
+++ b/sandboxd/src/httpio.zig
@@ -1,0 +1,122 @@
+//! Minimal HTTP/1.x request framing for sandboxd.
+//!
+//! Extracted from main.zig so the reassembly logic is unit-testable on any
+//! host (uses std.posix, not std.os.linux). Owns the full read side: first
+//! read grabs headers (and possibly part of the body), then the remaining
+//! Content-Length bytes are appended after them — see readRequest for the
+//! layout invariants that previously produced an "index out of bounds" panic
+//! when a TCP segment split the body across reads (E2E: sandboxd thread
+//! panic at main.zig handleRequest).
+
+const std = @import("std");
+
+/// maxRequestBodyBytes caps a single HTTP request body. Raised far above the
+/// old fixed 64KiB stack buffer so WriteFile can carry large payloads; the
+/// gateway gRPC layer already allows 64MiB messages (see KIP-16 M7).
+pub const maxRequestBodyBytes: usize = 64 * 1024 * 1024;
+
+pub const Error = error{
+    ReadFailed,
+    TooLarge,
+    Malformed,
+};
+
+/// A parsed HTTP request. Every slice points into `alloc`; free it with the
+/// same allocator passed to readRequest (free the FULL `alloc` slice — the
+/// parsed views may be shorter when a short body was clamped).
+pub const Request = struct {
+    method: []const u8,
+    path: []const u8,
+    query: []const u8,
+    body: []const u8,
+    /// Full backing allocation (may extend past the clamped request bytes
+    /// when the peer sent fewer body bytes than Content-Length promised).
+    alloc: []u8,
+    /// The clamped request bytes: headers + the body that actually arrived.
+    raw: []const u8,
+};
+
+const header_buf_len: usize = 16384;
+
+/// readRequest reads one HTTP/1.x request from fd and parses its request
+/// line, path, query string, and body.
+///
+/// Buffer layout (the invariant the old code got wrong): `head` — the first
+/// read — may already carry `body_in_head` body bytes right after the
+/// headers, and the follow-up reads append the rest AFTER those bytes, so the
+/// allocation must hold `header_end + content_length` bytes total:
+///
+///   [ headers | body_in_head | remaining ]
+///   ^buf                       ^append_at ^request end
+///
+/// Sizing the buffer without the `body_in_head` overlap both truncated the
+/// allocation (panic: index past len) and made the append loop overwrite the
+/// body bytes already copied from head. Short bodies (peer closed early) are
+/// clamped to what actually arrived instead of exposing uninitialized bytes.
+///
+/// Returns null when the connection closes before a header terminator is
+/// seen (keep-alive probes, empty connections).
+pub fn readRequest(allocator: std.mem.Allocator, fd: i32) !?Request {
+    var header_buf: [header_buf_len]u8 = undefined;
+    var content_length: usize = 0;
+
+    // First read: headers plus whatever body bytes arrived in the segment.
+    const n0 = std.posix.read(fd, &header_buf) catch return error.ReadFailed;
+    if (n0 == 0) return null;
+    const head = header_buf[0..n0];
+
+    // Parse Content-Length so we know how much body to expect.
+    var head_lines = std.mem.splitScalar(u8, head, '\n');
+    _ = head_lines.next(); // request line
+    while (head_lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, &std.ascii.whitespace);
+        if (std.ascii.startsWithIgnoreCase(trimmed, "content-length:")) {
+            const val = std.mem.trim(u8, trimmed["content-length:".len..], &std.ascii.whitespace);
+            content_length = std.fmt.parseInt(usize, val, 10) catch 0;
+        }
+    }
+    if (content_length > maxRequestBodyBytes) return error.TooLarge;
+
+    const header_end = std.mem.indexOf(u8, head, "\r\n\r\n") orelse return null;
+    const body_start = header_end + 4;
+    const body_in_head = if (head.len > body_start) head.len - body_start else 0;
+    const remaining = if (body_in_head < content_length) content_length - body_in_head else 0;
+
+    // Headers + FULL body: head.len covers headers+partial body, and the
+    // loop appends the remainder after it (never on top of it).
+    const buf_len = @max(head.len, body_start + content_length);
+    const buf = try allocator.alloc(u8, buf_len);
+    errdefer allocator.free(buf);
+    @memcpy(buf[0..head.len], head);
+
+    var read: usize = 0;
+    while (read < remaining) {
+        // Append after the partial body already copied from head.
+        const n = std.posix.read(fd, buf[body_start + body_in_head + read ..]) catch break;
+        if (n == 0) break;
+        read += n;
+    }
+
+    // Clamp to what actually arrived: a short body must not leak
+    // uninitialized buffer bytes into handlers.
+    const received = body_in_head + read;
+    const body_total = @min(received, content_length);
+
+    const raw = buf[0 .. body_start + body_total];
+
+    var lines = std.mem.splitScalar(u8, raw, '\n');
+    const request_line = lines.next() orelse return error.Malformed;
+    var parts = std.mem.splitScalar(u8, std.mem.trim(u8, request_line, &std.ascii.whitespace), ' ');
+    const method = parts.next() orelse return error.Malformed;
+    const path_full = parts.next() orelse return error.Malformed;
+
+    var path_parts = std.mem.splitScalar(u8, path_full, '?');
+    const path = path_parts.next() orelse path_full;
+    const query = path_parts.next() orelse "";
+
+    const body = if (std.mem.indexOf(u8, raw, "\r\n\r\n")) |i| raw[i + 4 ..] else "";
+
+    return .{ .method = method, .path = path, .query = query, .body = body, .alloc = buf, .raw = raw };
+}
+
+test {}

--- a/sandboxd/src/httpio_test.zig
+++ b/sandboxd/src/httpio_test.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+const testing = std.testing;
+const httpio = @import("httpio.zig");
+
+// --- regression: split-body reassembly (E2E panic "index out of bounds") ---
+//
+// The old framing math in main.zig handleRequest sized the request buffer as
+// max(head.len, header_end + remaining) while the final slice needed
+// header_end + content_length. Whenever the FIRST read returned headers plus
+// SOME body bytes (0 < body_in_head < content_length) the slice indexed past
+// the allocation and sandboxd's connection thread panicked:
+//
+//   thread 300 panic: index out of bounds: index 20626, len 16686
+//
+// These tests drive readRequest through a temp-file fd: reads on a regular
+// file return up to the 16KiB header_buf cap per call, so a >16KiB request
+// deterministically produces the "first read carries headers + PARTIAL body"
+// shape that triggered the panic.
+
+const ReqFile = struct {
+    tmp: std.testing.TmpDir,
+    file: std.Io.File,
+
+    fn init(bytes: []const u8) !ReqFile {
+        var tmp = std.testing.tmpDir(.{});
+        errdefer tmp.cleanup();
+        const f = try tmp.dir.createFile(testing.io, "request.bin", .{ .read = true });
+        try f.writePositionalAll(testing.io, bytes, 0);
+        return .{ .tmp = tmp, .file = f };
+    }
+
+    fn deinit(rf: *ReqFile) void {
+        rf.file.close(testing.io);
+        rf.tmp.cleanup();
+    }
+};
+
+fn buildRequest(content_length: usize) ![]u8 {
+    const head_fmt = "POST /files/write HTTP/1.1\r\nHost: sandboxd\r\nContent-Length: {d}\r\n\r\n";
+    var header_buf: [256]u8 = undefined;
+    const head = try std.fmt.bufPrint(&header_buf, head_fmt, .{content_length});
+    const buf = try testing.allocator.alloc(u8, head.len + content_length);
+    // Body bytes distinct per position so corruption would be detectable.
+    for (buf[head.len..], 0..) |*b, i| b.* = @intCast(i % 251 + 1);
+    @memcpy(buf[0..head.len], head);
+    return buf;
+}
+
+test "readRequest reassembles body split across reads (regression)" {
+    const allocator = testing.allocator;
+
+    // 20000-byte body + ~70B headers exceeds the 16KiB first-read cap, so the
+    // first read lands mid-body — the exact shape behind the E2E panic
+    // ("index 20626, len 16686": first read 16686B vs required 20626B).
+    const req_bytes = try buildRequest(20000);
+    defer allocator.free(req_bytes);
+
+    var rf = try ReqFile.init(req_bytes);
+    defer rf.deinit();
+
+    const req = (try httpio.readRequest(allocator, rf.file.handle)) orelse return error.TestUnexpectedResult;
+    defer allocator.free(req.alloc);
+
+    try testing.expectEqualStrings("POST", req.method);
+    try testing.expectEqualStrings("/files/write", req.path);
+    // Body must be complete AND uncorrupted: the old append offset overwrote
+    // the partial body copied from head.
+    try testing.expectEqual(@as(usize, 20000), req.body.len);
+    try testing.expectEqualSlices(u8, req_bytes[req_bytes.len - 20000 ..], req.body);
+}
+
+test "readRequest parses single-read GET" {
+    const allocator = testing.allocator;
+    const raw_req = "GET /events?limit=5 HTTP/1.1\r\nHost: sandboxd\r\nContent-Length: 0\r\n\r\n";
+
+    var rf = try ReqFile.init(raw_req);
+    defer rf.deinit();
+
+    const req = (try httpio.readRequest(allocator, rf.file.handle)) orelse return error.TestUnexpectedResult;
+    defer allocator.free(req.alloc);
+
+    try testing.expectEqualStrings("GET", req.method);
+    try testing.expectEqualStrings("/events", req.path);
+    try testing.expectEqualStrings("limit=5", req.query);
+    try testing.expectEqual(@as(usize, 0), req.body.len);
+}
+
+test "readRequest clamps short body to what arrived" {
+    const allocator = testing.allocator;
+    // Peer promises 100 bytes but sends 10 (EOF ends the read loop).
+    const raw_req = "POST /exec/stdin HTTP/1.1\r\nContent-Length: 100\r\n\r\n0123456789";
+
+    var rf = try ReqFile.init(raw_req);
+    defer rf.deinit();
+
+    const req = (try httpio.readRequest(allocator, rf.file.handle)) orelse return error.TestUnexpectedResult;
+    defer allocator.free(req.alloc);
+
+    try testing.expectEqualStrings("0123456789", req.body);
+}
+
+test "readRequest rejects oversized declared body" {
+    const allocator = testing.allocator;
+    const raw_req = "POST /files/write HTTP/1.1\r\nContent-Length: 999999999\r\n\r\nx";
+
+    var rf = try ReqFile.init(raw_req);
+    defer rf.deinit();
+
+    const result = httpio.readRequest(allocator, rf.file.handle);
+    try testing.expectError(error.TooLarge, result);
+}
+
+test "readRequest returns null for empty connection" {
+    const allocator = testing.allocator;
+
+    var rf = try ReqFile.init("");
+    defer rf.deinit();
+
+    const req = try httpio.readRequest(allocator, rf.file.handle);
+    try testing.expect(req == null);
+}

--- a/sandboxd/src/main.zig
+++ b/sandboxd/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const httpio = @import("httpio.zig");
 const exec = @import("exec.zig");
 const files = @import("files.zig");
 const workspace = @import("workspace.zig");
@@ -90,71 +91,21 @@ fn handleConn(allocator: std.mem.Allocator, client_fd: i32) void {
     };
 }
 
-/// maxRequestBodyBytes caps a single HTTP request body. Raised far above the
-/// old fixed 64KiB stack buffer so WriteFile can carry large payloads; the
-/// gateway gRPC layer already allows 64MiB messages (see KIP-16 M7).
-const maxRequestBodyBytes: usize = 64 * 1024 * 1024;
-
 fn handleRequest(allocator: std.mem.Allocator, client_fd: i32) !void {
-    // Read the whole request. Headers are tiny; bodies (WriteFile) can be large,
-    // so allocate on the heap sized by Content-Length instead of a stack array.
-    var header_buf: [16384]u8 = undefined;
-    var content_length: usize = 0;
+    const maybe = httpio.readRequest(allocator, client_fd) catch |err| switch (err) {
+        error.TooLarge => {
+            try writeResponse(client_fd, "413 Payload Too Large", "application/json", "{\"error\":\"request too large\"}");
+            return;
+        },
+        else => return err,
+    };
+    const req = maybe orelse return;
+    defer allocator.free(req.alloc);
 
-    // First read headers (single read is fine for our small requests).
-    const n0 = std.os.linux.read(client_fd, &header_buf, header_buf.len);
-    if (n0 < 0) return error.ReadFailed;
-    if (n0 == 0) return;
-    const head = header_buf[0..@as(usize, @intCast(n0))];
-
-    // Parse Content-Length so we know how much body to read.
-    var head_lines = std.mem.splitScalar(u8, head, '\n');
-    _ = head_lines.next(); // request line
-    while (head_lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, &std.ascii.whitespace);
-        if (std.ascii.startsWithIgnoreCase(trimmed, "content-length:")) {
-            const val = std.mem.trim(u8, trimmed["content-length:".len..], &std.ascii.whitespace);
-            content_length = std.fmt.parseInt(usize, val, 10) catch 0;
-        }
-    }
-    if (content_length > maxRequestBodyBytes) {
-        try writeResponse(client_fd, "413 Payload Too Large", "application/json", "{\"error\":\"request too large\"}");
-        return;
-    }
-
-    const header_end = std.mem.indexOf(u8, head, "\r\n\r\n") orelse return;
-    const body_start = header_end + 4;
-    const body_in_head = if (head.len > body_start) head.len - body_start else 0;
-    const remaining = if (body_in_head < content_length) content_length - body_in_head else 0;
-
-    const buf_len = if (head.len > body_start + remaining) head.len else body_start + remaining;
-    const buf = try allocator.alloc(u8, buf_len);
-    defer allocator.free(buf);
-    @memcpy(buf[0..head.len], head);
-
-    var read: usize = 0;
-    while (read < remaining) {
-        const n = std.os.linux.read(client_fd, buf.ptr + body_start + read, remaining - read);
-        if (n <= 0) break;
-        read += @as(usize, @intCast(n));
-    }
-
-    // request spans headers + body: body_in_head bytes already in the first
-    // read plus anything fetched by the loop.
-    const body_total = if (remaining > 0) content_length else body_in_head;
-    const request = buf[0 .. body_start + body_total];
-
-    var lines = std.mem.splitScalar(u8, request, '\n');
-    const request_line = lines.next() orelse return;
-    var parts = std.mem.splitScalar(u8, std.mem.trim(u8, request_line, &std.ascii.whitespace), ' ');
-    const method = parts.next() orelse return;
-    const path_full = parts.next() orelse return;
-
-    var path_parts = std.mem.splitScalar(u8, path_full, '?');
-    const path = path_parts.next() orelse path_full;
-    const query = path_parts.next() orelse "";
-
-    const body = if (std.mem.indexOf(u8, request, "\r\n\r\n")) |i| request[i + 4 ..] else "";
+    const method = req.method;
+    const path = req.path;
+    const query = req.query;
+    const body = req.body;
 
     if (std.mem.eql(u8, path, "/ready") and std.mem.eql(u8, method, "POST")) {
         try handleReady(client_fd);
@@ -282,6 +233,9 @@ fn handleEvents(allocator: std.mem.Allocator, client_fd: i32, query: []const u8)
     try writeResponse(client_fd, "200 OK", "application/json", body.items);
 }
 
+/// writeResponse writes a complete HTTP/1.1 response with Connection: close.
+/// Kept out of httpio.zig so that module stays host-portable for tests:
+/// sandboxd is linux-only and writes via raw syscalls.
 pub fn writeResponse(client_fd: i32, status: []const u8, content_type: []const u8, body: []const u8) !void {
     var header_buf: [4096]u8 = undefined;
     const header = try std.fmt.bufPrint(&header_buf,


### PR DESCRIPTION
## E2E failure

```
$ kubectl logs sandbox-sess-1787478187294766243 -n sandbox-matrix
info: sandboxd listening on :2024
thread 300 panic: index out of bounds: index 20626, len 16686
sandboxd/src/main.zig:145:24 in handleRequest
```

## Root cause

`handleRequest` framed HTTP requests with a single `read()` for headers, then a loop for the remaining `Content-Length`. When the **first read returned headers plus a partial body** (`0 < body_in_head < content_length`) — i.e. the body spanned TCP segments — three defects compounded:

1. **Buffer undersized → the panic.** Allocated `max(head.len, header_end + remaining)` but sliced `buf[0 .. header_end + content_length]`; whenever `body_in_head > 0` the slice end exceeds the allocation (`20626 > 16686`, overflow = 2 × body_in_head).
2. **Silent body corruption on the same path**: follow-up reads appended at `body_start + read`, overwriting the partial-body bytes already copied from head.
3. **Uninitialized memory exposure**: when the peer closed early, the final slice still used full `Content-Length`.

Any POST whose request crossed segment boundaries could trigger it (e.g. `/files/write` with larger payloads).

## Fix

Extract request framing into **`sandboxd/src/httpio.zig`** (`readRequest`) using `std.posix` so it unit-tests on any host:

- buffer sized `header_end + content_length` (headers + partial body + remainder),
- follow-up reads append **after** the partial body,
- short bodies clamped to what actually arrived,
- `Request` carries both the clamped view (`raw`) and the full allocation (`alloc`) so callers free exactly what was allocated,
- `413 Payload Too Large` preserved for oversized declared bodies.

`main.zig handleRequest` now delegates to it; `writeResponse` stays in main.zig (linux-only raw syscalls, as before).

## Tests

`sandboxd/src/httpio_test.zig` drives `readRequest` through a temp-file fd — regular-file reads cap at the 16KiB first-read buffer, which deterministically reproduces the "first read carries headers + partial body" shape behind the panic:

- split-body reassembly (20KB body): complete and uncorrupted ✅
- single-read GET parsing ✅
- short-body clamp ✅
- oversized Content-Length → `error.TooLarge` ✅
- empty connection → null ✅

All 6 pass locally; `zig build sandboxd` compiles clean for x86_64/aarch64/riscv64 linux-musl.

## Deploy note

sandboxd is baked into the sandbox image (`sandbox/Dockerfile`) — merge, then cut a new rc so sessions pick up the fixed binary.
