### PR TITLE
fix(sandbox): connect --reset-certs silently no-opped on default installs

### DIFF
--- a/pkg/sandboxcli/connect.go
+++ b/pkg/sandboxcli/connect.go
@@ -117,11 +117,7 @@ func connectAction(ctx *cli.Context) error {
 	apikey := resolved.APIKey
 
 	if ctx.Bool(flagResetCerts) {
-		if dir := resolved.CertDir; dir != "" {
-			for _, f := range []string{"ca.crt", "client.crt", "client.key", "endpoint"} {
-				_ = os.Remove(filepath.Join(dir, f))
-			}
-		}
+		resetCerts(resolved)
 	}
 
 	mode, cfgEndpoint, err := resolveConnectMode(endpoint, apikey)
@@ -168,6 +164,24 @@ func connectAction(ctx *cli.Context) error {
 
 	printConnectSuccess(mode, cfgEndpoint, cliPath, installedAgents, installResults)
 	return nil
+}
+
+// resetCerts deletes cached trust material (CA, client cert/key, endpoint
+// stamp) for this connection so the next dial re-bootstraps from the API key.
+// When no explicit cert_dir was configured it falls back to the default cache
+// dir (~/.k8e/sandbox) — otherwise --reset-certs would silently no-op on
+// default installs while the dial keeps trusting the stale CA there.
+func resetCerts(resolved *ResolvedConn) {
+	dir := resolved.CertDir
+	if dir == "" {
+		dir, _ = dataDir()
+	}
+	if dir == "" {
+		return
+	}
+	for _, f := range []string{"ca.crt", "client.crt", "client.key", "endpoint"} {
+		_ = os.Remove(filepath.Join(dir, f))
+	}
 }
 
 func connectSkillOnly(ctx *cli.Context) error {

--- a/pkg/sandboxcli/connect_test.go
+++ b/pkg/sandboxcli/connect_test.go
@@ -455,3 +455,49 @@ func TestConnFlag_EmptyWhenNowhereSet(t *testing.T) {
 		t.Fatalf("connFlag(profile) = %q, want empty", got)
 	}
 }
+
+func TestResetCerts_FallsBackToDefaultDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("K8E_SANDBOX_CERT_DIR", "")
+
+	dir := filepath.Join(home, ".k8e", "sandbox")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"ca.crt", "client.crt", "client.key", "endpoint", "config.json"} {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resetCerts(&ResolvedConn{Endpoint: "sandbox.example.com:50051"}) // CertDir empty → default dir
+
+	for _, f := range []string{"ca.crt", "client.crt", "client.key", "endpoint"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after reset (err=%v)", f, err)
+		}
+	}
+	// Non-cert files must be preserved.
+	if _, err := os.Stat(filepath.Join(dir, "config.json")); err != nil {
+		t.Fatalf("config.json should survive cert reset: %v", err)
+	}
+}
+
+func TestResetCerts_ExplicitCertDir(t *testing.T) {
+	custom := t.TempDir()
+	t.Setenv("K8E_SANDBOX_CERT_DIR", "")
+	for _, f := range []string{"ca.crt", "client.crt"} {
+		if err := os.WriteFile(filepath.Join(custom, f), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resetCerts(&ResolvedConn{Endpoint: "sandbox.example.com:50051", CertDir: custom})
+
+	for _, f := range []string{"ca.crt", "client.crt"} {
+		if _, err := os.Stat(filepath.Join(custom, f)); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after reset", f)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`k8e-sandbox-cli connect --reset-certs` did nothing on default installs. After a server reinstall / CA rotation, re-running the command reproduced the exact same failure it exists to clear:

```
gateway verify failed: ... tls: failed to verify certificate: x509: certificate signed by unknown authority
  hint: the cached CA (~/.k8e/sandbox/ca.crt) does not match this gateway ...
  (or re-run connect with --reset-certs)
```

## Root cause

The cert reset in `connectAction` was guarded by `resolved.CertDir != ""`. `CertDir` is only populated from `K8E_SANDBOX_CERT_DIR` or a profile's `cert_dir`; with the default layout (`cert_dir: ""`) the deletion block was skipped entirely. The dial then still trusted the stale `~/.k8e/sandbox/ca.crt`, because the client's `sandboxCacheDir()` falls back to that same default directory.

## Fix

Extract a `resetCerts(resolved)` helper that falls back to the default cache dir (`dataDir()` — same priority as the client's `sandboxCacheDir()`: env → `~/.k8e/sandbox`) when no explicit cert_dir is configured.

## Tests

- `TestResetCerts_FallsBackToDefaultDir`: with empty CertDir, ca.crt/client.crt/client.key/endpoint are removed from `~/.k8e/sandbox`; non-cert files (config.json) survive.
- `TestResetCerts_ExplicitCertDir`: explicit cert_dir path still works.
