### PR TITLE
fix(sandbox-cli): accept --endpoint/--apikey/--profile on connect directly

### DIFF
--- a/pkg/sandboxcli/connect.go
+++ b/pkg/sandboxcli/connect.go
@@ -22,6 +22,27 @@ const (
 	flagSkipPath   = "skip-path"
 )
 
+// Connection flag names. They are registered BOTH on the root command
+// (k8e-sandbox-cli --endpoint … connect) and on connect itself
+// (k8e-sandbox-cli connect --endpoint …) — the latter is the natural
+// spelling users reach for first.
+const (
+	flagEndpoint = "endpoint"
+	flagApikey   = "apikey"
+	flagProfile  = "profile"
+)
+
+// connFlag returns a connection flag from the subcommand-local flag set when
+// explicitly provided, else falls back to the root-command global flag (and
+// its env var binding). Needed because urfave/cli v1 keeps local and global
+// flag sets separate: an unset local flag does not see the global value.
+func connFlag(ctx *cli.Context, name string) string {
+	if v := ctx.String(name); v != "" {
+		return v
+	}
+	return ctx.GlobalString(name)
+}
+
 // ConnectCommand returns the "connect" subcommand: authenticate (local or remote),
 // persist connection config, verify the gateway, ensure CLI is on PATH, and install
 // agent skills so harnesses can invoke `/k8e-sandbox <goal>` (Claude),
@@ -32,6 +53,21 @@ func ConnectCommand() cli.Command {
 		Name:  "connect",
 		Usage: "Connect to local or remote K8E sandbox and install /k8e-sandbox agent skills",
 		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   flagEndpoint,
+				EnvVar: "K8E_SANDBOX_ENDPOINT",
+				Usage:  "gRPC endpoint (default: 127.0.0.1:50051)",
+			},
+			cli.StringFlag{
+				Name:   flagApikey,
+				EnvVar: "K8E_SANDBOX_APIKEY",
+				Usage:  "API key for remote cluster authentication",
+			},
+			cli.StringFlag{
+				Name:   flagProfile,
+				EnvVar: "K8E_SANDBOX_PROFILE",
+				Usage:  "Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17)",
+			},
 			cli.StringFlag{
 				Name:  flagAgent,
 				Value: "auto",
@@ -72,7 +108,7 @@ func connectAction(ctx *cli.Context) error {
 		return connectSkillOnly(ctx)
 	}
 
-	resolved, err := ResolveConn(ctx.GlobalString("endpoint"), ctx.GlobalString("apikey"), ctx.GlobalString("profile"), "")
+	resolved, err := ResolveConn(connFlag(ctx, flagEndpoint), connFlag(ctx, flagApikey), connFlag(ctx, flagProfile), "")
 	if err != nil {
 		return printErrorExit(err.Error(), 1)
 	}

--- a/pkg/sandboxcli/connect_test.go
+++ b/pkg/sandboxcli/connect_test.go
@@ -1,10 +1,13 @@
 package sandboxcli
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/urfave/cli"
 )
 
 func TestResolveConnectMode_LocalDefault(t *testing.T) {
@@ -391,4 +394,64 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+// --- connFlag: connect --endpoint … must work alongside the root-level
+// k8e-sandbox-cli --endpoint … spelling (urfave/cli v1 keeps local and
+// global flag sets separate, so an unset local flag must fall back). ---
+
+func connFlagTestCtx(t *testing.T, local, global map[string]string) *cli.Context {
+	t.Helper()
+	app := cli.NewApp()
+	localSet := flag.NewFlagSet("connect", flag.ContinueOnError)
+	globalSet := flag.NewFlagSet("k8e-sandbox-cli", flag.ContinueOnError)
+	for _, name := range []string{flagEndpoint, flagApikey, flagProfile} {
+		localSet.String(name, "", "")
+		globalSet.String(name, "", "")
+	}
+	args := []string{}
+	for name, v := range local {
+		args = append(args, "--"+name, v)
+	}
+	if err := localSet.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	gargs := []string{}
+	for name, v := range global {
+		gargs = append(gargs, "--"+name, v)
+	}
+	if err := globalSet.Parse(gargs); err != nil {
+		t.Fatal(err)
+	}
+	gctx := cli.NewContext(app, globalSet, nil)
+	return cli.NewContext(app, localSet, gctx)
+}
+
+func TestConnFlag_LocalOverridesGlobal(t *testing.T) {
+	ctx := connFlagTestCtx(t,
+		map[string]string{flagEndpoint: "local:50051"},
+		map[string]string{flagEndpoint: "global:50051"})
+	if got := connFlag(ctx, flagEndpoint); got != "local:50051" {
+		t.Fatalf("connFlag = %q, want local:50051", got)
+	}
+}
+
+func TestConnFlag_FallsBackToGlobal(t *testing.T) {
+	ctx := connFlagTestCtx(t, nil, map[string]string{
+		flagEndpoint: "global:50051",
+		flagApikey:   "gkey",
+	})
+	if got := connFlag(ctx, flagEndpoint); got != "global:50051" {
+		t.Fatalf("connFlag(endpoint) = %q, want global:50051", got)
+	}
+	if got := connFlag(ctx, flagApikey); got != "gkey" {
+		t.Fatalf("connFlag(apikey) = %q, want gkey", got)
+	}
+}
+
+func TestConnFlag_EmptyWhenNowhereSet(t *testing.T) {
+	ctx := connFlagTestCtx(t, nil, nil)
+	if got := connFlag(ctx, flagProfile); got != "" {
+		t.Fatalf("connFlag(profile) = %q, want empty", got)
+	}
 }

--- a/pkg/sandboxcli/connect_test.go
+++ b/pkg/sandboxcli/connect_test.go
@@ -409,14 +409,14 @@ func connFlagTestCtx(t *testing.T, local, global map[string]string) *cli.Context
 		localSet.String(name, "", "")
 		globalSet.String(name, "", "")
 	}
-	args := []string{}
+	var args []string
 	for name, v := range local {
 		args = append(args, "--"+name, v)
 	}
 	if err := localSet.Parse(args); err != nil {
 		t.Fatal(err)
 	}
-	gargs := []string{}
+	var gargs []string
 	for name, v := range global {
 		gargs = append(gargs, "--"+name, v)
 	}


### PR DESCRIPTION
## Problem

```
$ k8e-sandbox-cli connect --endpoint ec2-….amazonaws.com:50051 --apikey …
Incorrect Usage: flag provided but not defined: -endpoint
FATA[0000] flag provided but not defined: -endpoint
```

`--endpoint` / `--apikey` / `--profile` were registered **only on the root command** (urfave/cli v1 global flags), so they had to appear *before* the subcommand:

```
k8e-sandbox-cli --endpoint … --apikey … connect   # worked
k8e-sandbox-cli connect --endpoint …              # failed
```

The second spelling is the natural one users reach for first (and the one the docs/skills examples use).

## Fix

- Register `--endpoint`, `--apikey`, `--profile` on the **connect** subcommand too, with the same env bindings (`K8E_SANDBOX_ENDPOINT/APIKEY/PROFILE`).
- New `connFlag(ctx, name)` helper resolves local flag first, then falls back to the root-level global — required because urfave/cli v1 keeps local and global flag sets separate (an unset local flag does not see the global value).
- Both spellings now work:
  ```
  k8e-sandbox-cli connect --endpoint h:50051 --apikey KEY
  k8e-sandbox-cli --endpoint h:50051 --apikey KEY connect
  ```

## Tests

- `TestConnFlag_LocalOverridesGlobal` / `_FallsBackToGlobal` / `_EmptyWhenNowhereSet` cover the merge chain.
- Full `go test ./pkg/sandboxcli/` green; smoke-tested both invocations against a live gateway.

## Scope note

`login` and `doctor` still read only the global flags (`ctx.GlobalString`). The same pattern applies if we want subcommand-local flags there too — left out of this PR to keep it focused.
