### PR TITLE
fix(sandbox): enable gateway LocalAuth — unbreak the expose proxy chain

### DIFF
--- a/pkg/sandboxmatrix/controller.go
+++ b/pkg/sandboxmatrix/controller.go
@@ -89,6 +89,11 @@ func Register(ctx context.Context, k8s kubernetes.Interface, kubeconfig string, 
 		AdvertiseHostname: cfg.AdvertiseHostname,
 		ExposeBaseURL:     cfg.ExposeBaseURL,
 		AdvertiseIP:       cfg.AdvertiseIP,
+		// The embedded e2b server (same host process) dials the gateway over
+		// loopback with CA trust but NO client certificate (see
+		// runEmbeddedE2B / newLocalClient). LocalAuth permits exactly those
+		// loopback connections; every remote peer still requires full mTLS.
+		LocalAuth: true,
 	})
 	go func() {
 		if err := srv.Start(ctx); err != nil {

--- a/pkg/sandboxmatrix/grpc/cert_test.go
+++ b/pkg/sandboxmatrix/grpc/cert_test.go
@@ -1,12 +1,16 @@
 package grpc
 
 import (
+	"context"
 	"crypto/x509"
 	"net"
 	"os"
 	"testing"
 
 	"github.com/xiaods/k8e/pkg/daemons/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 )
 
 // TestCollectServerSANsAdvertiseHostname verifies the AWS/remote-host case: the
@@ -166,5 +170,39 @@ func TestAtomicWriteFile(t *testing.T) {
 	// No temp file may be left behind.
 	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
 		t.Fatalf("temp file left behind: %v", err)
+	}
+}
+
+// TestCheckMTLSAuthLoopbackLocalAuth pins the KIP-24 expose chain: the
+// embedded e2b server dials the gateway over loopback with CA trust but NO
+// client certificate (newLocalClient), relying on the gateway's LocalAuth
+// exemption. Without LocalAuth the dial is rejected with Unauthenticated and
+// every /k8e/expose/ request 503s ("client certificate required for mTLS").
+// Remote (non-loopback) peers must still be rejected without a client cert.
+func TestCheckMTLSAuthLoopbackLocalAuth(t *testing.T) {
+	loopback := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 45678}
+	remote := &net.TCPAddr{IP: net.ParseIP("203.0.113.7"), Port: 45678}
+	ctxFrom := func(addr net.Addr) context.Context {
+		return peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
+	}
+
+	s := &Server{}
+	if err := s.checkMTLSAuth(ctxFrom(loopback)); err == nil {
+		t.Fatal("loopback without LocalAuth must be rejected")
+	} else if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("loopback without LocalAuth: got %v, want Unauthenticated", err)
+	}
+	if err := s.checkMTLSAuth(ctxFrom(remote)); err == nil {
+		t.Fatal("remote without cert must always be rejected")
+	}
+
+	s.localAuth = true
+	if err := s.checkMTLSAuth(ctxFrom(loopback)); err != nil {
+		t.Fatalf("loopback with LocalAuth must pass, got %v", err)
+	}
+	if err := s.checkMTLSAuth(ctxFrom(remote)); err == nil {
+		t.Fatal("remote with LocalAuth set must still require mTLS")
+	} else if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("remote with LocalAuth set: got %v, want Unauthenticated", err)
 	}
 }


### PR DESCRIPTION
## Problem

`/k8e/expose/` URLs return **503 "gateway unreachable"** with the gateway log showing:

```
Unauthenticated: client certificate required for mTLS
```

The full expose chain is: Cilium Gateway (:80) → e2b HTTP server → **gRPC gateway (ListExposed authorization)** → sandboxd proxy. This failure is at the marked hop.

## Root cause

The embedded e2b server dials the gateway over **loopback** (`127.0.0.1:<grpc-port>`) via `newLocalClient`, which trusts the sandbox CA but presents **no client certificate**. That is by design: the gateway is supposed to exempt loopback peers via `ServerConfig.LocalAuth`:

```go
if isLocal && s.localAuth { return nil }   // checkMTLSAuth
```

But **nothing ever set `LocalAuth`** — the field existed, `runEmbeddedE2B`'s comment described exactly this design ("mTLS with loopback LocalAuth"), yet controller.go never passed it. So `localAuth` was always `false`, loopback peers fell through, and every expose request died at ListExposed with Unauthenticated.

This is the last hop of the KIP-24 chain that had never been deployment-verified end to end (the design doc marked M4 e2e as pending).

## Fix

`pkg/sandboxmatrix/controller.go`: set `LocalAuth: true` when constructing the gRPC `ServerConfig`.

Security posture unchanged for remote clients: the exemption is strictly `isLoopbackAddr(peer)`; every non-loopback peer still requires a full mTLS client certificate (enforced in the same code path).

## Test

`TestCheckMTLSAuthLoopbackLocalAuth`: loopback rejected without LocalAuth / allowed with it; remote peers rejected in both cases.

## Deployment note

The fix is in `k8e-server` — merge, then restart the server (no image rebuild needed; sandboxd is not involved in this hop).
