### PR TITLE
feat(sandbox): add API Key MCP HTTP entry and deployment

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,23 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  mcp:
+    name: MCP API Key and HTTPS interoperability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Test MCP and initialization
+        run: |
+          MCP_RUN_INTEROP=1 go test -race ./pkg/sandboxmcp ./cmd/sandboxcli -count=1
+          python3 tests/mcp/test_init.py
+          bash -n hack/init-sandbox-mcp.sh
+
   build:
     name: Build & Test (linux/amd64)
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Test MCP and initialization
         run: |
           MCP_RUN_INTEROP=1 go test -race ./pkg/sandboxmcp ./cmd/sandboxcli -count=1
+          go test -race -tags mcp_integration ./pkg/sandboxmcp -run '^TestGatewayWithKubernetesMock$' -count=1
           python3 tests/mcp/test_init.py
-          bash -n hack/init-sandbox-mcp.sh
+          bash -n hack/init-sandbox-mcp.sh hack/test-sandbox-mcp-orbstack.sh
+      - name: Build MCP deployment image
+        run: docker build -f manifests/sandbox-mcp/Dockerfile -t k8e-mcp:test .
 
   build:
     name: Build & Test (linux/amd64)

--- a/cmd/sandboxcli/main.go
+++ b/cmd/sandboxcli/main.go
@@ -7,13 +7,16 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/xiaods/k8e/pkg/sandboxcli"
+	"github.com/xiaods/k8e/pkg/sandboxmcp"
 	"github.com/xiaods/k8e/pkg/version"
 )
 
 func main() {
 	// Stage embedded skill files for connect (agent harness install).
-	if err := sandboxcli.StageSkills(); err != nil {
-		logrus.Fatalf("Failed to stage skill files: %v", err)
+	if len(os.Args) < 2 || os.Args[1] != "mcp-serve" {
+		if err := sandboxcli.StageSkills(); err != nil {
+			logrus.Fatalf("Failed to stage skill files: %v", err)
+		}
 	}
 
 	app := cli.NewApp()
@@ -27,6 +30,7 @@ func main() {
 		cli.StringFlag{Name: "profile", EnvVar: "K8E_SANDBOX_PROFILE", Usage: "Named profile from ~/.k8e/sandbox/profiles.yaml (KIP-17; not server /etc/k8e/config.yaml)"},
 	}
 	commands := []cli.Command{
+		sandboxmcp.Command(),
 		sandboxcli.ConnectCommand(),
 		sandboxcli.LoginCommand(),
 		sandboxcli.DoctorCommand(),

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Last audited: **2026-08-24**, against the in-tree sandbox matrix, gRPC proto,
 |-----|-------|--------|
 | [KIP-3](kip-3-agentic-ai-sandbox-matrix.md) | Agentic AI Sandbox Matrix (sessions, warm pool, gRPC, Cilium) | Implemented |
 | [KIP-25](kip-25-sandbox-warm-pool.md) | `SandboxWarmPool` CRD: fields, adaptive sizing, idle TTL | Implemented — default install stages a `size: 1` pool |
-| [KIP-8](kip-8-skill-cli-replace-mcp.md) | CLI + Skill and API Key MCP entry | CLI implemented; MCP cluster acceptance pending |
+| [KIP-8](kip-8-skill-cli-replace-mcp.md) | CLI + Skill and API Key MCP entry | MCP restart/client interop complete; Gateway API HTTPS exposure in validation |
 | [KIP-9](kip-9-sandbox-workspace-manifest.md) | Workspace manifest (`--manifest` / `--git-repo`) | Implemented |
 | [KIP-10](kip-10-sandbox-snapshot.md) | Workspace snapshot | Implemented — original client `tar.gz` evolved into KIP-16 M2 CAS layerstore |
 | [KIP-11](kip-11-background-sandbox-execution.md) | Background exec + poll | Implemented — runs in the **same** session pod, capped (`maxBackgroundRuns`, default 5); dedicated background pool was not shipped |

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Last audited: **2026-08-24**, against the in-tree sandbox matrix, gRPC proto,
 |-----|-------|--------|
 | [KIP-3](kip-3-agentic-ai-sandbox-matrix.md) | Agentic AI Sandbox Matrix (sessions, warm pool, gRPC, Cilium) | Implemented |
 | [KIP-25](kip-25-sandbox-warm-pool.md) | `SandboxWarmPool` CRD: fields, adaptive sizing, idle TTL | Implemented — default install stages a `size: 1` pool |
-| [KIP-8](kip-8-skill-cli-replace-mcp.md) | SKILL + CLI replace MCP | Implemented |
+| [KIP-8](kip-8-skill-cli-replace-mcp.md) | CLI + Skill and API Key MCP entry | CLI implemented; MCP cluster acceptance pending |
 | [KIP-9](kip-9-sandbox-workspace-manifest.md) | Workspace manifest (`--manifest` / `--git-repo`) | Implemented |
 | [KIP-10](kip-10-sandbox-snapshot.md) | Workspace snapshot | Implemented — original client `tar.gz` evolved into KIP-16 M2 CAS layerstore |
 | [KIP-11](kip-11-background-sandbox-execution.md) | Background exec + poll | Implemented — runs in the **same** session pod, capped (`maxBackgroundRuns`, default 5); dedicated background pool was not shipped |
@@ -65,7 +65,7 @@ Last audited: **2026-08-24**, against the in-tree sandbox matrix, gRPC proto,
 
 | KIP | Title | Status |
 |-----|-------|--------|
-| [KIP-4](kip-4-sandbox-mcp-skill.md) | Sandbox MCP skill (`k8e sandbox-mcp`) | **Outdated** — superseded by [KIP-8](kip-8-skill-cli-replace-mcp.md). `pkg/sandboxmcp/` does not exist. |
+| [KIP-4](kip-4-sandbox-mcp-skill.md) | Sandbox MCP skill (`k8e sandbox-mcp`) | **Outdated** — superseded by [KIP-8](kip-8-skill-cli-replace-mcp.md). The rebuilt `pkg/sandboxmcp/` uses the new HTTP protocol and API Key authentication. |
 | [KIP-5](kip-5-openclaw-sandbox-management.md) | OpenClaw via MCP | **Outdated** — depended on KIP-4 MCP. Agents consume the CLI + skill (KIP-8) or the dsh plugin (KIP-20). |
 
 Agent-facing repo conventions live under [`docs/agents/`](agents/). Those files (`domain.md`, `issue-tracker.md`, `triage-labels.md`) are skill conventions, not KIPs.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -34,7 +34,9 @@ How the engineering skills should consume this repo's domain documentation.
 └── sandboxd/                    # Runtime daemon (Zig)
 ```
 
-Do **not** treat KIP-4 / KIP-5 as current design: they are Outdated (MCP). There is no `docs/sandbox-mcp-quickstart.md` and no `pkg/sandboxmcp/`.
+Do **not** treat KIP-4 / KIP-5 as current design: their stdio/SSE MCP design is
+outdated. KIP-8 now defines the dual entry: CLI + skill for local coding and the
+rebuilt `pkg/sandboxmcp/` API Key HTTP adapter for remote clients.
 
 ## Key terms
 
@@ -43,7 +45,10 @@ When naming domain concepts (in issue titles, PRDs, refactors), use the terms as
 - **Sandbox** — an isolated execution environment (Kubernetes pod with a pluggable RuntimeClass: gVisor, Kata, Firecracker).
 - **Session** — a user-agent's live interaction with a sandbox, tracked via CRD (`SandboxSession`).
 - **Warm pool** — pre-booted sandbox pods that reduce session startup latency (`SandboxWarmPool` CRD).
-- **SKILL + CLI** — `k8e-sandbox-cli` commands; the shell-based bridge between AI agents and the sandbox orchestration layer (replaced MCP as of KIP-8).
+- **SKILL + CLI** — `k8e-sandbox-cli` commands for local coding and shell-based
+  agents.
+- **MCP HTTP adapter** — API Key authenticated remote entry, deployed behind
+  the K8E Cilium Gateway API at `/mcp`; it projects the same gRPC backend.
 - **Tenant ID** — the `tenantID` field used for cross-process session reuse via state files and `FindActiveSession()`.
 - **Orchestrator** — the gRPC-side logic that creates/destroys pods and manages sandbox lifecycle.
 - **E2B layer** — the embedded HTTP/Connect adapter (`pkg/sandbox/e2b`) that makes the official `e2b` SDK work against K8E (KIP-18).

--- a/docs/kip-8-skill-cli-replace-mcp.md
+++ b/docs/kip-8-skill-cli-replace-mcp.md
@@ -1,8 +1,86 @@
-# KIP-8: SKILL + CLI 替换 MCP 协议层
+# KIP-8: CLI + Skill 与 MCP 双入口
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @xiaods | 2026-08-24 | Implemented — `pkg/sandboxmcp/` is gone; the agent door is `k8e-sandbox-cli` + embedded SKILL.md. The command surface has grown past the original 9+1 list (snapshot, poll, log, events, ps, catalog, expose, allow-hosts, profiles, PTY-adjacent tools). |
+| @xiaods | 2026-09-08 | Revised design; MCP reimplementation pending |
+
+## 2026-09-08 修订：本地 CLI 与远程 MCP 并存
+
+本节替代下方历史版本中“删除 MCP、仅保留 CLI”的产品决策。2026-06-03 的 CLI 迁移已经实现；本次 MCP 重建尚未实现，不能据本文宣称远程入口已可用。保留历史正文用于解释迁移背景，不把旧命令示例、时延估计和会话设计当作当前规范。
+
+### 目标与架构
+
+面向本地编码、CI 和脚本保留 CLI + skill；面向远程、多客户端服务增加 MCP 2026-07-28 Streamable HTTP 入口。gRPC Gateway、sandboxd 和 Kubernetes 会话继续作为执行后端。
+
+```text
+本地编码 / CI       -> CLI + skill ------+
+远程 MCP 客户端     -> MCP HTTP adapter -+-> gRPC Gateway -> sandboxd
+自有宿主            -> 原生工具插件 ------+
+```
+
+MCP adapter 不启动 CLI 子进程，不调用依赖 cli.Context、stdout 或进程环境修改的 CLI handler。复用显式配置的 gRPC client；需要共享的语言包装、操作结果与会话初始化逻辑在独立接口中实现。连接池按后端及认证身份隔离。禁止在并发请求中调用 `ApplyResolvedConn` 修改全局环境。
+
+旧 MCP 进程退出时丢失默认会话属于旧实现的状态设计问题，不是 MCP 协议限制。CLI 每次启动进程并建立连接，常驻适配器有连接复用优势；两条路径的实际延迟和 token 成本以相同工作负载测量，不沿用历史 localhost 握手估计作为结论。
+
+### 协议范围
+
+以 MCP **2026-07-28** 为唯一首期协议版本，不默默接受旧版初始化请求。首期采用单一 `/mcp` POST 端点和普通 JSON 响应；请求级 SSE 按需求后续增加。
+
+- 实现 `server/discover`、`tools/list`、`tools/call`，只声明已经实现的能力。
+- 按规范处理每请求版本、client capabilities、HTTP metadata 与 body 一致性校验；发现方法遵循其专门规则。
+- 普通结果包含 `resultType: complete`；工具列表包含 `ttlMs`、`cacheScope`，稳定排序。鉴权相关的列表使用 private 缓存范围，不能跨身份共享。
+- 不建立协议级 session，不使用 `Mcp-Session-Id`，不实现旧 `initialize` 握手或 GET SSE 端点。沙箱 `session_id` 是业务 handle，生命周期独立于 HTTP 连接。
+- 不声明未实现的 subscriptions、resources、prompts、Tasks、MRTR 或 Skills 扩展。Tasks 后续可以适配现有后台任务，但必须完成扩展协商及持久化语义，不能只改结果字段。
+- JSON-RPC 参数错误、协议错误、认证失败与沙箱程序非零退出分别表达。程序失败保留结构化 `exit_code`，不误报成传输失败。
+
+首期工具覆盖：创建/查询/销毁沙箱、提交后台命令、轮询结果、读取/写入/列出文件。所有操作显式携带沙箱或运行 handle；不使用跨用户共享的 default session。长任务通过 `run_id + poll` 返回，PTY、快照和服务暴露保留现有 CLI/gRPC 路径，后续按客户端需求扩展。
+
+### 认证与所有权
+
+当前 gRPC mTLS interceptor 验证客户端身份与证书吊销；这不等于逐资源授权。公开 MCP 入口前必须建立并测试下列边界：
+
+1. 每个请求由服务端认证取得稳定 principal，不能信任模型传入的 tenant、owner、profile、endpoint 或任意转发身份头。
+2. 沙箱创建时持久化 owner；查询、执行、文件访问、销毁及运行轮询均校验 owner。运行 handle 必须可追溯到所属沙箱与 principal，列表也按 owner 过滤。
+3. 首期仅允许访问通过该入口创建且具有可信 owner 记录的沙箱；旧的无 owner 沙箱不自动授予远程用户。管理迁移需独立授权流程。
+4. 后端连接身份不能悄悄退化为全局管理员权限。若由受信服务账号访问 gRPC，则入口必须强制逐资源授权，后端仅允许受信入口访问，并明确这一部署信任边界。
+5. 对标准远程客户端的授权机制按官方 HTTP authorization 规范实现；现有 K8E API key/mTLS 是后端认证，不能冒充已经实现 MCP OAuth。任何受限认证试验必须标注兼容性，不能宣称通用客户端正式可用。
+6. 默认关闭入口；显式配置启用。远程传输使用 HTTPS，验证 Origin，限制请求大小和操作超时，不记录凭证。反向代理负责哪些校验必须在部署文档中明确。
+
+### 幂等、持久化与断线
+
+新版 Streamable HTTP 不支持 SSE Last-Event-ID 恢复。网络失败后新的 JSON-RPC request ID 不能保证业务去重。首期将创建沙箱和执行提交视为必须去重的操作：
+
+- 客户端提交稳定 `operation_id`，服务端按 `(principal, operation_kind, operation_id)` 原子登记请求摘要和状态；相同键不同参数明确拒绝。
+- 重复请求返回已有 handle 或可查询状态，不重复创建沙箱或执行命令。记录由多副本共享并持久化，不能仅保存在 MCP 进程内存。
+- 写入已受理记录后、后端执行完成前的进程崩溃必须有明确恢复策略。提交结果不确定时返回可查询的 unknown/reconciling 状态，禁止盲目重新执行；不宣称跨后端 exactly-once。
+- 业务 `session_id`、`run_id` 与 operation 记录一起跨 adapter 重启恢复。后台任务与其轮询 HTTP 请求取消分离；取消一次轮询不会杀死后台进程。
+- 如果后续增加前台 SSE，关闭响应流应按规范传递取消，但取消不是回滚。必须验证 context 到后端进程的实际传播，不能只关闭 HTTP socket。
+
+### 实施顺序与验收
+
+| 阶段 | 交付物 | 必须验证 |
+|------|--------|----------|
+| A | 显式客户端配置、principal/owner 与 operation 存储接口 | 并发身份不串扰；持久化原子性；相同键不同参数拒绝 |
+| B | MCP HTTP 协议处理与工具适配 | discover/list/call；版本/头部校验；错误与结构化结果；请求限制 |
+| C | 认证、CLI/服务启用配置与部署文档 | 匿名拒绝；伪造身份拒绝；不同用户不可读取、执行、销毁或轮询对方资源 |
+| D | 后端集成与恢复验证 | 跨副本重复提交只产生一次业务提交；崩溃后的不确定状态可查询；后台结果恢复 |
+| E | 回归、客户端互操作与性能比较 | CLI+skill 原行为保持；声明支持的 MCP 客户端实测；相同工作负载对比 |
+
+验收测试使用 fake backend 覆盖协议与拒绝路径、真实持久化接口覆盖竞争/重启；运行集群验收前不能把单元测试通过等同于生产就绪。部署启用、发布和生产变更不包含在代码实现授权内。
+
+### 依据
+
+- [MCP 2026-07-28 变更说明](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [Streamable HTTP](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)
+- [Tasks 扩展](https://modelcontextprotocol.io/extensions/tasks/overview)
+- [Skills Over MCP 工作组](https://modelcontextprotocol.io/community/working-groups/skills-over-mcp)：属于独立扩展工作，不作为首期前置依赖。
+- 本仓库：`proto/sandbox/v1/sandbox.proto`、`pkg/sandboxcli/commands.go`、`pkg/sandboxcli/profile.go`、`pkg/sandboxmatrix/grpc/server.go`、`plugins/deepseek-harness/packages/dsh-k8e-sandbox-client/src/grpc.ts`。
+
+---
+
+## 历史版本：2026-06-03 CLI 迁移（已实现）
+
+截至 2026-08-24，CLI 迁移已完成，命令集扩展至 snapshot、poll、log、events、ps、catalog、expose、allow-hosts、profiles 及 PTY 相关功能。该历史验收不代表本次重建的 MCP 已通过验收。
 
 ## Summary
 

--- a/docs/kip-8-skill-cli-replace-mcp.md
+++ b/docs/kip-8-skill-cli-replace-mcp.md
@@ -2,11 +2,11 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @xiaods | 2026-09-08 | MCP implementation in progress; cluster acceptance pending |
+| @xiaods | 2026-09-09 | MCP API Key entry implemented; Gateway API exposure in validation |
 
 ## 2026-09-08 修订：本地 CLI 与远程 MCP 并存
 
-本节替代下方历史版本中“删除 MCP、仅保留 CLI”的产品决策。2026-06-03 的 CLI 迁移已经实现；MCP 入口、API Key 认证、持久化去重和部署清单已进入代码，真实 K8E 集群重启与正式客户端互通仍待验收。首期仅支持 API Key；通用客户端自动登录与 OAuth 集成延后评估。保留历史正文用于解释迁移背景，不把旧命令示例、时延估计和会话设计当作当前规范。
+本节替代下方历史版本中“删除 MCP、仅保留 CLI”的产品决策。2026-06-03 的 CLI 迁移已经实现；MCP 入口、API Key 认证、持久化去重、独立客户端互通和真实 K8E 控制平面重启恢复已经进入代码与验收。MCP Pod 通过现有 Cilium Gateway API 的 HTTPS 监听器自动暴露 `/mcp`，完整公网证书和 DNS 验收仍由部署环境完成。首期仅支持 API Key；通用客户端自动登录与 OAuth 集成延后评估。
 
 ### 目标与架构
 
@@ -14,7 +14,7 @@
 
 ```text
 本地编码 / CI       -> CLI + skill ------+
-远程 MCP 客户端     -> MCP HTTP adapter -+-> gRPC Gateway -> sandboxd
+远程 MCP 客户端 -> API Gateway HTTPS -> MCP HTTP adapter -+-> gRPC Gateway -> sandboxd
 自有宿主            -> 原生工具插件 ------+
 ```
 
@@ -44,7 +44,7 @@ MCP adapter 不启动 CLI 子进程，不调用依赖 cli.Context、stdout 或�
 3. 首期仅允许访问通过该入口创建且具有可信 owner 记录的沙箱；旧的无 owner 沙箱不自动授予远程用户。管理迁移需独立授权流程。
 4. 后端连接身份不能悄悄退化为全局管理员权限。若由受信服务账号访问 gRPC，则入口必须强制逐资源授权，后端仅允许受信入口访问，并明确这一部署信任边界。
 5. 首期仅支持能设置 Authorization 请求头的客户端；不声明 OAuth 自动登录兼容性，不提供 issuer、introspection 或 OAuth 资源发现。每次请求重新读取 API Key Secret；过期、撤销和模糊身份拒绝，存储故障返回 503。owner 由 Secret UID、记录名和 created_at 派生，轮换保留记录名和 created_at，重建记录应使用新 created_at；旧版无创建时间记录不得复用名称给其他用户。
-6. 默认关闭入口；显式配置启用。远程传输使用 HTTPS，验证 Origin，限制请求大小和操作超时，不记录凭证。反向代理负责哪些校验必须在部署文档中明确。
+6. 默认关闭入口；显式配置启用。Cilium Gateway 终止公网 HTTPS，并通过受限的 HTTPRoute/ReferenceGrant 把 `/mcp` 转到 Pod 的集群内 HTTP 端口。MCP handler 继续验证 Origin、请求大小、协议元数据、API Key 和操作超时；网关不得剥离 Authorization 或 MCP headers。
 
 ### 幂等、持久化与断线
 
@@ -66,7 +66,7 @@ MCP adapter 不启动 CLI 子进程，不调用依赖 cli.Context、stdout 或�
 | D | 后端集成与恢复验证 | 跨副本重复提交只产生一次业务提交；崩溃后的不确定状态可查询；后台结果恢复 |
 | E | 回归、客户端互操作与性能比较 | CLI+skill 原行为保持；声明支持的 MCP 客户端实测；相同工作负载对比 |
 
-验收测试使用 fake backend 覆盖协议与拒绝路径，独立 Python 客户端覆盖 wire discovery/call/dedup/poll，Kubernetes 测试覆盖跨进程 ConfigMap CAS 和可选 K8E 容器重启。真实集群命令见 `manifests/sandbox-mcp/README.md`；在该验收完成前不能把单元测试通过等同于生产就绪。部署启用、发布和生产变更不包含在代码实现授权内。
+验收测试使用 fake backend 覆盖协议与拒绝路径，独立 Python 客户端覆盖 wire discovery/call/dedup/poll，Kubernetes 测试覆盖跨进程 ConfigMap CAS 和 K8E 容器重启。部署清单还校验 Gateway HTTPS listener、跨 namespace ReferenceGrant 和 HTTPRoute 的 Accepted/ResolvedRefs 状态。真实集群命令见 `manifests/sandbox-mcp/README.md`；公网 DNS 与证书的最终验收属于具体部署环境。
 
 ### 依据
 

--- a/docs/kip-8-skill-cli-replace-mcp.md
+++ b/docs/kip-8-skill-cli-replace-mcp.md
@@ -2,11 +2,11 @@
 
 | Author | Updated | Status |
 |--------|---------|--------|
-| @xiaods | 2026-09-08 | Revised design; MCP reimplementation pending |
+| @xiaods | 2026-09-08 | MCP implementation in progress; cluster acceptance pending |
 
 ## 2026-09-08 修订：本地 CLI 与远程 MCP 并存
 
-本节替代下方历史版本中“删除 MCP、仅保留 CLI”的产品决策。2026-06-03 的 CLI 迁移已经实现；本次 MCP 重建尚未实现，不能据本文宣称远程入口已可用。保留历史正文用于解释迁移背景，不把旧命令示例、时延估计和会话设计当作当前规范。
+本节替代下方历史版本中“删除 MCP、仅保留 CLI”的产品决策。2026-06-03 的 CLI 迁移已经实现；MCP 入口、API Key 认证、持久化去重和部署清单已进入代码，真实 K8E 集群重启与正式客户端互通仍待验收。首期仅支持 API Key；通用客户端自动登录与 OAuth 集成延后评估。保留历史正文用于解释迁移背景，不把旧命令示例、时延估计和会话设计当作当前规范。
 
 ### 目标与架构
 
@@ -37,13 +37,13 @@ MCP adapter 不启动 CLI 子进程，不调用依赖 cli.Context、stdout 或�
 
 ### 认证与所有权
 
-当前 gRPC mTLS interceptor 验证客户端身份与证书吊销；这不等于逐资源授权。公开 MCP 入口前必须建立并测试下列边界：
+当前 gRPC mTLS interceptor 验证客户端身份与证书吊销；MCP 入口通过 K8E 的 sandbox-matrix/sandbox-apikeys Secret 校验 Bearer API Key，并复用 keys.json 格式和有效期逻辑。公开 MCP 入口前必须建立并测试下列边界：
 
 1. 每个请求由服务端认证取得稳定 principal，不能信任模型传入的 tenant、owner、profile、endpoint 或任意转发身份头。
 2. 沙箱创建时持久化 owner；查询、执行、文件访问、销毁及运行轮询均校验 owner。运行 handle 必须可追溯到所属沙箱与 principal，列表也按 owner 过滤。
 3. 首期仅允许访问通过该入口创建且具有可信 owner 记录的沙箱；旧的无 owner 沙箱不自动授予远程用户。管理迁移需独立授权流程。
 4. 后端连接身份不能悄悄退化为全局管理员权限。若由受信服务账号访问 gRPC，则入口必须强制逐资源授权，后端仅允许受信入口访问，并明确这一部署信任边界。
-5. 对标准远程客户端的授权机制按官方 HTTP authorization 规范实现；现有 K8E API key/mTLS 是后端认证，不能冒充已经实现 MCP OAuth。任何受限认证试验必须标注兼容性，不能宣称通用客户端正式可用。
+5. 首期仅支持能设置 Authorization 请求头的客户端；不声明 OAuth 自动登录兼容性，不提供 issuer、introspection 或 OAuth 资源发现。每次请求重新读取 API Key Secret；过期、撤销和模糊身份拒绝，存储故障返回 503。owner 由 Secret UID、记录名和 created_at 派生，轮换保留记录名和 created_at，重建记录应使用新 created_at；旧版无创建时间记录不得复用名称给其他用户。
 6. 默认关闭入口；显式配置启用。远程传输使用 HTTPS，验证 Origin，限制请求大小和操作超时，不记录凭证。反向代理负责哪些校验必须在部署文档中明确。
 
 ### 幂等、持久化与断线
@@ -66,7 +66,7 @@ MCP adapter 不启动 CLI 子进程，不调用依赖 cli.Context、stdout 或�
 | D | 后端集成与恢复验证 | 跨副本重复提交只产生一次业务提交；崩溃后的不确定状态可查询；后台结果恢复 |
 | E | 回归、客户端互操作与性能比较 | CLI+skill 原行为保持；声明支持的 MCP 客户端实测；相同工作负载对比 |
 
-验收测试使用 fake backend 覆盖协议与拒绝路径、真实持久化接口覆盖竞争/重启；运行集群验收前不能把单元测试通过等同于生产就绪。部署启用、发布和生产变更不包含在代码实现授权内。
+验收测试使用 fake backend 覆盖协议与拒绝路径，独立 Python 客户端覆盖 wire discovery/call/dedup/poll，Kubernetes 测试覆盖跨进程 ConfigMap CAS 和可选 K8E 容器重启。真实集群命令见 `manifests/sandbox-mcp/README.md`；在该验收完成前不能把单元测试通过等同于生产就绪。部署启用、发布和生产变更不包含在代码实现授权内。
 
 ### 依据
 

--- a/hack/init-sandbox-mcp.sh
+++ b/hack/init-sandbox-mcp.sh
@@ -23,7 +23,18 @@ needed. An existing sandbox-matrix/sandbox-e2b certificate is reused unless a
 new public certificate pair is supplied explicitly. The existing k8e API
 Gateway exposes https://HOST/mcp. Without --apply, validates local inputs only.
 The deployment uses k8e-mcp:local; import that image into K8E containerd first.
+
+Set MCP_PROBE_API_KEY (environment, never argv) to additionally prove the
+authenticated MCP path by calling server/discover and requiring HTTP 200.
 EOF
+}
+
+rollout_failure_diagnostics() {
+  echo "k8e-mcp did not become ready; collecting diagnostics:" >&2
+  kubectl "${kubectl_args[@]}" -n k8e-mcp get pods -o wide >&2 || true
+  kubectl "${kubectl_args[@]}" -n k8e-mcp describe deployment/k8e-mcp >&2 || true
+  kubectl "${kubectl_args[@]}" -n k8e-mcp logs deployment/k8e-mcp --all-containers --tail=40 >&2 || true
+  echo "check that --gateway-ca/--gateway-cert/--gateway-key are a valid, unexpired mTLS client pair for the sandbox gateway" >&2
 }
 
 while [[ $# -gt 0 ]]; do
@@ -92,7 +103,10 @@ fi
 kubectl "${kubectl_args[@]}" -n k8e-mcp create secret generic mcp-gateway-tls --from-file=ca.crt="$gateway_ca" --from-file=tls.crt="$gateway_cert" --from-file=tls.key="$gateway_key" --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply --server-side --field-manager=k8e-mcp-init -f -
 kubectl "${kubectl_args[@]}" apply -f "$repo_root/manifests/sandbox-mcp/deployment.yaml"
 kubectl "${kubectl_args[@]}" -n k8e-mcp rollout restart deployment/k8e-mcp
-kubectl "${kubectl_args[@]}" -n k8e-mcp rollout status deployment/k8e-mcp --timeout=120s
+if ! kubectl "${kubectl_args[@]}" -n k8e-mcp rollout status deployment/k8e-mcp --timeout=120s; then
+  rollout_failure_diagnostics
+  exit 1
+fi
 kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=condition=Programmed gateway/e2b --timeout=120s
 kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=jsonpath='{.status.listeners[?(@.name=="https")].conditions[?(@.type=="Programmed")].status}'=True gateway/e2b --timeout=120s
 kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=jsonpath='{.status.listeners[?(@.name=="https")].conditions[?(@.type=="ResolvedRefs")].status}'=True gateway/e2b --timeout=120s
@@ -122,4 +136,18 @@ if [[ -n "$hostname" && ( "$gateway_address" == *:* || "$gateway_address" =~ ^[0
 fi
 status="$(curl "${curl_args[@]}" "https://$endpoint_authority/mcp")"
 [[ "$status" == 405 ]] || { echo "MCP HTTPS probe expected 405, got $status" >&2; exit 1; }
+if [[ -n "${MCP_PROBE_API_KEY:-}" ]]; then
+  probe_body='{"jsonrpc":"2.0","id":"init-probe","method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}'
+  auth_status="$(curl "${curl_args[@]}" \
+    --request POST \
+    --header "Authorization: Bearer ${MCP_PROBE_API_KEY}" \
+    --header 'Content-Type: application/json' \
+    --header 'Accept: application/json, text/event-stream' \
+    --header 'MCP-Protocol-Version: 2026-07-28' \
+    --header 'Mcp-Method: server/discover' \
+    --data "$probe_body" \
+    "https://$endpoint_authority/mcp")"
+  [[ "$auth_status" == 200 ]] || { echo "authenticated MCP probe expected 200, got $auth_status" >&2; exit 1; }
+  echo "Authenticated MCP probe passed (server/discover returned 200)."
+fi
 echo "MCP endpoint: https://$endpoint_authority/mcp"

--- a/hack/init-sandbox-mcp.sh
+++ b/hack/init-sandbox-mcp.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+kubeconfig=""
+public_cert=""
+public_key=""
+gateway_ca=""
+gateway_cert=""
+gateway_key=""
+apply=false
+
+usage() {
+  cat <<'EOF'
+Usage: bash hack/init-sandbox-mcp.sh --kubeconfig FILE \
+  --public-cert FILE --public-key FILE \
+  --gateway-ca FILE --gateway-cert FILE --gateway-key FILE [--apply]
+
+Uses existing K8E keys from sandbox-matrix/sandbox-apikeys. No OAuth server is
+needed. Without --apply, validates local inputs only. The deployment uses
+k8e-mcp:local; import that image into K8E containerd before deployment.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) apply=true; shift; continue ;;
+    -h|--help) usage; exit 0 ;;
+  esac
+  [[ $# -ge 2 && "$2" != --* ]] || { echo "missing option value: $1" >&2; exit 2; }
+  case "$1" in
+    --kubeconfig) kubeconfig="$2" ;;
+    --public-cert) public_cert="$2" ;;
+    --public-key) public_key="$2" ;;
+    --gateway-ca) gateway_ca="$2" ;;
+    --gateway-cert) gateway_cert="$2" ;;
+    --gateway-key) gateway_key="$2" ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+  shift 2
+done
+
+for file in "$kubeconfig" "$public_cert" "$public_key" "$gateway_ca" "$gateway_cert" "$gateway_key"; do
+  [[ -n "$file" && -r "$file" && -s "$file" ]] || { echo "required nonempty readable file: $file" >&2; exit 2; }
+done
+command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 2; }
+
+if [[ "$apply" != true ]]; then
+  echo "API Key mode; namespace=k8e-mcp; credentials=sandbox-matrix/sandbox-apikeys"
+  echo "Local inputs checked. Add --apply to initialize Kubernetes."
+  exit 0
+fi
+
+kubectl_args=(--kubeconfig "$kubeconfig")
+kubectl "${kubectl_args[@]}" -n sandbox-matrix get secret sandbox-apikeys -o name >/dev/null
+kubectl "${kubectl_args[@]}" create namespace k8e-mcp --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply -f -
+kubectl "${kubectl_args[@]}" -n k8e-mcp create secret tls mcp-public-tls --cert="$public_cert" --key="$public_key" --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply --server-side --field-manager=k8e-mcp-init -f -
+kubectl "${kubectl_args[@]}" -n k8e-mcp create secret generic mcp-gateway-tls --from-file=ca.crt="$gateway_ca" --from-file=tls.crt="$gateway_cert" --from-file=tls.key="$gateway_key" --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply --server-side --field-manager=k8e-mcp-init -f -
+kubectl "${kubectl_args[@]}" apply -f "$repo_root/manifests/sandbox-mcp/deployment.yaml"
+kubectl "${kubectl_args[@]}" -n k8e-mcp rollout restart deployment/k8e-mcp
+kubectl "${kubectl_args[@]}" -n k8e-mcp rollout status deployment/k8e-mcp --timeout=120s

--- a/hack/init-sandbox-mcp.sh
+++ b/hack/init-sandbox-mcp.sh
@@ -8,17 +8,21 @@ public_key=""
 gateway_ca=""
 gateway_cert=""
 gateway_key=""
+hostname=""
 apply=false
 
 usage() {
   cat <<'EOF'
 Usage: bash hack/init-sandbox-mcp.sh --kubeconfig FILE \
-  --public-cert FILE --public-key FILE \
-  --gateway-ca FILE --gateway-cert FILE --gateway-key FILE [--apply]
+  --gateway-ca FILE --gateway-cert FILE --gateway-key FILE \
+  [--public-cert FILE --public-key FILE] \
+  [--hostname MCP_PUBLIC_HOST] [--apply]
 
 Uses existing K8E keys from sandbox-matrix/sandbox-apikeys. No OAuth server is
-needed. Without --apply, validates local inputs only. The deployment uses
-k8e-mcp:local; import that image into K8E containerd before deployment.
+needed. An existing sandbox-matrix/sandbox-e2b certificate is reused unless a
+new public certificate pair is supplied explicitly. The existing k8e API
+Gateway exposes https://HOST/mcp. Without --apply, validates local inputs only.
+The deployment uses k8e-mcp:local; import that image into K8E containerd first.
 EOF
 }
 
@@ -35,15 +39,39 @@ while [[ $# -gt 0 ]]; do
     --gateway-ca) gateway_ca="$2" ;;
     --gateway-cert) gateway_cert="$2" ;;
     --gateway-key) gateway_key="$2" ;;
+    --hostname) hostname="$2" ;;
     *) echo "unknown option: $1" >&2; exit 2 ;;
   esac
   shift 2
 done
 
-for file in "$kubeconfig" "$public_cert" "$public_key" "$gateway_ca" "$gateway_cert" "$gateway_key"; do
+for file in "$kubeconfig" "$gateway_ca" "$gateway_cert" "$gateway_key"; do
   [[ -n "$file" && -r "$file" && -s "$file" ]] || { echo "required nonempty readable file: $file" >&2; exit 2; }
 done
+if [[ -n "$public_cert" || -n "$public_key" ]]; then
+  [[ -n "$public_cert" && -n "$public_key" ]] || { echo "--public-cert and --public-key must be supplied together" >&2; exit 2; }
+  for file in "$public_cert" "$public_key"; do
+    [[ -r "$file" && -s "$file" ]] || { echo "required nonempty readable file: $file" >&2; exit 2; }
+  done
+fi
 command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 2; }
+command -v curl >/dev/null || { echo "curl is required" >&2; exit 2; }
+command -v openssl >/dev/null || { echo "openssl is required" >&2; exit 2; }
+if [[ -n "$hostname" ]]; then
+  valid_host=false
+  if [[ ${#hostname} -le 253 && "$hostname" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]]; then
+    valid_host=true
+  fi
+  if [[ "$hostname" == *.* && "$hostname" =~ ^[0-9.]+$ ]]; then
+    valid_host=true
+    IFS=. read -r -a octets <<<"$hostname"
+    [[ ${#octets[@]} -eq 4 ]] || valid_host=false
+    for octet in "${octets[@]}"; do
+      [[ "$octet" =~ ^[0-9]{1,3}$ && $((10#$octet)) -le 255 ]] || valid_host=false
+    done
+  fi
+  [[ "$valid_host" == true ]] || { echo "--hostname must be a DNS name or IPv4 address without scheme, port, path, or whitespace" >&2; exit 2; }
+fi
 
 if [[ "$apply" != true ]]; then
   echo "API Key mode; namespace=k8e-mcp; credentials=sandbox-matrix/sandbox-apikeys"
@@ -53,9 +81,45 @@ fi
 
 kubectl_args=(--kubeconfig "$kubeconfig")
 kubectl "${kubectl_args[@]}" -n sandbox-matrix get secret sandbox-apikeys -o name >/dev/null
+kubectl "${kubectl_args[@]}" -n sandbox-matrix get gateway e2b -o name >/dev/null
+if [[ -z "$public_cert" ]]; then
+  kubectl "${kubectl_args[@]}" -n sandbox-matrix get secret sandbox-e2b -o name >/dev/null
+fi
 kubectl "${kubectl_args[@]}" create namespace k8e-mcp --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply -f -
-kubectl "${kubectl_args[@]}" -n k8e-mcp create secret tls mcp-public-tls --cert="$public_cert" --key="$public_key" --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply --server-side --field-manager=k8e-mcp-init -f -
+if [[ -n "$public_cert" ]]; then
+  kubectl "${kubectl_args[@]}" -n sandbox-matrix create secret tls sandbox-e2b --cert="$public_cert" --key="$public_key" --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply --server-side --field-manager=k8e-mcp-init -f -
+fi
 kubectl "${kubectl_args[@]}" -n k8e-mcp create secret generic mcp-gateway-tls --from-file=ca.crt="$gateway_ca" --from-file=tls.crt="$gateway_cert" --from-file=tls.key="$gateway_key" --dry-run=client -o yaml | kubectl "${kubectl_args[@]}" apply --server-side --field-manager=k8e-mcp-init -f -
 kubectl "${kubectl_args[@]}" apply -f "$repo_root/manifests/sandbox-mcp/deployment.yaml"
 kubectl "${kubectl_args[@]}" -n k8e-mcp rollout restart deployment/k8e-mcp
 kubectl "${kubectl_args[@]}" -n k8e-mcp rollout status deployment/k8e-mcp --timeout=120s
+kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=condition=Programmed gateway/e2b --timeout=120s
+kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=jsonpath='{.status.listeners[?(@.name=="https")].conditions[?(@.type=="Programmed")].status}'=True gateway/e2b --timeout=120s
+kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=jsonpath='{.status.listeners[?(@.name=="https")].conditions[?(@.type=="ResolvedRefs")].status}'=True gateway/e2b --timeout=120s
+kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=jsonpath='{.status.parents[0].conditions[?(@.type=="Accepted")].status}'=True httproute/k8e-mcp --timeout=120s
+kubectl "${kubectl_args[@]}" -n sandbox-matrix wait --for=jsonpath='{.status.parents[0].conditions[?(@.type=="ResolvedRefs")].status}'=True httproute/k8e-mcp --timeout=120s
+
+gateway_address="$(kubectl "${kubectl_args[@]}" -n sandbox-matrix get gateway e2b -o jsonpath='{.status.addresses[0].value}')"
+endpoint_host="${hostname:-$gateway_address}"
+[[ -n "$endpoint_host" ]] || { echo "k8e API Gateway has no advertised address" >&2; exit 1; }
+endpoint_authority="$endpoint_host"
+if [[ "$endpoint_authority" == *:* ]]; then
+  endpoint_authority="[$endpoint_authority]"
+fi
+
+endpoint_cert="$public_cert"
+if [[ -z "$endpoint_cert" ]]; then
+  endpoint_cert="$(mktemp)"
+  trap 'rm -f "$endpoint_cert"' EXIT
+  kubectl "${kubectl_args[@]}" -n sandbox-matrix get secret sandbox-e2b -o jsonpath='{.data.tls\.crt}' | openssl base64 -d -A >"$endpoint_cert"
+  [[ -s "$endpoint_cert" ]] || { echo "sandbox-matrix/sandbox-e2b has no tls.crt" >&2; exit 1; }
+fi
+curl_args=(--silent --show-error --output /dev/null --write-out '%{http_code}' --cacert "$endpoint_cert" --connect-timeout 10 --max-time 20)
+if [[ -n "$hostname" && ( "$gateway_address" == *:* || "$gateway_address" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ) ]]; then
+  resolve_address="$gateway_address"
+  [[ "$resolve_address" == *:* ]] && resolve_address="[$resolve_address]"
+  curl_args+=(--resolve "$hostname:443:$resolve_address")
+fi
+status="$(curl "${curl_args[@]}" "https://$endpoint_authority/mcp")"
+[[ "$status" == 405 ]] || { echo "MCP HTTPS probe expected 405, got $status" >&2; exit 1; }
+echo "MCP endpoint: https://$endpoint_authority/mcp"

--- a/hack/test-sandbox-mcp-orbstack.sh
+++ b/hack/test-sandbox-mcp-orbstack.sh
@@ -10,7 +10,7 @@ image="${K8E_MCP_IMAGE:-golang:1.25.9}"
 command -v docker >/dev/null || { echo "docker is required" >&2; exit 2; }
 command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 2; }
 command -v go >/dev/null || { echo "go is required" >&2; exit 2; }
-test -x "$binary" || { echo "missing executable K8E_BINARY=$binary" >&2; exit 2; }
+[[ -x "$binary" ]] || { echo "missing executable K8E_BINARY=$binary" >&2; exit 2; }
 cd "$(dirname "$0")/.."
 mkdir -p "$data_dir"
 
@@ -30,7 +30,7 @@ docker run -d --name "$container_name" \
 
 kubeconfig="$data_dir/client-kubeconfig.yaml"
 for _ in $(seq 1 120); do
-  if test -s "$data_dir/kubeconfig.yaml"; then
+  if [[ -s "$data_dir/kubeconfig.yaml" ]]; then
     cp "$data_dir/kubeconfig.yaml" "$kubeconfig"
     kubectl --kubeconfig "$kubeconfig" config set-cluster default --server="https://127.0.0.1:${host_port}" >/dev/null
     if kubectl --kubeconfig "$kubeconfig" --request-timeout=2s get --raw=/readyz >/dev/null 2>&1; then
@@ -39,7 +39,7 @@ for _ in $(seq 1 120); do
   fi
   sleep 1
 done
-test -s "$kubeconfig" || { echo "K8E did not write kubeconfig" >&2; exit 1; }
+[[ -s "$kubeconfig" ]] || { echo "K8E did not write kubeconfig" >&2; exit 1; }
 kubectl --kubeconfig "$kubeconfig" --request-timeout=10s get --raw=/readyz >/dev/null
 
 MCP_TEST_KUBECONFIG="$kubeconfig" \

--- a/hack/test-sandbox-mcp-orbstack.sh
+++ b/hack/test-sandbox-mcp-orbstack.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container_name="${K8E_MCP_CONTAINER:-k8e-mcp-recovery-init}"
+host_port="${K8E_MCP_API_PORT:-16444}"
+data_dir="${K8E_MCP_DATA_DIR:-/tmp/k8e-mcp-cluster-init}"
+binary="${K8E_BINARY:-/tmp/k8e-mcp-server}"
+image="${K8E_MCP_IMAGE:-golang:1.25.9}"
+
+command -v docker >/dev/null || { echo "docker is required" >&2; exit 2; }
+command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 2; }
+command -v go >/dev/null || { echo "go is required" >&2; exit 2; }
+test -x "$binary" || { echo "missing executable K8E_BINARY=$binary" >&2; exit 2; }
+cd "$(dirname "$0")/.."
+mkdir -p "$data_dir"
+
+docker run -d --name "$container_name" \
+  -p "127.0.0.1:${host_port}:6443" \
+  -v "$data_dir:/test" \
+  -v "$binary:/usr/local/bin/k8e:ro" \
+  "$image" \
+  k8e server --cluster-init \
+    --data-dir /test/data \
+    --write-kubeconfig /test/kubeconfig.yaml \
+    --https-listen-port 6443 \
+    --tls-san 127.0.0.1 \
+    --disable-agent --disable-sandbox-matrix --disable-e2b \
+    --disable-cilium --disable-cloud-controller \
+    --egress-selector-mode disabled >/dev/null
+
+kubeconfig="$data_dir/client-kubeconfig.yaml"
+for _ in $(seq 1 120); do
+  if test -s "$data_dir/kubeconfig.yaml"; then
+    cp "$data_dir/kubeconfig.yaml" "$kubeconfig"
+    kubectl --kubeconfig "$kubeconfig" config set-cluster default --server="https://127.0.0.1:${host_port}" >/dev/null
+    if kubectl --kubeconfig "$kubeconfig" --request-timeout=2s get --raw=/readyz >/dev/null 2>&1; then
+      break
+    fi
+  fi
+  sleep 1
+done
+test -s "$kubeconfig" || { echo "K8E did not write kubeconfig" >&2; exit 1; }
+kubectl --kubeconfig "$kubeconfig" --request-timeout=10s get --raw=/readyz >/dev/null
+
+MCP_TEST_KUBECONFIG="$kubeconfig" \
+MCP_TEST_RESTART_CONTAINER="$container_name" \
+go test -race ./pkg/sandboxmcp -run '^TestKubernetesRestartRecovery$' -v -count=1
+
+echo "OrbStack K8E cluster-init recovery test passed: $container_name"

--- a/manifests/sandbox-mcp/Dockerfile
+++ b/manifests/sandbox-mcp/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.25.9 AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/k8e-sandbox-cli ./cmd/sandboxcli
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /out/k8e-sandbox-cli /usr/local/bin/k8e-sandbox-cli
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/k8e-sandbox-cli", "mcp-serve"]

--- a/manifests/sandbox-mcp/Dockerfile
+++ b/manifests/sandbox-mcp/Dockerfile
@@ -3,8 +3,8 @@ WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /out/k8e-sandbox-cli ./cmd/sandboxcli
 
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /out/k8e-sandbox-cli /usr/local/bin/k8e-sandbox-cli
 USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/k8e-sandbox-cli", "mcp-serve"]

--- a/manifests/sandbox-mcp/README.md
+++ b/manifests/sandbox-mcp/README.md
@@ -23,6 +23,9 @@ automatically available there):
 docker build -f manifests/sandbox-mcp/Dockerfile -t k8e-mcp:local .
 ```
 
+The runtime image is a non-root `scratch` image containing the static CLI and
+the CA bundle required for gateway TLS verification.
+
 For a registry deployment, replace the image with your published immutable digest.
 Initialize using operator-provisioned public TLS and authorized gateway mTLS files:
 

--- a/manifests/sandbox-mcp/README.md
+++ b/manifests/sandbox-mcp/README.md
@@ -61,6 +61,36 @@ second creates a temporary namespace and verifies real ConfigMap CAS and recover
 in separate processes. On a dedicated local K8E container, additionally set
 `MCP_TEST_RESTART_CONTAINER` to restart that control plane between phases.
 
+For an OrbStack-hosted K8E control plane, use the repository helper. It starts
+K8E with `--cluster-init` (required for the managed embedded datastore), waits
+for `/readyz`, then runs the restart recovery test against the generated
+kubeconfig:
+
+```sh
+K8E_BINARY=/tmp/k8e-mcp-server hack/test-sandbox-mcp-orbstack.sh
+```
+
+The helper leaves its container and data available for inspection and refuses
+to replace an existing container. Choose another `K8E_MCP_CONTAINER`,
+`K8E_MCP_DATA_DIR` and `K8E_MCP_API_PORT` for an independent run.
+
+Validated on OrbStack Linux on 2026-09-08: the native K8E control plane
+started with `--cluster-init`, passed `/readyz`, and passed the race-enabled
+`TestKubernetesRestartRecovery` including an actual container restart (8.731s).
+Completed results, unknown-outcome non-replay and ownership survived restart.
+The race-enabled `TestGatewayWithKubernetesMock` also passed inside Linux
+(1.082s); it exercises production gRPC handlers with Kubernetes and sandboxd
+fixtures, without gateway mTLS or real workload pods:
+
+```sh
+go test -race -tags mcp_integration ./pkg/sandboxmcp -run '^TestGatewayWithKubernetesMock$' -v -count=1
+```
+
+This validates Kubernetes API persistence and restart recovery with the sandbox
+backend simulated by the test. It does not claim real gVisor pod execution or
+public gateway TLS acceptance; those require an agent-enabled K8E deployment
+and imported gateway certificates.
+
 For deployed gateway acceptance, set `MCP_TEST_API_KEY` in the environment, then:
 
 ```sh

--- a/manifests/sandbox-mcp/README.md
+++ b/manifests/sandbox-mcp/README.md
@@ -1,0 +1,76 @@
+# Deploy MCP with K8E API keys
+
+K8E server supplies the Kubernetes cluster and sandbox gRPC gateway. MCP runs as
+an independent HTTPS deployment. No OAuth issuer, introspection service, resource
+configuration or OAuth client secret is required.
+
+Create a named key using the existing K8E server command:
+
+```sh
+k8e sandbox-apikey create my-agent
+```
+
+Use the bare `key` from its output, not the `e2b_key` variant. Keep it private.
+Existing unexpired keys in `sandbox-matrix/sandbox-apikeys` also work. Each client
+should have its own named record; names/created_at determine the stable identity.
+Preserve created_at when rotating credentials. Do not reuse legacy key names for
+new users. Changing the Secret UID requires explicit ownership migration.
+
+Build and import the image into K8E containerd (OrbStack Docker images are not
+automatically available there):
+
+```sh
+docker build -f manifests/sandbox-mcp/Dockerfile -t k8e-mcp:local .
+```
+
+For a registry deployment, replace the image with your published immutable digest.
+Initialize using operator-provisioned public TLS and authorized gateway mTLS files:
+
+```sh
+bash hack/init-sandbox-mcp.sh --kubeconfig /path/to/k8e.yaml \
+  --public-cert /path/to/public/tls.crt --public-key /path/to/public/tls.key \
+  --gateway-ca /path/to/gateway/ca.crt \
+  --gateway-cert /path/to/gateway/tls.crt --gateway-key /path/to/gateway/tls.key \
+  --apply
+```
+
+Without `--apply`, only local input checks run. With it, the script verifies the
+existing API key Secret, creates the namespace and TLS Secrets, applies the
+deployment, and rolls it to reload certificates. It does not print credential
+contents or copy API keys. No ConfigMap for authentication settings is needed.
+
+RBAC grants ConfigMap get/create/update in `k8e-mcp`, plus get on exactly
+`sandbox-matrix/sandbox-apikeys`. The deployment uses two replicas and a disruption
+budget, non-root execution and a read-only filesystem. `/healthz` reports process
+health only. Route HTTPS through your existing gateway to Service `k8e-mcp:443`;
+this manifest does not create public DNS, certificates or ingress automatically.
+
+Clients connect to `https://YOUR_HOST/mcp` with `Authorization: Bearer <key>`.
+Configuration syntax varies by client. Only clients supporting custom headers
+and MCP 2026-07-28 are in scope; automatic OAuth login is deferred.
+
+## Verification
+
+```sh
+MCP_RUN_INTEROP=1 go test -race ./pkg/sandboxmcp -run TestIndependentPythonClient -v
+MCP_TEST_KUBECONFIG=/path/to/k8e.yaml go test -race ./pkg/sandboxmcp -run TestKubernetesRestartRecovery -v
+```
+
+The first uses an independent Python HTTPS client with a simulated backend. The
+second creates a temporary namespace and verifies real ConfigMap CAS and recovery
+in separate processes. On a dedicated local K8E container, additionally set
+`MCP_TEST_RESTART_CONTAINER` to restart that control plane between phases.
+
+For deployed gateway acceptance, set `MCP_TEST_API_KEY` in the environment, then:
+
+```sh
+python3 tests/mcp/client_smoke.py --endpoint https://YOUR_HOST/mcp --state /tmp/mcp-smoke.json --phase before
+kubectl --kubeconfig /path/to/k8e.yaml -n k8e-mcp rollout restart deployment/k8e-mcp
+kubectl --kubeconfig /path/to/k8e.yaml -n k8e-mcp rollout status deployment/k8e-mcp
+python3 tests/mcp/client_smoke.py --endpoint https://YOUR_HOST/mcp --state /tmp/mcp-smoke.json --phase after
+python3 tests/mcp/client_smoke.py --endpoint https://YOUR_HOST/mcp --state /tmp/mcp-smoke.json --phase cleanup
+```
+
+Use `--ca /path/to/ca.pem` for a private CA. Retain state records and uncertain
+operation IDs; do not delete them to force retries. Establish state backup and
+quota policies before production use. Full gateway acceptance is still pending.

--- a/manifests/sandbox-mcp/README.md
+++ b/manifests/sandbox-mcp/README.md
@@ -23,12 +23,36 @@ automatically available there):
 
 ```sh
 docker build -f manifests/sandbox-mcp/Dockerfile -t k8e-mcp:local .
+# Import into the target node's containerd (k8s.io namespace):
+docker save k8e-mcp:local | docker exec -i <k8e-node-container> ctr -n k8s.io images import -
 ```
 
 The runtime image is a non-root `scratch` image containing the static CLI and
-the CA bundle required for gateway TLS verification.
+the CA bundle required for gateway TLS verification. Importing an image only
+matters on an agent-enabled K8E (the control-plane-only OrbStack recovery
+harness has no node, so MCP pods cannot schedule there).
 
 For a registry deployment, replace the image with your published immutable digest.
+
+### Gateway mTLS material
+
+`mcp-serve` reaches the sandbox gRPC gateway with a client certificate signed by
+the sandbox CA. Bootstrap that pair from the same API key you created above —
+the CLI performs the gateway `Login` handshake and writes `ca.crt`, `client.crt`
+and `client.key`:
+
+```sh
+K8E_SANDBOX_CERT_DIR=/path/to/gateway-mtls \
+  k8e-sandbox-cli connect --endpoint <gateway-host>:50051 \
+  --apikey <bare-key-from-sandbox-apikey-create> --skip-skill
+```
+
+Pass those three files as `--gateway-ca/--gateway-cert/--gateway-key` below. The
+files are the adapter's own backend identity: keep them out of source control and
+treat the directory as secret material. The gateway only verifies that a client
+certificate is present and unrevoked; the MCP adapter, not gRPC mTLS, is what
+enforces per-resource ownership (see `pkg/sandboxmcp/README.md`).
+
 Initialize using authorized gateway mTLS files. If the API Gateway already has
 the `sandbox-matrix/sandbox-e2b` TLS Secret, omit `--public-cert` and
 `--public-key`. Supply both options to install or deliberately update that
@@ -48,12 +72,17 @@ existing API key Secret and the K8E API Gateway, creates the namespace, verifies
 or explicitly updates `sandbox-matrix/sandbox-e2b`, creates the gateway mTLS
 client Secret, applies the Deployment, Service, ReferenceGrant and HTTPRoute,
 then waits for the Deployment, the Gateway's `https` listener and route
-references. Before reporting success, it makes an unauthenticated HTTPS request
-to `/mcp` and requires the MCP backend's expected `405` response; this verifies
-certificate trust and hostname matching without exposing an API Key. It does
-not print credential contents or copy API keys. No ConfigMap for authentication
-settings is needed. A replacement shared certificate must cover every hostname
-already served by the HTTPS listener.
+references. If the Deployment does not become ready it prints pod status,
+the deployment description and recent logs, then exits non-zero. Before
+reporting success, it makes an unauthenticated HTTPS request to `/mcp` and
+requires the MCP backend's expected `405` response; this verifies certificate
+trust and hostname matching without exposing an API Key. Export
+`MCP_PROBE_API_KEY` (environment, never argv) to additionally call
+`server/discover` with `Authorization: Bearer` and require `200`, which proves
+the full authenticated path end to end. It does not print credential contents or
+copy API keys. No ConfigMap for authentication settings is needed. A replacement
+shared certificate must cover every hostname already served by the HTTPS
+listener.
 
 The script prints the final client URL. `--hostname` should match the public
 certificate and DNS record. When omitted, the script uses the first address from
@@ -63,7 +92,9 @@ contains that IP.
 RBAC grants ConfigMap get/create/update in `k8e-mcp`, plus get on exactly
 `sandbox-matrix/sandbox-apikeys`. The deployment uses two replicas and a disruption
 budget, non-root execution and a read-only filesystem. `/healthz` reports process
-health only. The HTTPRoute lives in `sandbox-matrix` so it can attach to the
+health only; `/readyz` additionally verifies the ConfigMap state store and the
+sandbox gateway, so a replica that cannot serve tool calls leaves Service
+endpoints instead of accepting traffic. The HTTPRoute lives in `sandbox-matrix` so it can attach to the
 Gateway's namespace-local HTTPS listener. A narrow ReferenceGrant in `k8e-mcp`
 allows only that HTTPRoute kind and namespace to reference Service `k8e-mcp`.
 Authorization headers and MCP metadata pass through unchanged. Public DNS still

--- a/manifests/sandbox-mcp/README.md
+++ b/manifests/sandbox-mcp/README.md
@@ -1,8 +1,10 @@
 # Deploy MCP with K8E API keys
 
-K8E server supplies the Kubernetes cluster and sandbox gRPC gateway. MCP runs as
-an independent HTTPS deployment. No OAuth issuer, introspection service, resource
-configuration or OAuth client secret is required.
+K8E server supplies the Kubernetes cluster, sandbox gRPC gateway and Cilium
+Gateway API entry. MCP runs as an independent deployment. The existing
+`sandbox-matrix/e2b` Gateway terminates public TLS and routes `/mcp` to the
+MCP Service over cluster-internal HTTP. No OAuth issuer, introspection service,
+resource configuration or OAuth client secret is required.
 
 Create a named key using the existing K8E server command:
 
@@ -27,28 +29,48 @@ The runtime image is a non-root `scratch` image containing the static CLI and
 the CA bundle required for gateway TLS verification.
 
 For a registry deployment, replace the image with your published immutable digest.
-Initialize using operator-provisioned public TLS and authorized gateway mTLS files:
+Initialize using authorized gateway mTLS files. If the API Gateway already has
+the `sandbox-matrix/sandbox-e2b` TLS Secret, omit `--public-cert` and
+`--public-key`. Supply both options to install or deliberately update that
+shared Gateway certificate:
 
 ```sh
 bash hack/init-sandbox-mcp.sh --kubeconfig /path/to/k8e.yaml \
-  --public-cert /path/to/public/tls.crt --public-key /path/to/public/tls.key \
   --gateway-ca /path/to/gateway/ca.crt \
   --gateway-cert /path/to/gateway/tls.crt --gateway-key /path/to/gateway/tls.key \
+  --public-cert /path/to/public/tls.crt --public-key /path/to/public/tls.key \
+  --hostname mcp.example.com \
   --apply
 ```
 
 Without `--apply`, only local input checks run. With it, the script verifies the
-existing API key Secret, creates the namespace and TLS Secrets, applies the
-deployment, and rolls it to reload certificates. It does not print credential
-contents or copy API keys. No ConfigMap for authentication settings is needed.
+existing API key Secret and the K8E API Gateway, creates the namespace, verifies
+or explicitly updates `sandbox-matrix/sandbox-e2b`, creates the gateway mTLS
+client Secret, applies the Deployment, Service, ReferenceGrant and HTTPRoute,
+then waits for the Deployment, the Gateway's `https` listener and route
+references. Before reporting success, it makes an unauthenticated HTTPS request
+to `/mcp` and requires the MCP backend's expected `405` response; this verifies
+certificate trust and hostname matching without exposing an API Key. It does
+not print credential contents or copy API keys. No ConfigMap for authentication
+settings is needed. A replacement shared certificate must cover every hostname
+already served by the HTTPS listener.
+
+The script prints the final client URL. `--hostname` should match the public
+certificate and DNS record. When omitted, the script uses the first address from
+`Gateway/e2b.status.addresses`; this works directly when the certificate
+contains that IP.
 
 RBAC grants ConfigMap get/create/update in `k8e-mcp`, plus get on exactly
 `sandbox-matrix/sandbox-apikeys`. The deployment uses two replicas and a disruption
 budget, non-root execution and a read-only filesystem. `/healthz` reports process
-health only. Route HTTPS through your existing gateway to Service `k8e-mcp:443`;
-this manifest does not create public DNS, certificates or ingress automatically.
+health only. The HTTPRoute lives in `sandbox-matrix` so it can attach to the
+Gateway's namespace-local HTTPS listener. A narrow ReferenceGrant in `k8e-mcp`
+allows only that HTTPRoute kind and namespace to reference Service `k8e-mcp`.
+Authorization headers and MCP metadata pass through unchanged. Public DNS still
+points to the Gateway address and remains operator-managed.
 
-Clients connect to `https://YOUR_HOST/mcp` with `Authorization: Bearer <key>`.
+Clients connect to the printed `https://YOUR_HOST/mcp` URL with
+`Authorization: Bearer <key>`.
 Configuration syntax varies by client. Only clients supporting custom headers
 and MCP 2026-07-28 are in scope; automatic OAuth login is deferred.
 
@@ -90,9 +112,9 @@ go test -race -tags mcp_integration ./pkg/sandboxmcp -run '^TestGatewayWithKuber
 ```
 
 This validates Kubernetes API persistence and restart recovery with the sandbox
-backend simulated by the test. It does not claim real gVisor pod execution or
-public gateway TLS acceptance; those require an agent-enabled K8E deployment
-and imported gateway certificates.
+backend simulated by the test. Public gateway acceptance additionally requires
+a running Cilium Gateway controller, a DNS name or reachable Gateway address,
+and a certificate valid for that client-visible host.
 
 For deployed gateway acceptance, set `MCP_TEST_API_KEY` in the environment, then:
 

--- a/manifests/sandbox-mcp/deployment.yaml
+++ b/manifests/sandbox-mcp/deployment.yaml
@@ -1,0 +1,165 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8e-mcp
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8e-mcp
+  namespace: k8e-mcp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcp-state
+  namespace: k8e-mcp
+rules:
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, create, update]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-state
+  namespace: k8e-mcp
+subjects:
+  - kind: ServiceAccount
+    name: k8e-mcp
+    namespace: k8e-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-state
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcp-api-key-reader
+  namespace: sandbox-matrix
+rules:
+  - apiGroups: [""]
+    resources: [secrets]
+    resourceNames: [sandbox-apikeys]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-api-key-reader
+  namespace: sandbox-matrix
+subjects:
+  - kind: ServiceAccount
+    name: k8e-mcp
+    namespace: k8e-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-api-key-reader
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8e-mcp
+  namespace: k8e-mcp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: k8e-mcp
+  template:
+    metadata:
+      labels:
+        app: k8e-mcp
+    spec:
+      serviceAccountName: k8e-mcp
+      terminationGracePeriodSeconds: 45
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mcp
+          image: k8e-mcp:local
+          imagePullPolicy: IfNotPresent
+          command: [/usr/local/bin/k8e-sandbox-cli]
+          args:
+            - mcp-serve
+            - --listen=:8443
+            - --tls-cert=/credentials/public/tls.crt
+            - --tls-key=/credentials/public/tls.key
+            - --gateway=sandbox-grpc-gateway.sandbox-matrix.svc:50051
+            - --gateway-ca=/credentials/gateway/ca.crt
+            - --gateway-cert=/credentials/gateway/tls.crt
+            - --gateway-key=/credentials/gateway/tls.key
+            - --state-namespace=k8e-mcp
+          ports:
+            - name: https
+              containerPort: 8443
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          startupProbe:
+            tcpSocket:
+              port: https
+            failureThreshold: 30
+            periodSeconds: 2
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: https
+              path: /healthz
+          livenessProbe:
+            tcpSocket:
+              port: https
+          volumeMounts:
+            - name: public-tls
+              mountPath: /credentials/public
+              readOnly: true
+            - name: gateway-tls
+              mountPath: /credentials/gateway
+              readOnly: true
+      volumes:
+        - name: public-tls
+          secret:
+            secretName: mcp-public-tls
+        - name: gateway-tls
+          secret:
+            secretName: mcp-gateway-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8e-mcp
+  namespace: k8e-mcp
+spec:
+  selector:
+    app: k8e-mcp
+  ports:
+    - name: https
+      port: 443
+      targetPort: https
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: k8e-mcp
+  namespace: k8e-mcp
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: k8e-mcp

--- a/manifests/sandbox-mcp/deployment.yaml
+++ b/manifests/sandbox-mcp/deployment.yaml
@@ -94,6 +94,8 @@ spec:
             - --gateway-ca=/credentials/gateway/ca.crt
             - --gateway-cert=/credentials/gateway/tls.crt
             - --gateway-key=/credentials/gateway/tls.key
+            - --api-key-namespace=sandbox-matrix
+            - --api-key-secret=sandbox-apikeys
             - --state-namespace=k8e-mcp
           ports:
             - name: http
@@ -119,7 +121,10 @@ spec:
             httpGet:
               scheme: HTTP
               port: http
-              path: /healthz
+              path: /readyz
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
             tcpSocket:
               port: http

--- a/manifests/sandbox-mcp/deployment.yaml
+++ b/manifests/sandbox-mcp/deployment.yaml
@@ -89,17 +89,15 @@ spec:
           command: [/usr/local/bin/k8e-sandbox-cli]
           args:
             - mcp-serve
-            - --listen=:8443
-            - --tls-cert=/credentials/public/tls.crt
-            - --tls-key=/credentials/public/tls.key
+            - --listen=:8080
             - --gateway=sandbox-grpc-gateway.sandbox-matrix.svc:50051
             - --gateway-ca=/credentials/gateway/ca.crt
             - --gateway-cert=/credentials/gateway/tls.crt
             - --gateway-key=/credentials/gateway/tls.key
             - --state-namespace=k8e-mcp
           ports:
-            - name: https
-              containerPort: 8443
+            - name: http
+              containerPort: 8080
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -114,28 +112,22 @@ spec:
               memory: 512Mi
           startupProbe:
             tcpSocket:
-              port: https
+              port: http
             failureThreshold: 30
             periodSeconds: 2
           readinessProbe:
             httpGet:
-              scheme: HTTPS
-              port: https
+              scheme: HTTP
+              port: http
               path: /healthz
           livenessProbe:
             tcpSocket:
-              port: https
+              port: http
           volumeMounts:
-            - name: public-tls
-              mountPath: /credentials/public
-              readOnly: true
             - name: gateway-tls
               mountPath: /credentials/gateway
               readOnly: true
       volumes:
-        - name: public-tls
-          secret:
-            secretName: mcp-public-tls
         - name: gateway-tls
           secret:
             secretName: mcp-gateway-tls
@@ -145,13 +137,56 @@ kind: Service
 metadata:
   name: k8e-mcp
   namespace: k8e-mcp
+  labels:
+    app.kubernetes.io/managed-by: k8e
 spec:
   selector:
     app: k8e-mcp
   ports:
-    - name: https
-      port: 443
-      targetPort: https
+    - name: http
+      port: 80
+      targetPort: http
+      appProtocol: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ReferenceGrant
+metadata:
+  name: sandbox-gateway-to-mcp
+  namespace: k8e-mcp
+  labels:
+    app.kubernetes.io/managed-by: k8e
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: sandbox-matrix
+  to:
+    - group: ""
+      kind: Service
+      name: k8e-mcp
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: k8e-mcp
+  namespace: sandbox-matrix
+  labels:
+    app.kubernetes.io/managed-by: k8e
+spec:
+  parentRefs:
+    - name: e2b
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mcp
+      timeouts:
+        request: 45s
+      backendRefs:
+        - name: k8e-mcp
+          namespace: k8e-mcp
+          port: 80
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/manifests/sandbox-mcp/deployment.yaml
+++ b/manifests/sandbox-mcp/deployment.yaml
@@ -109,6 +109,7 @@ spec:
             requests:
               cpu: 100m
               memory: 128Mi
+              ephemeral-storage: 16Mi
             limits:
               cpu: "1"
               memory: 512Mi

--- a/pkg/sandboxmcp/README.md
+++ b/pkg/sandboxmcp/README.md
@@ -33,6 +33,8 @@ Deployment and initialization: `manifests/sandbox-mcp/README.md`.
 go test -race ./pkg/sandboxmcp ./cmd/sandboxcli -count=1
 MCP_RUN_INTEROP=1 go test ./pkg/sandboxmcp -run TestIndependentPythonClient -v
 MCP_TEST_KUBECONFIG=/path/to/k8e.yaml go test ./pkg/sandboxmcp -run TestKubernetesRestartRecovery -v
+# OrbStack: native K8E control plane with managed embedded etcd.
+K8E_BINARY=/tmp/k8e-mcp-server hack/test-sandbox-mcp-orbstack.sh
 ```
 
 The Python test uses real HTTPS with a simulated backend. The cluster test uses

--- a/pkg/sandboxmcp/README.md
+++ b/pkg/sandboxmcp/README.md
@@ -1,34 +1,40 @@
-# MCP HTTP boundary (in progress)
+# MCP API Key entry
 
-`Server` implements the KIP-8 MCP 2026-07-28 request/response boundary without
-opening a listener. It is not yet a deployable MCP service.
+The standalone sandbox CLI exposes `mcp-serve`, an HTTPS MCP 2026-07-28 entry
+using K8E API keys. Configure a client with the `/mcp` URL and
+`Authorization: Bearer <bare K8E key>`. OAuth login/discovery is not implemented;
+clients must support explicit Authorization headers and this protocol version.
 
-Implemented: authenticated principal injection, exact Origin allowlist, request
-size/deadline limits, per-request protocol metadata, header/body checks,
-`server/discover`, stable `tools/list`, and `tools/call`. Only tools capability is
-advertised. JSON responses include the modern result discriminator. There is no
-protocol session, initialization handshake, SSE stream, or Tasks extension.
+The service reads `sandbox-matrix/sandbox-apikeys` on every authenticated request,
+using the shared K8E `keys.json` codec and expiry checks. Revocation applies to
+subsequent requests; already admitted work is not cancelled. Kubernetes failures
+fail closed with 503, and invalid credentials receive 401. Duplicate keys assigned
+to multiple identities are rejected. API keys are never sent to the gateway.
 
-Tool callbacks own argument validation and resource authorization. Authentication
-is a required dependency; the fake authentication in tests is not a supported
-production credential mechanism. No generic CLI handler or process environment
-is used. Schemas currently describe object arguments; actual K8E schemas and
-validation must be implemented together with the backend adapter. Do not attach
-schemas with `x-mcp-header` until custom parameter header validation is supported.
+Ownership uses Secret UID, record name and created_at, not the credential bytes.
+Rotate a v2 record by changing its key while preserving name and created_at.
+Deleting/recreating a record with a new created_at gives it a new identity.
+Legacy records lack created_at: never recycle their names for different users.
+Recreating the entire Secret changes its UID and requires deliberate ownership
+migration. No automatic adoption of previous OAuth-owned or legacy sessions occurs.
 
-Next implementation slice:
+The nine tools validate ownership for sessions/runs and persist atomic operation
+admission in ConfigMaps. Lost replies and uncertain completion writes remain
+unknown and never trigger automatic resubmission. State records must be retained;
+there is no automatic GC or unknown-outcome reconciler.
 
-1. Add the principal/owner and durable operation store, including concurrent
-   admission and unknown-result recovery tests.
-2. Add concrete K8E tool schemas and a gRPC backend; enforce ownership on every
-   handle, including background run polling.
-3. Add standards-compatible HTTP authorization, HTTPS deployment configuration,
-   and an opt-in listener. No anonymous or shared-default-session mode.
-4. Validate real-client interoperability and restart/cross-replica behavior before
-   marking the revised KIP implemented. CLI behavior remains unchanged.
+Only discover/list/call are advertised; there are no protocol sessions, initialize
+handshake, SSE streams or Tasks extensions. Browser CORS preflight is not supported.
+The `/healthz` endpoint reports process health, not gateway or Kubernetes readiness.
 
-Validation:
+Deployment and initialization: `manifests/sandbox-mcp/README.md`.
 
 ```sh
-go test -race ./pkg/sandboxmcp -count=1
+go test -race ./pkg/sandboxmcp ./cmd/sandboxcli -count=1
+MCP_RUN_INTEROP=1 go test ./pkg/sandboxmcp -run TestIndependentPythonClient -v
+MCP_TEST_KUBECONFIG=/path/to/k8e.yaml go test ./pkg/sandboxmcp -run TestKubernetesRestartRecovery -v
 ```
+
+The Python test uses real HTTPS with a simulated backend. The cluster test uses
+a real Kubernetes API with a simulated backend; full sandbox end-to-end and
+official client interoperability remain separate acceptance work.

--- a/pkg/sandboxmcp/README.md
+++ b/pkg/sandboxmcp/README.md
@@ -1,0 +1,34 @@
+# MCP HTTP boundary (in progress)
+
+`Server` implements the KIP-8 MCP 2026-07-28 request/response boundary without
+opening a listener. It is not yet a deployable MCP service.
+
+Implemented: authenticated principal injection, exact Origin allowlist, request
+size/deadline limits, per-request protocol metadata, header/body checks,
+`server/discover`, stable `tools/list`, and `tools/call`. Only tools capability is
+advertised. JSON responses include the modern result discriminator. There is no
+protocol session, initialization handshake, SSE stream, or Tasks extension.
+
+Tool callbacks own argument validation and resource authorization. Authentication
+is a required dependency; the fake authentication in tests is not a supported
+production credential mechanism. No generic CLI handler or process environment
+is used. Schemas currently describe object arguments; actual K8E schemas and
+validation must be implemented together with the backend adapter. Do not attach
+schemas with `x-mcp-header` until custom parameter header validation is supported.
+
+Next implementation slice:
+
+1. Add the principal/owner and durable operation store, including concurrent
+   admission and unknown-result recovery tests.
+2. Add concrete K8E tool schemas and a gRPC backend; enforce ownership on every
+   handle, including background run polling.
+3. Add standards-compatible HTTP authorization, HTTPS deployment configuration,
+   and an opt-in listener. No anonymous or shared-default-session mode.
+4. Validate real-client interoperability and restart/cross-replica behavior before
+   marking the revised KIP implemented. CLI behavior remains unchanged.
+
+Validation:
+
+```sh
+go test -race ./pkg/sandboxmcp -count=1
+```

--- a/pkg/sandboxmcp/README.md
+++ b/pkg/sandboxmcp/README.md
@@ -25,7 +25,9 @@ there is no automatic GC or unknown-outcome reconciler.
 
 Only discover/list/call are advertised; there are no protocol sessions, initialize
 handshake, SSE streams or Tasks extensions. Browser CORS preflight is not supported.
-The `/healthz` endpoint reports process health, not gateway or Kubernetes readiness.
+The `/healthz` endpoint reports process health only; `/readyz` verifies the
+ConfigMap state store and the sandbox gateway connection and returns 503 while
+either is unavailable.
 
 Deployment and initialization: `manifests/sandbox-mcp/README.md`.
 

--- a/pkg/sandboxmcp/auth.go
+++ b/pkg/sandboxmcp/auth.go
@@ -26,12 +26,8 @@ func NewAPIKeyAuthenticator(secrets typedcore.SecretInterface, secretName string
 	}
 	return func(request *http.Request) (Principal, error) {
 		denied := &authenticationError{status: http.StatusUnauthorized, challenge: `Bearer realm="k8e-mcp"`}
-		headers := request.Header.Values("Authorization")
-		if len(headers) != 1 || request.URL.Query().Has("access_token") || request.URL.Query().Has("api_key") {
-			return Principal{}, denied
-		}
-		parts := strings.Fields(headers[0])
-		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || len(parts[1]) > 4096 {
+		key, ok := bearerAPIKey(request)
+		if !ok {
 			return Principal{}, denied
 		}
 		secret, err := secrets.Get(request.Context(), secretName, metav1.GetOptions{})
@@ -42,20 +38,37 @@ func NewAPIKeyAuthenticator(secrets typedcore.SecretInterface, secretName string
 		if err != nil {
 			return Principal{}, &authenticationError{status: http.StatusServiceUnavailable}
 		}
-		candidate := sha256.Sum256([]byte(parts[1]))
-		principal := Principal{}
-		matches := 0
-		for name, record := range records {
-			digest := sha256.Sum256([]byte(record.Key))
-			matched := subtle.ConstantTimeCompare(candidate[:], digest[:]) == 1
-			if matched && name != "" && record.Key != "" && !record.Expired(time.Now()) {
-				matches++
-				principal.ID = recordKey("apikey", string(secret.UID), name, record.CreatedAt.UTC().Format(time.RFC3339Nano))
-			}
-		}
-		if matches != 1 {
+		principal, ok := matchAPIKey(key, string(secret.UID), records, time.Now())
+		if !ok {
 			return Principal{}, denied
 		}
 		return principal, nil
 	}, nil
+}
+
+func bearerAPIKey(request *http.Request) (string, bool) {
+	headers := request.Header.Values("Authorization")
+	if len(headers) != 1 || request.URL.Query().Has("access_token") || request.URL.Query().Has("api_key") {
+		return "", false
+	}
+	parts := strings.Fields(headers[0])
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || len(parts[1]) > 4096 {
+		return "", false
+	}
+	return parts[1], true
+}
+
+func matchAPIKey(key, secretUID string, records map[string]apikey.Record, now time.Time) (Principal, bool) {
+	candidate := sha256.Sum256([]byte(key))
+	principal := Principal{}
+	matches := 0
+	for name, record := range records {
+		digest := sha256.Sum256([]byte(record.Key))
+		matched := subtle.ConstantTimeCompare(candidate[:], digest[:]) == 1
+		if matched && name != "" && record.Key != "" && !record.Expired(now) {
+			matches++
+			principal.ID = recordKey("apikey", secretUID, name, record.CreatedAt.UTC().Format(time.RFC3339Nano))
+		}
+	}
+	return principal, matches == 1
 }

--- a/pkg/sandboxmcp/auth.go
+++ b/pkg/sandboxmcp/auth.go
@@ -20,6 +20,7 @@ type authenticationError struct {
 
 func (err *authenticationError) Error() string { return "API key rejected" }
 
+// NewAPIKeyAuthenticator authenticates bearer keys against the named Kubernetes Secret.
 func NewAPIKeyAuthenticator(secrets typedcore.SecretInterface, secretName string) (Authenticate, error) {
 	if secrets == nil || secretName == "" {
 		return nil, errors.New("API key Secret client and name required")

--- a/pkg/sandboxmcp/auth.go
+++ b/pkg/sandboxmcp/auth.go
@@ -1,0 +1,61 @@
+package sandboxmcp
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/xiaods/k8e/pkg/sandbox/apikey"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type authenticationError struct {
+	status    int
+	challenge string
+}
+
+func (err *authenticationError) Error() string { return "API key rejected" }
+
+func NewAPIKeyAuthenticator(secrets typedcore.SecretInterface, secretName string) (Authenticate, error) {
+	if secrets == nil || secretName == "" {
+		return nil, errors.New("API key Secret client and name required")
+	}
+	return func(request *http.Request) (Principal, error) {
+		denied := &authenticationError{status: http.StatusUnauthorized, challenge: `Bearer realm="k8e-mcp"`}
+		headers := request.Header.Values("Authorization")
+		if len(headers) != 1 || request.URL.Query().Has("access_token") || request.URL.Query().Has("api_key") {
+			return Principal{}, denied
+		}
+		parts := strings.Fields(headers[0])
+		if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") || len(parts[1]) > 4096 {
+			return Principal{}, denied
+		}
+		secret, err := secrets.Get(request.Context(), secretName, metav1.GetOptions{})
+		if err != nil {
+			return Principal{}, &authenticationError{status: http.StatusServiceUnavailable}
+		}
+		records, err := apikey.Parse(secret.Data["keys.json"])
+		if err != nil {
+			return Principal{}, &authenticationError{status: http.StatusServiceUnavailable}
+		}
+		candidate := sha256.Sum256([]byte(parts[1]))
+		principal := Principal{}
+		matches := 0
+		for name, record := range records {
+			digest := sha256.Sum256([]byte(record.Key))
+			matched := subtle.ConstantTimeCompare(candidate[:], digest[:]) == 1
+			if matched && name != "" && record.Key != "" && !record.Expired(time.Now()) {
+				matches++
+				principal.ID = recordKey("apikey", string(secret.UID), name, record.CreatedAt.UTC().Format(time.RFC3339Nano))
+			}
+		}
+		if matches != 1 {
+			return Principal{}, denied
+		}
+		return principal, nil
+	}, nil
+}

--- a/pkg/sandboxmcp/auth_test.go
+++ b/pkg/sandboxmcp/auth_test.go
@@ -35,7 +35,7 @@ func TestAPIKeyLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	request := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	request := httptest.NewRequest(http.MethodPost, "/mcp", http.NoBody)
 	request.Header.Set("Authorization", "Bearer original")
 	first, err := authenticate(request)
 	if err != nil || first.ID == "" {
@@ -74,7 +74,7 @@ func TestAPIKeyHTTPFailures(t *testing.T) {
 	authenticate, _ := NewAPIKeyAuthenticator(fixture, "sandbox-apikeys")
 	server, _ := New(Config{Authenticate: authenticate})
 	for _, authorization := range []string{"", "Basic valid", "Bearer invalid"} {
-		request := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		request := httptest.NewRequest(http.MethodPost, "/mcp", http.NoBody)
 		request.Header.Set("Authorization", authorization)
 		response := httptest.NewRecorder()
 		server.ServeHTTP(response, request)
@@ -82,12 +82,12 @@ func TestAPIKeyHTTPFailures(t *testing.T) {
 			t.Fatal(response)
 		}
 	}
-	request := httptest.NewRequest(http.MethodPost, "/mcp?api_key=valid", nil)
+	request := httptest.NewRequest(http.MethodPost, "/mcp?api_key=valid", http.NoBody)
 	request.Header.Set("Authorization", "Bearer valid")
 	if _, err := authenticate(request); err == nil {
 		t.Fatal("query credential accepted")
 	}
-	request = httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	request = httptest.NewRequest(http.MethodPost, "/mcp", http.NoBody)
 	request.Header.Add("Authorization", "Bearer valid")
 	request.Header.Add("Authorization", "Bearer valid")
 	if _, err := authenticate(request); err == nil {

--- a/pkg/sandboxmcp/auth_test.go
+++ b/pkg/sandboxmcp/auth_test.go
@@ -1,0 +1,107 @@
+package sandboxmcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/xiaods/k8e/pkg/sandbox/apikey"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type secretFixture struct {
+	typedcore.SecretInterface
+	records map[string]apikey.Record
+	err     error
+}
+
+func (fixture *secretFixture) Get(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+	if fixture.err != nil {
+		return nil, fixture.err
+	}
+	data, err := apikey.Encode(fixture.records)
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{UID: "test-secret"}, Data: map[string][]byte{"keys.json": data}}, err
+}
+
+func TestAPIKeyLifecycle(t *testing.T) {
+	record := apikey.NewRecord("original", 30, false, time.Now())
+	fixture := &secretFixture{records: map[string]apikey.Record{"alice": record}}
+	authenticate, err := NewAPIKeyAuthenticator(fixture, "sandbox-apikeys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	request.Header.Set("Authorization", "Bearer original")
+	first, err := authenticate(request)
+	if err != nil || first.ID == "" {
+		t.Fatalf("authentication: %v", err)
+	}
+	record.Key = "rotated"
+	fixture.records["alice"] = record
+	if _, err := authenticate(request); err == nil {
+		t.Fatal("old key accepted")
+	}
+	request.Header.Set("Authorization", "Bearer rotated")
+	rotated, err := authenticate(request)
+	if err != nil || rotated != first {
+		t.Fatal("rotation lost principal")
+	}
+	record.CreatedAt = record.CreatedAt.Add(time.Second)
+	fixture.records["alice"] = record
+	recreated, err := authenticate(request)
+	if err != nil || recreated == first {
+		t.Fatal("recreated key inherited owner")
+	}
+	expired := time.Now().Add(-time.Second)
+	record.ExpiresAt = &expired
+	fixture.records["alice"] = record
+	if _, err := authenticate(request); err == nil {
+		t.Fatal("expired key accepted")
+	}
+	delete(fixture.records, "alice")
+	if _, err := authenticate(request); err == nil {
+		t.Fatal("revoked key accepted")
+	}
+}
+
+func TestAPIKeyHTTPFailures(t *testing.T) {
+	fixture := &secretFixture{records: map[string]apikey.Record{"alice": {Key: "valid"}}}
+	authenticate, _ := NewAPIKeyAuthenticator(fixture, "sandbox-apikeys")
+	server, _ := New(Config{Authenticate: authenticate})
+	for _, authorization := range []string{"", "Basic valid", "Bearer invalid"} {
+		request := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+		request.Header.Set("Authorization", authorization)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		if response.Code != 401 || response.Header().Get("WWW-Authenticate") != `Bearer realm="k8e-mcp"` {
+			t.Fatal(response)
+		}
+	}
+	request := httptest.NewRequest(http.MethodPost, "/mcp?api_key=valid", nil)
+	request.Header.Set("Authorization", "Bearer valid")
+	if _, err := authenticate(request); err == nil {
+		t.Fatal("query credential accepted")
+	}
+	request = httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	request.Header.Add("Authorization", "Bearer valid")
+	request.Header.Add("Authorization", "Bearer valid")
+	if _, err := authenticate(request); err == nil {
+		t.Fatal("duplicate auth accepted")
+	}
+	request.Header.Set("Authorization", "Bearer valid")
+	fixture.records["bob"] = apikey.Record{Key: "valid"}
+	if _, err := authenticate(request); err == nil {
+		t.Fatal("ambiguous identity accepted")
+	}
+	fixture.err = errors.New("private storage error")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != 503 {
+		t.Fatal(response)
+	}
+}

--- a/pkg/sandboxmcp/cluster_test.go
+++ b/pkg/sandboxmcp/cluster_test.go
@@ -25,10 +25,10 @@ func TestKubernetesRestartRecovery(t *testing.T) {
 	defer cancel()
 	phase := os.Getenv("MCP_TEST_PHASE")
 	if phase == "" {
-		runRecoveryCoordinator(t, ctx, core)
+		runRecoveryCoordinator(ctx, t, core)
 		return
 	}
-	runRecoveryChild(t, ctx, core, phase, os.Getenv("MCP_TEST_NAMESPACE"))
+	runRecoveryChild(t, core, phase, os.Getenv("MCP_TEST_NAMESPACE"))
 }
 
 func recoveryCoreClient(t *testing.T, configPath string) typedcore.CoreV1Interface {
@@ -45,17 +45,17 @@ func recoveryCoreClient(t *testing.T, configPath string) typedcore.CoreV1Interfa
 	return core
 }
 
-func runRecoveryCoordinator(t *testing.T, ctx context.Context, core typedcore.CoreV1Interface) {
+func runRecoveryCoordinator(ctx context.Context, t *testing.T, core typedcore.CoreV1Interface) {
 	t.Helper()
 	namespace, err := core.Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "mcp-recovery-test-"}}, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { deleteRecoveryNamespace(t, core, namespace.Name) })
-	verifyConfigMapCAS(t, ctx, core.ConfigMaps(namespace.Name))
-	runRecoveryProcess(t, ctx, "submit", namespace.Name)
-	restartRecoveryContainer(t, ctx, core, namespace.Name)
-	runRecoveryProcess(t, ctx, "recover", namespace.Name)
+	verifyConfigMapCAS(ctx, t, core.ConfigMaps(namespace.Name))
+	runRecoveryProcess(ctx, t, "submit", namespace.Name)
+	restartRecoveryContainer(ctx, t, core, namespace.Name)
+	runRecoveryProcess(ctx, t, "recover", namespace.Name)
 }
 
 func deleteRecoveryNamespace(t *testing.T, core typedcore.CoreV1Interface, namespace string) {
@@ -66,7 +66,7 @@ func deleteRecoveryNamespace(t *testing.T, core typedcore.CoreV1Interface, names
 	}
 }
 
-func verifyConfigMapCAS(t *testing.T, ctx context.Context, maps typedcore.ConfigMapInterface) {
+func verifyConfigMapCAS(ctx context.Context, t *testing.T, maps typedcore.ConfigMapInterface) {
 	t.Helper()
 	store, _ := NewKubernetesStore(maps)
 	record, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"})
@@ -87,7 +87,7 @@ func verifyConfigMapCAS(t *testing.T, ctx context.Context, maps typedcore.Config
 	}
 }
 
-func runRecoveryProcess(t *testing.T, ctx context.Context, phase, namespace string) {
+func runRecoveryProcess(ctx context.Context, t *testing.T, phase, namespace string) {
 	t.Helper()
 	process := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestKubernetesRestartRecovery$", "-test.v")
 	process.Env = append(os.Environ(), "MCP_TEST_PHASE="+phase, "MCP_TEST_NAMESPACE="+namespace)
@@ -98,7 +98,7 @@ func runRecoveryProcess(t *testing.T, ctx context.Context, phase, namespace stri
 	}
 }
 
-func restartRecoveryContainer(t *testing.T, ctx context.Context, core typedcore.CoreV1Interface, namespace string) {
+func restartRecoveryContainer(ctx context.Context, t *testing.T, core typedcore.CoreV1Interface, namespace string) {
 	t.Helper()
 	container := os.Getenv("MCP_TEST_RESTART_CONTAINER")
 	if container == "" {
@@ -121,7 +121,7 @@ func restartRecoveryContainer(t *testing.T, ctx context.Context, core typedcore.
 	}
 }
 
-func runRecoveryChild(t *testing.T, ctx context.Context, core typedcore.CoreV1Interface, phase, namespace string) {
+func runRecoveryChild(t *testing.T, core typedcore.CoreV1Interface, phase, namespace string) {
 	t.Helper()
 	if phase != "submit" && phase != "recover" {
 		t.Fatal("invalid test phase")
@@ -135,15 +135,15 @@ func runRecoveryChild(t *testing.T, ctx context.Context, core typedcore.CoreV1In
 	if err != nil {
 		t.Fatal(err)
 	}
-	sessionID := submitRecoveryOperations(t, ctx, service, backend)
+	sessionID := submitRecoveryOperations(t, service, backend)
 	if phase == "recover" {
-		assertRecoveredOperations(t, ctx, service, backend)
+		assertRecoveredOperations(t, service, backend)
 	} else if backend.creates != 1 || backend.execs != 2 || sessionID == "" {
 		t.Fatal("submission did not reach backend")
 	}
 }
 
-func submitRecoveryOperations(t *testing.T, ctx context.Context, service *Service, backend *testBackend) string {
+func submitRecoveryOperations(t *testing.T, service *Service, backend *testBackend) string {
 	t.Helper()
 	created, err := invoke(t, service, "alice", "sandbox_create", map[string]any{"operation_id": "create"})
 	if err != nil {
@@ -162,7 +162,7 @@ func submitRecoveryOperations(t *testing.T, ctx context.Context, service *Servic
 	return sessionID
 }
 
-func assertRecoveredOperations(t *testing.T, ctx context.Context, service *Service, backend *testBackend) {
+func assertRecoveredOperations(t *testing.T, service *Service, backend *testBackend) {
 	t.Helper()
 	if backend.creates != 0 || backend.execs != 0 {
 		t.Fatal("restart replayed a backend mutation")

--- a/pkg/sandboxmcp/cluster_test.go
+++ b/pkg/sandboxmcp/cluster_test.go
@@ -1,0 +1,132 @@
+package sandboxmcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestKubernetesRestartRecovery(t *testing.T) {
+	configPath := os.Getenv("MCP_TEST_KUBECONFIG")
+	if configPath == "" {
+		t.Skip("set MCP_TEST_KUBECONFIG to run against a real Kubernetes API")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Timeout = 10 * time.Second
+	core, err := typedcore.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	phase := os.Getenv("MCP_TEST_PHASE")
+	if phase == "" {
+		namespace, err := core.Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "mcp-recovery-test-"}}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			cleanup, done := context.WithTimeout(context.Background(), 15*time.Second)
+			defer done()
+			if err := core.Namespaces().Delete(cleanup, namespace.Name, metav1.DeleteOptions{}); err != nil {
+				t.Errorf("cleanup namespace %s: %v", namespace.Name, err)
+			}
+		}()
+		store, _ := NewKubernetesStore(core.ConfigMaps(namespace.Name))
+		record, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"}); !errors.Is(err, ErrRecordExists) {
+			t.Fatalf("atomic admission: %v", err)
+		}
+		updated := record
+		updated.State = "admitted"
+		if err := store.Update(ctx, "cas-probe", updated); err != nil {
+			t.Fatal(err)
+		}
+		record.State = "complete"
+		if err := store.Update(ctx, "cas-probe", record); !apierrors.IsConflict(err) {
+			t.Fatalf("stale update must conflict: %v", err)
+		}
+		for _, phase := range []string{"submit", "recover"} {
+			process := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestKubernetesRestartRecovery$", "-test.v")
+			process.Env = append(os.Environ(), "MCP_TEST_PHASE="+phase, "MCP_TEST_NAMESPACE="+namespace.Name)
+			output, err := process.CombinedOutput()
+			t.Logf("%s process: %s", phase, output)
+			if err != nil {
+				t.Fatalf("%s: %v", phase, err)
+			}
+			if phase == "submit" && os.Getenv("MCP_TEST_RESTART_CONTAINER") != "" {
+				restart := exec.CommandContext(ctx, "docker", "restart", os.Getenv("MCP_TEST_RESTART_CONTAINER"))
+				if output, err := restart.CombinedOutput(); err != nil {
+					t.Fatalf("restart K8E: %v: %s", err, output)
+				}
+				for {
+					if _, err := core.Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{}); err == nil {
+						break
+					}
+					select {
+					case <-ctx.Done():
+						t.Fatal("K8E API did not recover after restart")
+					case <-time.After(time.Second):
+					}
+				}
+				t.Log("K8E container restarted; persisted test namespace recovered")
+			}
+		}
+		return
+	}
+	if phase != "submit" && phase != "recover" {
+		t.Fatal("invalid test phase")
+	}
+	namespace := os.Getenv("MCP_TEST_NAMESPACE")
+	if namespace == "" {
+		t.Fatal("missing test namespace")
+	}
+	store, _ := NewKubernetesStore(core.ConfigMaps(namespace))
+	backend := &testBackend{}
+	service, err := NewService(backend, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := invoke(t, service, "alice", "sandbox_create", map[string]any{"operation_id": "create"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID := resultObject(t, created)["session_id"].(string)
+	result, err := invoke(t, service, "alice", "sandbox_exec", map[string]any{"session_id": sessionID, "operation_id": "completed", "command": "echo ok"})
+	if err != nil || resultObject(t, result)["run_id"] != "run-1" {
+		t.Fatalf("completed recovery: %v %v", result, err)
+	}
+	backend.lostReply = true
+	result, err = invoke(t, service, "alice", "sandbox_exec", map[string]any{"session_id": sessionID, "operation_id": "unknown", "command": "echo uncertain"})
+	if err != nil || resultObject(t, result)["status"] != "unknown" {
+		t.Fatalf("unknown recovery: %v %v", result, err)
+	}
+	if phase == "recover" {
+		if backend.creates != 0 || backend.execs != 0 {
+			t.Fatal("restart replayed a backend mutation")
+		}
+		if _, err := invoke(t, service, "bob", "sandbox_poll", map[string]any{"run_id": "run-1"}); err == nil {
+			t.Fatal("ownership lost on restart")
+		}
+		if _, err := invoke(t, service, "alice", "sandbox_poll", map[string]any{"run_id": "run-1"}); err != nil {
+			t.Fatal(err)
+		}
+	} else if backend.creates != 1 || backend.execs != 2 {
+		t.Fatal("submission did not reach backend")
+	}
+}

--- a/pkg/sandboxmcp/cluster_test.go
+++ b/pkg/sandboxmcp/cluster_test.go
@@ -20,6 +20,19 @@ func TestKubernetesRestartRecovery(t *testing.T) {
 	if configPath == "" {
 		t.Skip("set MCP_TEST_KUBECONFIG to run against a real Kubernetes API")
 	}
+	core := recoveryCoreClient(t, configPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	phase := os.Getenv("MCP_TEST_PHASE")
+	if phase == "" {
+		runRecoveryCoordinator(t, ctx, core)
+		return
+	}
+	runRecoveryChild(t, ctx, core, phase, os.Getenv("MCP_TEST_NAMESPACE"))
+}
+
+func recoveryCoreClient(t *testing.T, configPath string) typedcore.CoreV1Interface {
+	t.Helper()
 	config, err := clientcmd.BuildConfigFromFlags("", configPath)
 	if err != nil {
 		t.Fatal(err)
@@ -29,70 +42,90 @@ func TestKubernetesRestartRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel()
-	phase := os.Getenv("MCP_TEST_PHASE")
-	if phase == "" {
-		namespace, err := core.Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "mcp-recovery-test-"}}, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			cleanup, done := context.WithTimeout(context.Background(), 15*time.Second)
-			defer done()
-			if err := core.Namespaces().Delete(cleanup, namespace.Name, metav1.DeleteOptions{}); err != nil {
-				t.Errorf("cleanup namespace %s: %v", namespace.Name, err)
-			}
-		}()
-		store, _ := NewKubernetesStore(core.ConfigMaps(namespace.Name))
-		record, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"}); !errors.Is(err, ErrRecordExists) {
-			t.Fatalf("atomic admission: %v", err)
-		}
-		updated := record
-		updated.State = "admitted"
-		if err := store.Update(ctx, "cas-probe", updated); err != nil {
-			t.Fatal(err)
-		}
-		record.State = "complete"
-		if err := store.Update(ctx, "cas-probe", record); !apierrors.IsConflict(err) {
-			t.Fatalf("stale update must conflict: %v", err)
-		}
-		for _, phase := range []string{"submit", "recover"} {
-			process := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestKubernetesRestartRecovery$", "-test.v")
-			process.Env = append(os.Environ(), "MCP_TEST_PHASE="+phase, "MCP_TEST_NAMESPACE="+namespace.Name)
-			output, err := process.CombinedOutput()
-			t.Logf("%s process: %s", phase, output)
-			if err != nil {
-				t.Fatalf("%s: %v", phase, err)
-			}
-			if phase == "submit" && os.Getenv("MCP_TEST_RESTART_CONTAINER") != "" {
-				restart := exec.CommandContext(ctx, "docker", "restart", os.Getenv("MCP_TEST_RESTART_CONTAINER"))
-				if output, err := restart.CombinedOutput(); err != nil {
-					t.Fatalf("restart K8E: %v: %s", err, output)
-				}
-				for {
-					if _, err := core.Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{}); err == nil {
-						break
-					}
-					select {
-					case <-ctx.Done():
-						t.Fatal("K8E API did not recover after restart")
-					case <-time.After(time.Second):
-					}
-				}
-				t.Log("K8E container restarted; persisted test namespace recovered")
-			}
-		}
+	return core
+}
+
+func runRecoveryCoordinator(t *testing.T, ctx context.Context, core typedcore.CoreV1Interface) {
+	t.Helper()
+	namespace, err := core.Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "mcp-recovery-test-"}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { deleteRecoveryNamespace(t, core, namespace.Name) })
+	verifyConfigMapCAS(t, ctx, core.ConfigMaps(namespace.Name))
+	runRecoveryProcess(t, ctx, "submit", namespace.Name)
+	restartRecoveryContainer(t, ctx, core, namespace.Name)
+	runRecoveryProcess(t, ctx, "recover", namespace.Name)
+}
+
+func deleteRecoveryNamespace(t *testing.T, core typedcore.CoreV1Interface, namespace string) {
+	cleanup, done := context.WithTimeout(context.Background(), 15*time.Second)
+	defer done()
+	if err := core.Namespaces().Delete(cleanup, namespace, metav1.DeleteOptions{}); err != nil {
+		t.Errorf("cleanup namespace %s: %v", namespace, err)
+	}
+}
+
+func verifyConfigMapCAS(t *testing.T, ctx context.Context, maps typedcore.ConfigMapInterface) {
+	t.Helper()
+	store, _ := NewKubernetesStore(maps)
+	record, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create(ctx, "cas-probe", Record{Owner: "probe", State: "unknown"}); !errors.Is(err, ErrRecordExists) {
+		t.Fatalf("atomic admission: %v", err)
+	}
+	updated := record
+	updated.State = "admitted"
+	if err := store.Update(ctx, "cas-probe", updated); err != nil {
+		t.Fatal(err)
+	}
+	record.State = "complete"
+	if err := store.Update(ctx, "cas-probe", record); !apierrors.IsConflict(err) {
+		t.Fatalf("stale update must conflict: %v", err)
+	}
+}
+
+func runRecoveryProcess(t *testing.T, ctx context.Context, phase, namespace string) {
+	t.Helper()
+	process := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestKubernetesRestartRecovery$", "-test.v")
+	process.Env = append(os.Environ(), "MCP_TEST_PHASE="+phase, "MCP_TEST_NAMESPACE="+namespace)
+	output, err := process.CombinedOutput()
+	t.Logf("%s process: %s", phase, output)
+	if err != nil {
+		t.Fatalf("%s: %v", phase, err)
+	}
+}
+
+func restartRecoveryContainer(t *testing.T, ctx context.Context, core typedcore.CoreV1Interface, namespace string) {
+	t.Helper()
+	container := os.Getenv("MCP_TEST_RESTART_CONTAINER")
+	if container == "" {
 		return
 	}
+	restart := exec.CommandContext(ctx, "docker", "restart", container)
+	if output, err := restart.CombinedOutput(); err != nil {
+		t.Fatalf("restart K8E: %v: %s", err, output)
+	}
+	for {
+		if _, err := core.Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err == nil {
+			t.Log("K8E container restarted; persisted test namespace recovered")
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("K8E API did not recover after restart")
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func runRecoveryChild(t *testing.T, ctx context.Context, core typedcore.CoreV1Interface, phase, namespace string) {
+	t.Helper()
 	if phase != "submit" && phase != "recover" {
 		t.Fatal("invalid test phase")
 	}
-	namespace := os.Getenv("MCP_TEST_NAMESPACE")
 	if namespace == "" {
 		t.Fatal("missing test namespace")
 	}
@@ -102,6 +135,16 @@ func TestKubernetesRestartRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sessionID := submitRecoveryOperations(t, ctx, service, backend)
+	if phase == "recover" {
+		assertRecoveredOperations(t, ctx, service, backend)
+	} else if backend.creates != 1 || backend.execs != 2 || sessionID == "" {
+		t.Fatal("submission did not reach backend")
+	}
+}
+
+func submitRecoveryOperations(t *testing.T, ctx context.Context, service *Service, backend *testBackend) string {
+	t.Helper()
 	created, err := invoke(t, service, "alice", "sandbox_create", map[string]any{"operation_id": "create"})
 	if err != nil {
 		t.Fatal(err)
@@ -116,17 +159,18 @@ func TestKubernetesRestartRecovery(t *testing.T) {
 	if err != nil || resultObject(t, result)["status"] != "unknown" {
 		t.Fatalf("unknown recovery: %v %v", result, err)
 	}
-	if phase == "recover" {
-		if backend.creates != 0 || backend.execs != 0 {
-			t.Fatal("restart replayed a backend mutation")
-		}
-		if _, err := invoke(t, service, "bob", "sandbox_poll", map[string]any{"run_id": "run-1"}); err == nil {
-			t.Fatal("ownership lost on restart")
-		}
-		if _, err := invoke(t, service, "alice", "sandbox_poll", map[string]any{"run_id": "run-1"}); err != nil {
-			t.Fatal(err)
-		}
-	} else if backend.creates != 1 || backend.execs != 2 {
-		t.Fatal("submission did not reach backend")
+	return sessionID
+}
+
+func assertRecoveredOperations(t *testing.T, ctx context.Context, service *Service, backend *testBackend) {
+	t.Helper()
+	if backend.creates != 0 || backend.execs != 0 {
+		t.Fatal("restart replayed a backend mutation")
+	}
+	if _, err := invoke(t, service, "bob", "sandbox_poll", map[string]any{"run_id": "run-1"}); err == nil {
+		t.Fatal("ownership lost on restart")
+	}
+	if _, err := invoke(t, service, "alice", "sandbox_poll", map[string]any{"run_id": "run-1"}); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/sandboxmcp/command.go
+++ b/pkg/sandboxmcp/command.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Command returns the mcp-serve CLI command and its deployment-facing options.
 func Command() cli.Command {
 	flags := []cli.Flag{
 		cli.StringFlag{Name: "listen", Value: "127.0.0.1:8443", EnvVar: "K8E_MCP_LISTEN"},
@@ -117,7 +118,7 @@ func buildHandler(command *cli.Context, connection *grpc.ClientConn, core typedc
 func serveHTTP(command *cli.Context, handler http.Handler) error {
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", handler)
-	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusNoContent) })
+	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, _ *http.Request) { writer.WriteHeader(http.StatusNoContent) })
 	server := &http.Server{Addr: command.String("listen"), Handler: mux, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 45 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 32 * 1024, TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/pkg/sandboxmcp/command.go
+++ b/pkg/sandboxmcp/command.go
@@ -39,58 +39,82 @@ func Command() cli.Command {
 }
 
 func serveCommand(command *cli.Context) error {
+	if err := validateServeOptions(command); err != nil {
+		return err
+	}
+	connection, err := connectGateway(command)
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+	core, err := connectKubernetes(command)
+	if err != nil {
+		return err
+	}
+	handler, err := buildHandler(command, connection, core)
+	if err != nil {
+		return err
+	}
+	return serveHTTP(command, handler)
+}
+
+func validateServeOptions(command *cli.Context) error {
 	for _, name := range []string{"tls-cert", "tls-key", "api-key-namespace", "api-key-secret", "gateway", "gateway-ca", "gateway-cert", "gateway-key", "state-namespace"} {
 		if command.String(name) == "" {
 			return errors.New("required MCP option: --" + name)
 		}
 	}
+	return nil
+}
+
+func connectGateway(command *cli.Context) (*grpc.ClientConn, error) {
 	certificate, err := tls.LoadX509KeyPair(command.String("gateway-cert"), command.String("gateway-key"))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	rootPEM, err := os.ReadFile(command.String("gateway-ca"))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(rootPEM) {
-		return errors.New("gateway CA has no certificates")
+		return nil, errors.New("gateway CA has no certificates")
 	}
-	connection, err := grpc.NewClient(command.String("gateway"), grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots, Certificates: []tls.Certificate{certificate}})))
-	if err != nil {
-		return err
-	}
-	defer connection.Close()
+	return grpc.NewClient(command.String("gateway"), grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots, Certificates: []tls.Certificate{certificate}})))
+}
+
+func connectKubernetes(command *cli.Context) (typedcore.CoreV1Interface, error) {
 	var kubeConfig *rest.Config
+	var err error
 	if command.String("kubeconfig") == "" {
 		kubeConfig, err = rest.InClusterConfig()
 	} else {
 		kubeConfig, err = clientcmd.BuildConfigFromFlags("", command.String("kubeconfig"))
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	kubeConfig.Timeout = 10 * time.Second
-	core, err := typedcore.NewForConfig(kubeConfig)
-	if err != nil {
-		return err
-	}
+	return typedcore.NewForConfig(kubeConfig)
+}
+
+func buildHandler(command *cli.Context, connection *grpc.ClientConn, core typedcore.CoreV1Interface) (*Server, error) {
 	store, err := NewKubernetesStore(core.ConfigMaps(command.String("state-namespace")))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	service, err := NewService(pb.NewSandboxServiceClient(connection), store)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	authenticate, err := NewAPIKeyAuthenticator(core.Secrets(command.String("api-key-namespace")), command.String("api-key-secret"))
 	if err != nil {
-		return err
+		return nil, err
 	}
-	handler, err := New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice("allowed-origin")})
-	if err != nil {
-		return err
-	}
+	return New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice("allowed-origin")})
+}
+
+func serveHTTP(command *cli.Context, handler http.Handler) error {
 	mux := http.NewServeMux()
 	mux.Handle("/mcp", handler)
 	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusNoContent) })

--- a/pkg/sandboxmcp/command.go
+++ b/pkg/sandboxmcp/command.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -14,7 +15,9 @@ import (
 	"github.com/urfave/cli"
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,6 +60,41 @@ func serveCommand(command *cli.Context) error {
 		return err
 	}
 	return serveHTTP(command, handler)
+}
+
+// readiness verifies the two dependencies every tool call needs: the durable
+// ConfigMap state store and the sandbox gRPC gateway. It issues a cheap gateway
+// RPC so a socket that is open but unusable (TLS/credentials rejected) is not
+// reported ready. A pod that cannot reach its dependencies leaves Service
+// endpoints instead of accepting calls that would fail.
+func readiness(store RecordStore, client pb.SandboxServiceClient) func(context.Context) error {
+	return func(ctx context.Context) error {
+		if _, err := store.Get(ctx, "mcp-readiness-probe"); err != nil && !errors.Is(err, ErrRecordMissing) {
+			return fmt.Errorf("state store unavailable: %w", err)
+		}
+		// Any application-level error proves the gateway answered; only transport
+		// and credential failures mean the adapter cannot serve tool calls.
+		_, err := client.GetSession(ctx, &pb.GetSessionRequest{})
+		switch status.Code(err) {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled, codes.Unauthenticated:
+			return fmt.Errorf("sandbox gateway unavailable: %w", err)
+		}
+		return nil
+	}
+}
+
+// readinessHandler serves probe requests against the configured readiness
+// check. A handler without a check always reports ready.
+func readinessHandler(server *Server) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		ctx, cancel := context.WithTimeout(request.Context(), 5*time.Second)
+		defer cancel()
+		if err := server.Ready(ctx); err != nil {
+			http.Error(writer, "MCP dependencies unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}
 }
 
 func validateServeOptions(command *cli.Context) error {
@@ -115,23 +153,24 @@ func buildHandler(command *cli.Context, connection *grpc.ClientConn, core typedc
 	if err != nil {
 		return nil, err
 	}
-	return New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice("allowed-origin")})
+	return New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice("allowed-origin"), Ready: readiness(store, pb.NewSandboxServiceClient(connection))})
 }
 
-func serveHTTP(command *cli.Context, handler http.Handler) error {
+func serveHTTP(command *cli.Context, server *Server) error {
 	mux := http.NewServeMux()
-	mux.Handle("/mcp", handler)
+	mux.Handle("/mcp", server)
 	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, _ *http.Request) { writer.WriteHeader(http.StatusNoContent) })
-	server := &http.Server{Addr: command.String("listen"), Handler: mux, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 45 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 32 * 1024, TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+	mux.HandleFunc("/readyz", readinessHandler(server))
+	httpServer := &http.Server{Addr: command.String("listen"), Handler: mux, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 45 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 32 * 1024, TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	completed := make(chan error, 1)
 	go func() {
 		if command.String("tls-cert") == "" {
-			completed <- server.ListenAndServe()
+			completed <- httpServer.ListenAndServe()
 			return
 		}
-		completed <- server.ListenAndServeTLS(command.String("tls-cert"), command.String("tls-key"))
+		completed <- httpServer.ListenAndServeTLS(command.String("tls-cert"), command.String("tls-key"))
 	}()
 	select {
 	case err := <-completed:
@@ -142,8 +181,8 @@ func serveHTTP(command *cli.Context, handler http.Handler) error {
 	case <-ctx.Done():
 		shutdown, cancel := context.WithTimeout(context.Background(), 35*time.Second)
 		defer cancel()
-		if err := server.Shutdown(shutdown); err != nil {
-			_ = server.Close()
+		if err := httpServer.Shutdown(shutdown); err != nil {
+			_ = httpServer.Close()
 			return err
 		}
 		return nil

--- a/pkg/sandboxmcp/command.go
+++ b/pkg/sandboxmcp/command.go
@@ -36,7 +36,7 @@ func Command() cli.Command {
 		cli.StringFlag{Name: "state-namespace", EnvVar: "K8E_MCP_STATE_NAMESPACE"},
 		cli.StringFlag{Name: "kubeconfig", EnvVar: "KUBECONFIG"},
 	}
-	return cli.Command{Name: "mcp-serve", Usage: "Serve MCP over HTTPS using K8E API keys and an explicit mTLS sandbox gateway", Flags: flags, Action: serveCommand}
+	return cli.Command{Name: "mcp-serve", Usage: "Serve MCP using K8E API keys and an explicit mTLS sandbox gateway", Flags: flags, Action: serveCommand}
 }
 
 func serveCommand(command *cli.Context) error {
@@ -60,10 +60,13 @@ func serveCommand(command *cli.Context) error {
 }
 
 func validateServeOptions(command *cli.Context) error {
-	for _, name := range []string{"tls-cert", "tls-key", "api-key-namespace", "api-key-secret", "gateway", "gateway-ca", "gateway-cert", "gateway-key", "state-namespace"} {
+	for _, name := range []string{"api-key-namespace", "api-key-secret", "gateway", "gateway-ca", "gateway-cert", "gateway-key", "state-namespace"} {
 		if command.String(name) == "" {
 			return errors.New("required MCP option: --" + name)
 		}
+	}
+	if (command.String("tls-cert") == "") != (command.String("tls-key") == "") {
+		return errors.New("MCP TLS requires both --tls-cert and --tls-key")
 	}
 	return nil
 }
@@ -123,7 +126,13 @@ func serveHTTP(command *cli.Context, handler http.Handler) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	completed := make(chan error, 1)
-	go func() { completed <- server.ListenAndServeTLS(command.String("tls-cert"), command.String("tls-key")) }()
+	go func() {
+		if command.String("tls-cert") == "" {
+			completed <- server.ListenAndServe()
+			return
+		}
+		completed <- server.ListenAndServeTLS(command.String("tls-cert"), command.String("tls-key"))
+	}()
 	select {
 	case err := <-completed:
 		if errors.Is(err, http.ErrServerClosed) {

--- a/pkg/sandboxmcp/command.go
+++ b/pkg/sandboxmcp/command.go
@@ -23,21 +23,38 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Flag names are declared once and reused by the command definition and every
+// accessor, so a rename cannot leave a stale literal behind.
+const (
+	flagListen          = "listen"
+	flagAllowedOrigin   = "allowed-origin"
+	flagTLSCert         = "tls-cert"
+	flagTLSKey          = "tls-key"
+	flagAPIKeyNamespace = "api-key-namespace"
+	flagAPIKeySecret    = "api-key-secret"
+	flagGateway         = "gateway"
+	flagGatewayCA       = "gateway-ca"
+	flagGatewayCert     = "gateway-cert"
+	flagGatewayKey      = "gateway-key"
+	flagStateNamespace  = "state-namespace"
+	flagKubeconfig      = "kubeconfig"
+)
+
 // Command returns the mcp-serve CLI command and its deployment-facing options.
 func Command() cli.Command {
 	flags := []cli.Flag{
-		cli.StringFlag{Name: "listen", Value: "127.0.0.1:8443", EnvVar: "K8E_MCP_LISTEN"},
-		cli.StringSliceFlag{Name: "allowed-origin", EnvVar: "K8E_MCP_ALLOWED_ORIGINS"},
-		cli.StringFlag{Name: "tls-cert", EnvVar: "K8E_MCP_TLS_CERT"},
-		cli.StringFlag{Name: "tls-key", EnvVar: "K8E_MCP_TLS_KEY"},
-		cli.StringFlag{Name: "api-key-namespace", Value: "sandbox-matrix", EnvVar: "K8E_MCP_API_KEY_NAMESPACE"},
-		cli.StringFlag{Name: "api-key-secret", Value: "sandbox-apikeys", EnvVar: "K8E_MCP_API_KEY_SECRET"},
-		cli.StringFlag{Name: "gateway", EnvVar: "K8E_MCP_GATEWAY"},
-		cli.StringFlag{Name: "gateway-ca", EnvVar: "K8E_MCP_GATEWAY_CA"},
-		cli.StringFlag{Name: "gateway-cert", EnvVar: "K8E_MCP_GATEWAY_CERT"},
-		cli.StringFlag{Name: "gateway-key", EnvVar: "K8E_MCP_GATEWAY_KEY"},
-		cli.StringFlag{Name: "state-namespace", EnvVar: "K8E_MCP_STATE_NAMESPACE"},
-		cli.StringFlag{Name: "kubeconfig", EnvVar: "KUBECONFIG"},
+		cli.StringFlag{Name: flagListen, Value: "127.0.0.1:8443", EnvVar: "K8E_MCP_LISTEN"},
+		cli.StringSliceFlag{Name: flagAllowedOrigin, EnvVar: "K8E_MCP_ALLOWED_ORIGINS"},
+		cli.StringFlag{Name: flagTLSCert, EnvVar: "K8E_MCP_TLS_CERT"},
+		cli.StringFlag{Name: flagTLSKey, EnvVar: "K8E_MCP_TLS_KEY"},
+		cli.StringFlag{Name: flagAPIKeyNamespace, Value: "sandbox-matrix", EnvVar: "K8E_MCP_API_KEY_NAMESPACE"},
+		cli.StringFlag{Name: flagAPIKeySecret, Value: "sandbox-apikeys", EnvVar: "K8E_MCP_API_KEY_SECRET"},
+		cli.StringFlag{Name: flagGateway, EnvVar: "K8E_MCP_GATEWAY"},
+		cli.StringFlag{Name: flagGatewayCA, EnvVar: "K8E_MCP_GATEWAY_CA"},
+		cli.StringFlag{Name: flagGatewayCert, EnvVar: "K8E_MCP_GATEWAY_CERT"},
+		cli.StringFlag{Name: flagGatewayKey, EnvVar: "K8E_MCP_GATEWAY_KEY"},
+		cli.StringFlag{Name: flagStateNamespace, EnvVar: "K8E_MCP_STATE_NAMESPACE"},
+		cli.StringFlag{Name: flagKubeconfig, EnvVar: "KUBECONFIG"},
 	}
 	return cli.Command{Name: "mcp-serve", Usage: "Serve MCP using K8E API keys and an explicit mTLS sandbox gateway", Flags: flags, Action: serveCommand}
 }
@@ -98,23 +115,23 @@ func readinessHandler(server *Server) http.HandlerFunc {
 }
 
 func validateServeOptions(command *cli.Context) error {
-	for _, name := range []string{"api-key-namespace", "api-key-secret", "gateway", "gateway-ca", "gateway-cert", "gateway-key", "state-namespace"} {
+	for _, name := range []string{flagAPIKeyNamespace, flagAPIKeySecret, flagGateway, flagGatewayCA, flagGatewayCert, flagGatewayKey, flagStateNamespace} {
 		if command.String(name) == "" {
 			return errors.New("required MCP option: --" + name)
 		}
 	}
-	if (command.String("tls-cert") == "") != (command.String("tls-key") == "") {
-		return errors.New("MCP TLS requires both --tls-cert and --tls-key")
+	if (command.String(flagTLSCert) == "") != (command.String(flagTLSKey) == "") {
+		return errors.New("MCP TLS requires both --" + flagTLSCert + " and --" + flagTLSKey)
 	}
 	return nil
 }
 
 func connectGateway(command *cli.Context) (*grpc.ClientConn, error) {
-	certificate, err := tls.LoadX509KeyPair(command.String("gateway-cert"), command.String("gateway-key"))
+	certificate, err := tls.LoadX509KeyPair(command.String(flagGatewayCert), command.String(flagGatewayKey))
 	if err != nil {
 		return nil, err
 	}
-	rootPEM, err := os.ReadFile(command.String("gateway-ca"))
+	rootPEM, err := os.ReadFile(command.String(flagGatewayCA))
 	if err != nil {
 		return nil, err
 	}
@@ -122,16 +139,16 @@ func connectGateway(command *cli.Context) (*grpc.ClientConn, error) {
 	if !roots.AppendCertsFromPEM(rootPEM) {
 		return nil, errors.New("gateway CA has no certificates")
 	}
-	return grpc.NewClient(command.String("gateway"), grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots, Certificates: []tls.Certificate{certificate}})))
+	return grpc.NewClient(command.String(flagGateway), grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots, Certificates: []tls.Certificate{certificate}})))
 }
 
 func connectKubernetes(command *cli.Context) (typedcore.CoreV1Interface, error) {
 	var kubeConfig *rest.Config
 	var err error
-	if command.String("kubeconfig") == "" {
+	if command.String(flagKubeconfig) == "" {
 		kubeConfig, err = rest.InClusterConfig()
 	} else {
-		kubeConfig, err = clientcmd.BuildConfigFromFlags("", command.String("kubeconfig"))
+		kubeConfig, err = clientcmd.BuildConfigFromFlags("", command.String(flagKubeconfig))
 	}
 	if err != nil {
 		return nil, err
@@ -141,7 +158,7 @@ func connectKubernetes(command *cli.Context) (typedcore.CoreV1Interface, error) 
 }
 
 func buildHandler(command *cli.Context, connection *grpc.ClientConn, core typedcore.CoreV1Interface) (*Server, error) {
-	store, err := NewKubernetesStore(core.ConfigMaps(command.String("state-namespace")))
+	store, err := NewKubernetesStore(core.ConfigMaps(command.String(flagStateNamespace)))
 	if err != nil {
 		return nil, err
 	}
@@ -149,11 +166,11 @@ func buildHandler(command *cli.Context, connection *grpc.ClientConn, core typedc
 	if err != nil {
 		return nil, err
 	}
-	authenticate, err := NewAPIKeyAuthenticator(core.Secrets(command.String("api-key-namespace")), command.String("api-key-secret"))
+	authenticate, err := NewAPIKeyAuthenticator(core.Secrets(command.String(flagAPIKeyNamespace)), command.String(flagAPIKeySecret))
 	if err != nil {
 		return nil, err
 	}
-	return New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice("allowed-origin"), Ready: readiness(store, pb.NewSandboxServiceClient(connection))})
+	return New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice(flagAllowedOrigin), Ready: readiness(store, pb.NewSandboxServiceClient(connection))})
 }
 
 func serveHTTP(command *cli.Context, server *Server) error {
@@ -161,16 +178,16 @@ func serveHTTP(command *cli.Context, server *Server) error {
 	mux.Handle("/mcp", server)
 	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, _ *http.Request) { writer.WriteHeader(http.StatusNoContent) })
 	mux.HandleFunc("/readyz", readinessHandler(server))
-	httpServer := &http.Server{Addr: command.String("listen"), Handler: mux, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 45 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 32 * 1024, TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+	httpServer := &http.Server{Addr: command.String(flagListen), Handler: mux, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 45 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 32 * 1024, TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	completed := make(chan error, 1)
 	go func() {
-		if command.String("tls-cert") == "" {
+		if command.String(flagTLSCert) == "" {
 			completed <- httpServer.ListenAndServe()
 			return
 		}
-		completed <- httpServer.ListenAndServeTLS(command.String("tls-cert"), command.String("tls-key"))
+		completed <- httpServer.ListenAndServeTLS(command.String(flagTLSCert), command.String(flagTLSKey))
 	}()
 	select {
 	case err := <-completed:

--- a/pkg/sandboxmcp/command.go
+++ b/pkg/sandboxmcp/command.go
@@ -1,0 +1,117 @@
+package sandboxmcp
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func Command() cli.Command {
+	flags := []cli.Flag{
+		cli.StringFlag{Name: "listen", Value: "127.0.0.1:8443", EnvVar: "K8E_MCP_LISTEN"},
+		cli.StringSliceFlag{Name: "allowed-origin", EnvVar: "K8E_MCP_ALLOWED_ORIGINS"},
+		cli.StringFlag{Name: "tls-cert", EnvVar: "K8E_MCP_TLS_CERT"},
+		cli.StringFlag{Name: "tls-key", EnvVar: "K8E_MCP_TLS_KEY"},
+		cli.StringFlag{Name: "api-key-namespace", Value: "sandbox-matrix", EnvVar: "K8E_MCP_API_KEY_NAMESPACE"},
+		cli.StringFlag{Name: "api-key-secret", Value: "sandbox-apikeys", EnvVar: "K8E_MCP_API_KEY_SECRET"},
+		cli.StringFlag{Name: "gateway", EnvVar: "K8E_MCP_GATEWAY"},
+		cli.StringFlag{Name: "gateway-ca", EnvVar: "K8E_MCP_GATEWAY_CA"},
+		cli.StringFlag{Name: "gateway-cert", EnvVar: "K8E_MCP_GATEWAY_CERT"},
+		cli.StringFlag{Name: "gateway-key", EnvVar: "K8E_MCP_GATEWAY_KEY"},
+		cli.StringFlag{Name: "state-namespace", EnvVar: "K8E_MCP_STATE_NAMESPACE"},
+		cli.StringFlag{Name: "kubeconfig", EnvVar: "KUBECONFIG"},
+	}
+	return cli.Command{Name: "mcp-serve", Usage: "Serve MCP over HTTPS using K8E API keys and an explicit mTLS sandbox gateway", Flags: flags, Action: serveCommand}
+}
+
+func serveCommand(command *cli.Context) error {
+	for _, name := range []string{"tls-cert", "tls-key", "api-key-namespace", "api-key-secret", "gateway", "gateway-ca", "gateway-cert", "gateway-key", "state-namespace"} {
+		if command.String(name) == "" {
+			return errors.New("required MCP option: --" + name)
+		}
+	}
+	certificate, err := tls.LoadX509KeyPair(command.String("gateway-cert"), command.String("gateway-key"))
+	if err != nil {
+		return err
+	}
+	rootPEM, err := os.ReadFile(command.String("gateway-ca"))
+	if err != nil {
+		return err
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(rootPEM) {
+		return errors.New("gateway CA has no certificates")
+	}
+	connection, err := grpc.NewClient(command.String("gateway"), grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots, Certificates: []tls.Certificate{certificate}})))
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+	var kubeConfig *rest.Config
+	if command.String("kubeconfig") == "" {
+		kubeConfig, err = rest.InClusterConfig()
+	} else {
+		kubeConfig, err = clientcmd.BuildConfigFromFlags("", command.String("kubeconfig"))
+	}
+	if err != nil {
+		return err
+	}
+	kubeConfig.Timeout = 10 * time.Second
+	core, err := typedcore.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
+	}
+	store, err := NewKubernetesStore(core.ConfigMaps(command.String("state-namespace")))
+	if err != nil {
+		return err
+	}
+	service, err := NewService(pb.NewSandboxServiceClient(connection), store)
+	if err != nil {
+		return err
+	}
+	authenticate, err := NewAPIKeyAuthenticator(core.Secrets(command.String("api-key-namespace")), command.String("api-key-secret"))
+	if err != nil {
+		return err
+	}
+	handler, err := New(Config{Authenticate: authenticate, Tools: service.Tools(), AllowedOrigins: command.StringSlice("allowed-origin")})
+	if err != nil {
+		return err
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", handler)
+	mux.HandleFunc("/healthz", func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusNoContent) })
+	server := &http.Server{Addr: command.String("listen"), Handler: mux, ReadHeaderTimeout: 5 * time.Second, ReadTimeout: 15 * time.Second, WriteTimeout: 45 * time.Second, IdleTimeout: 60 * time.Second, MaxHeaderBytes: 32 * 1024, TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	completed := make(chan error, 1)
+	go func() { completed <- server.ListenAndServeTLS(command.String("tls-cert"), command.String("tls-key")) }()
+	select {
+	case err := <-completed:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		shutdown, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdown); err != nil {
+			_ = server.Close()
+			return err
+		}
+		return nil
+	}
+}

--- a/pkg/sandboxmcp/command_test.go
+++ b/pkg/sandboxmcp/command_test.go
@@ -1,7 +1,11 @@
 package sandboxmcp
 
 import (
+	"context"
+	"errors"
 	"flag"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -23,6 +27,41 @@ func TestValidateServeOptionsRejectsIncompleteTLS(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "both --tls-cert and --tls-key") {
 			t.Fatalf("cert=%q key=%q: %v", files[0], files[1], err)
 		}
+	}
+}
+
+func TestReadinessReflectsDependencies(t *testing.T) {
+	authenticate := func(*http.Request) (Principal, error) { return Principal{ID: "a"}, nil }
+	healthy := false
+	server, err := New(Config{Authenticate: authenticate, Ready: func(context.Context) error {
+		if healthy {
+			return nil
+		}
+		return errors.New("downstream down")
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	probe := readinessHandler(server)
+	response := httptest.NewRecorder()
+	probe(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unhealthy dependency reported ready: %d", response.Code)
+	}
+	healthy = true
+	response = httptest.NewRecorder()
+	probe(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("healthy dependency reported unready: %d", response.Code)
+	}
+	plain, err := New(Config{Authenticate: authenticate})
+	if err != nil {
+		t.Fatal(err)
+	}
+	response = httptest.NewRecorder()
+	readinessHandler(plain)(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("default readiness probe must report ready: %d", response.Code)
 	}
 }
 

--- a/pkg/sandboxmcp/command_test.go
+++ b/pkg/sandboxmcp/command_test.go
@@ -44,13 +44,13 @@ func TestReadinessReflectsDependencies(t *testing.T) {
 	}
 	probe := readinessHandler(server)
 	response := httptest.NewRecorder()
-	probe(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	probe(response, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
 	if response.Code != http.StatusServiceUnavailable {
 		t.Fatalf("unhealthy dependency reported ready: %d", response.Code)
 	}
 	healthy = true
 	response = httptest.NewRecorder()
-	probe(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	probe(response, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("healthy dependency reported unready: %d", response.Code)
 	}
@@ -59,7 +59,7 @@ func TestReadinessReflectsDependencies(t *testing.T) {
 		t.Fatal(err)
 	}
 	response = httptest.NewRecorder()
-	readinessHandler(plain)(response, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	readinessHandler(plain)(response, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("default readiness probe must report ready: %d", response.Code)
 	}

--- a/pkg/sandboxmcp/command_test.go
+++ b/pkg/sandboxmcp/command_test.go
@@ -1,0 +1,43 @@
+package sandboxmcp
+
+import (
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestValidateServeOptionsAllowsGatewayTerminatedTLS(t *testing.T) {
+	if err := validateServeOptions(testServeContext(t, "", "")); err != nil {
+		t.Fatalf("gateway-terminated TLS should allow an internal HTTP listener: %v", err)
+	}
+	if err := validateServeOptions(testServeContext(t, "tls.crt", "tls.key")); err != nil {
+		t.Fatalf("direct TLS should remain supported: %v", err)
+	}
+}
+
+func TestValidateServeOptionsRejectsIncompleteTLS(t *testing.T) {
+	for _, files := range [][2]string{{"tls.crt", ""}, {"", "tls.key"}} {
+		err := validateServeOptions(testServeContext(t, files[0], files[1]))
+		if err == nil || !strings.Contains(err.Error(), "both --tls-cert and --tls-key") {
+			t.Fatalf("cert=%q key=%q: %v", files[0], files[1], err)
+		}
+	}
+}
+
+func testServeContext(t *testing.T, cert, key string) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("mcp-serve", flag.ContinueOnError)
+	values := map[string]string{
+		"tls-cert": cert, "tls-key": key,
+		"api-key-namespace": "sandbox-matrix", "api-key-secret": "sandbox-apikeys",
+		"gateway": "sandbox-grpc-gateway:50051", "gateway-ca": "ca.crt",
+		"gateway-cert": "client.crt", "gateway-key": "client.key",
+		"state-namespace": "k8e-mcp",
+	}
+	for name, value := range values {
+		set.String(name, value, "")
+	}
+	return cli.NewContext(cli.NewApp(), set, nil)
+}

--- a/pkg/sandboxmcp/gateway_integration_test.go
+++ b/pkg/sandboxmcp/gateway_integration_test.go
@@ -97,43 +97,11 @@ func TestGatewayWithKubernetesMock(t *testing.T) {
 	store, _ := NewKubernetesStore(core.CoreV1().ConfigMaps("mcp-state"))
 	authenticate, _ := NewAPIKeyAuthenticator(core.CoreV1().Secrets("sandbox-matrix"), "sandbox-apikeys")
 	newHandler := func() *Server {
-		service, err := NewService(pb.NewSandboxServiceClient(connection), store)
-		if err != nil {
-			t.Fatal(err)
-		}
-		handler, err := New(Config{Authenticate: authenticate, Tools: service.Tools()})
-		if err != nil {
-			t.Fatal(err)
-		}
-		return handler
+		return newGatewayHandler(t, connection, store, authenticate)
 	}
 	handler := newHandler()
 	call := func(key, name string, arguments map[string]any, rejected bool) map[string]any {
-		t.Helper()
-		request := newRequest("tools/call", arguments)
-		var body map[string]any
-		_ = json.NewDecoder(request.Body).Decode(&body)
-		body["params"].(map[string]any)["name"] = name
-		encoded, _ := json.Marshal(body)
-		updated := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(encoded)))
-		updated.Header = request.Header
-		updated.Header.Set("Mcp-Name", name)
-		updated.Header.Set("Authorization", "Bearer "+key)
-		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, updated)
-		var envelope struct {
-			Result struct {
-				IsError bool           `json:"isError"`
-				Data    map[string]any `json:"structuredContent"`
-			}
-		}
-		if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
-			t.Fatal(err)
-		}
-		if response.Code != 200 || envelope.Result.IsError != rejected {
-			t.Fatalf("%s: %s", name, response.Body.String())
-		}
-		return envelope.Result.Data
+		return callGatewayTool(t, handler, key, name, arguments, rejected)
 	}
 	created := call("alice-key", "sandbox_create", map[string]any{"operation_id": "create"}, false)
 	session := created["session_id"]
@@ -156,12 +124,53 @@ func TestGatewayWithKubernetesMock(t *testing.T) {
 	handler = newHandler()
 	replayed := call("alice-key", "sandbox_exec", execArgs, false)
 	if replayed["run_id"] != submitted["run_id"] || submissions.Load() != 1 {
-		 t.Fatal("duplicate execution after MCP reconstruction")
+		t.Fatal("duplicate execution after MCP reconstruction")
 	}
 	call("alice-key", "sandbox_operation", map[string]any{"operation_kind": "sandbox_exec", "operation_id": "exec"}, false)
 	call("alice-key", "sandbox_poll", map[string]any{"run_id": submitted["run_id"]}, false)
 	call("bob-key", "sandbox_poll", map[string]any{"run_id": submitted["run_id"]}, true)
 	call("alice-key", "sandbox_destroy", map[string]any{"session_id": session, "operation_id": "destroy"}, false)
+}
+
+func newGatewayHandler(t *testing.T, connection *grpc.ClientConn, store RecordStore, authenticate Authenticate) *Server {
+	t.Helper()
+	service, err := NewService(pb.NewSandboxServiceClient(connection), store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := New(Config{Authenticate: authenticate, Tools: service.Tools()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handler
+}
+
+func callGatewayTool(t *testing.T, handler *Server, key, name string, arguments map[string]any, rejected bool) map[string]any {
+	t.Helper()
+	request := newRequest("tools/call", arguments)
+	var body map[string]any
+	_ = json.NewDecoder(request.Body).Decode(&body)
+	body["params"].(map[string]any)["name"] = name
+	encoded, _ := json.Marshal(body)
+	updated := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(encoded)))
+	updated.Header = request.Header
+	updated.Header.Set("Mcp-Name", name)
+	updated.Header.Set("Authorization", "Bearer "+key)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, updated)
+	var envelope struct {
+		Result struct {
+			IsError bool           `json:"isError"`
+			Data    map[string]any `json:"structuredContent"`
+		}
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != 200 || envelope.Result.IsError != rejected {
+		t.Fatalf("%s: %s", name, response.Body.String())
+	}
+	return envelope.Result.Data
 }
 
 func installConfigMapCAS(client *kubefake.Clientset) {

--- a/pkg/sandboxmcp/gateway_integration_test.go
+++ b/pkg/sandboxmcp/gateway_integration_test.go
@@ -1,0 +1,204 @@
+//go:build mcp_integration
+
+package sandboxmcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	gateway "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestGatewayWithKubernetesMock(t *testing.T) {
+	var submissions atomic.Int32
+	var stored string
+	var files sync.Mutex
+	sandboxd := &http.Server{Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		var result any
+		switch {
+		case request.URL.Path == "/exec/background":
+			submissions.Add(1)
+			result = map[string]any{"status": "started"}
+		case strings.HasPrefix(request.URL.Path, "/exec/background/"):
+			result = map[string]any{"status": "completed", "exit_code": 0, "stdout": "mock-ok"}
+		case request.URL.Path == "/files/write":
+			var body struct{ Content string }
+			if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			files.Lock()
+			stored = body.Content
+			files.Unlock()
+			result = map[string]any{"ok": true}
+		case request.URL.Path == "/files/read":
+			files.Lock()
+			content := stored
+			files.Unlock()
+			result = map[string]any{"content": base64.StdEncoding.EncodeToString([]byte(content)), "encoding": "base64"}
+		case request.URL.Path == "/files/list":
+			result = map[string]any{"files": []any{map[string]any{"path": "/workspace/test", "type": "file"}}}
+		default:
+			result = map[string]any{"status": "ready"}
+		}
+		_ = json.NewEncoder(writer).Encode(result)
+	})}
+	listener, err := net.Listen("tcp4", "127.0.0.1:2024")
+	if err != nil {
+		t.Fatal("run in an isolated container with port 2024 free:", err)
+	}
+	go sandboxd.Serve(listener)
+	t.Cleanup(func() { _ = sandboxd.Close() })
+
+	core := kubefake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "mock-node"}, Status: corev1.NodeStatus{Allocatable: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")}}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "warm", Namespace: "sandbox-matrix", Labels: map[string]string{"sandbox.k8e.io/state": "warm", "sandbox.k8e.io/runtime-class": "gvisor"}}, Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "127.0.0.1", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sandbox-apikeys", Namespace: "sandbox-matrix", UID: "mock-secret"}, Data: map[string][]byte{"keys.json": []byte(`{"alice":"alice-key","bob":"bob-key"}`)}},
+	)
+	installConfigMapCAS(core)
+	dynamic := dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		{Group: "k8e.sh", Version: "v1alpha1", Resource: "sandboxsessions"}:    "SandboxSessionList",
+		{Group: "k8e.sh", Version: "v1alpha1", Resource: "sandboxmatrices"}:    "SandboxMatrixList",
+		{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"}: "CiliumNetworkPolicyList",
+	})
+	backend := gateway.NewServer(gateway.ServerConfig{K8s: core, Dyn: dynamic})
+	transport := bufconn.Listen(1 << 20)
+	grpcServer := grpc.NewServer()
+	pb.RegisterSandboxServiceServer(grpcServer, backend)
+	go grpcServer.Serve(transport)
+	t.Cleanup(grpcServer.Stop)
+	connection, err := grpc.NewClient("passthrough:///mock-gateway", grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return transport.Dial() }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	store, _ := NewKubernetesStore(core.CoreV1().ConfigMaps("mcp-state"))
+	authenticate, _ := NewAPIKeyAuthenticator(core.CoreV1().Secrets("sandbox-matrix"), "sandbox-apikeys")
+	newHandler := func() *Server {
+		service, err := NewService(pb.NewSandboxServiceClient(connection), store)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler, err := New(Config{Authenticate: authenticate, Tools: service.Tools()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return handler
+	}
+	handler := newHandler()
+	call := func(key, name string, arguments map[string]any, rejected bool) map[string]any {
+		t.Helper()
+		request := newRequest("tools/call", arguments)
+		var body map[string]any
+		_ = json.NewDecoder(request.Body).Decode(&body)
+		body["params"].(map[string]any)["name"] = name
+		encoded, _ := json.Marshal(body)
+		updated := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(encoded)))
+		updated.Header = request.Header
+		updated.Header.Set("Mcp-Name", name)
+		updated.Header.Set("Authorization", "Bearer "+key)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, updated)
+		var envelope struct {
+			Result struct {
+				IsError bool           `json:"isError"`
+				Data    map[string]any `json:"structuredContent"`
+			}
+		}
+		if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+			t.Fatal(err)
+		}
+		if response.Code != 200 || envelope.Result.IsError != rejected {
+			t.Fatalf("%s: %s", name, response.Body.String())
+		}
+		return envelope.Result.Data
+	}
+	created := call("alice-key", "sandbox_create", map[string]any{"operation_id": "create"}, false)
+	session := created["session_id"]
+	if session == nil {
+		t.Fatal(created)
+	}
+	call("alice-key", "sandbox_get", map[string]any{"session_id": session}, false)
+	call("bob-key", "sandbox_get", map[string]any{"session_id": session}, true)
+	call("alice-key", "sandbox_write", map[string]any{"session_id": session, "operation_id": "write", "path": "/workspace/test", "content": "payload"}, false)
+	read := call("alice-key", "sandbox_read", map[string]any{"session_id": session, "path": "/workspace/test"}, false)
+	if read["content"] != base64.StdEncoding.EncodeToString([]byte("payload")) {
+		t.Fatal(read)
+	}
+	call("alice-key", "sandbox_list", map[string]any{"session_id": session}, false)
+	execArgs := map[string]any{"session_id": session, "operation_id": "exec", "command": "echo mock-ok"}
+	submitted := call("alice-key", "sandbox_exec", execArgs, false)
+	if submitted["run_id"] == nil {
+		t.Fatal(submitted)
+	}
+	handler = newHandler()
+	replayed := call("alice-key", "sandbox_exec", execArgs, false)
+	if replayed["run_id"] != submitted["run_id"] || submissions.Load() != 1 {
+		 t.Fatal("duplicate execution after MCP reconstruction")
+	}
+	call("alice-key", "sandbox_operation", map[string]any{"operation_kind": "sandbox_exec", "operation_id": "exec"}, false)
+	call("alice-key", "sandbox_poll", map[string]any{"run_id": submitted["run_id"]}, false)
+	call("bob-key", "sandbox_poll", map[string]any{"run_id": submitted["run_id"]}, true)
+	call("alice-key", "sandbox_destroy", map[string]any{"session_id": session, "operation_id": "destroy"}, false)
+}
+
+func installConfigMapCAS(client *kubefake.Clientset) {
+	var lock sync.Mutex
+	var version int
+	resourceID := corev1.SchemeGroupVersion.WithResource("configmaps")
+	client.PrependReactor("*", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
+		lock.Lock()
+		defer lock.Unlock()
+		var configMap *corev1.ConfigMap
+		switch action.GetVerb() {
+		case "create":
+			configMap = action.(ktesting.CreateAction).GetObject().(*corev1.ConfigMap).DeepCopy()
+		case "update":
+			configMap = action.(ktesting.UpdateAction).GetObject().(*corev1.ConfigMap).DeepCopy()
+		default:
+			return false, nil, nil
+		}
+		previous, err := client.Tracker().Get(resourceID, action.GetNamespace(), configMap.Name)
+		if action.GetVerb() == "create" && err == nil {
+			return true, nil, apierrors.NewAlreadyExists(resourceID.GroupResource(), configMap.Name)
+		}
+		if action.GetVerb() == "update" {
+			if err != nil {
+				return true, nil, err
+			}
+			if previous.(*corev1.ConfigMap).ResourceVersion != configMap.ResourceVersion {
+				return true, nil, apierrors.NewConflict(resourceID.GroupResource(), configMap.Name, fmt.Errorf("stale version"))
+			}
+		}
+		version++
+		configMap.ResourceVersion = fmt.Sprint(version)
+		if action.GetVerb() == "create" {
+			err = client.Tracker().Create(resourceID, configMap, action.GetNamespace())
+		} else {
+			err = client.Tracker().Update(resourceID, configMap, action.GetNamespace())
+		}
+		return true, configMap, err
+	})
+}

--- a/pkg/sandboxmcp/gateway_integration_test.go
+++ b/pkg/sandboxmcp/gateway_integration_test.go
@@ -180,34 +180,57 @@ func installConfigMapCAS(client *kubefake.Clientset) {
 	client.PrependReactor("*", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
 		lock.Lock()
 		defer lock.Unlock()
-		var configMap *corev1.ConfigMap
-		switch action.GetVerb() {
-		case "create":
-			configMap = action.(ktesting.CreateAction).GetObject().(*corev1.ConfigMap).DeepCopy()
-		case "update":
-			configMap = action.(ktesting.UpdateAction).GetObject().(*corev1.ConfigMap).DeepCopy()
-		default:
+		configMap, ok := configMapFromAction(action)
+		if !ok {
 			return false, nil, nil
 		}
 		previous, err := client.Tracker().Get(resourceID, action.GetNamespace(), configMap.Name)
-		if action.GetVerb() == "create" && err == nil {
-			return true, nil, apierrors.NewAlreadyExists(resourceID.GroupResource(), configMap.Name)
-		}
-		if action.GetVerb() == "update" {
-			if err != nil {
-				return true, nil, err
-			}
-			if previous.(*corev1.ConfigMap).ResourceVersion != configMap.ResourceVersion {
-				return true, nil, apierrors.NewConflict(resourceID.GroupResource(), configMap.Name, fmt.Errorf("stale version"))
-			}
+		if err := configMapCASError(action, previous, err, configMap, resourceID); err != nil {
+			return true, nil, err
 		}
 		version++
 		configMap.ResourceVersion = fmt.Sprint(version)
-		if action.GetVerb() == "create" {
-			err = client.Tracker().Create(resourceID, configMap, action.GetNamespace())
-		} else {
-			err = client.Tracker().Update(resourceID, configMap, action.GetNamespace())
-		}
+		err = storeConfigMap(client, resourceID, action, configMap)
 		return true, configMap, err
 	})
+}
+
+// configMapFromAction extracts the ConfigMap under test, or reports that this
+// reactor should let the request through untouched.
+func configMapFromAction(action ktesting.Action) (*corev1.ConfigMap, bool) {
+	switch action.GetVerb() {
+	case "create":
+		return action.(ktesting.CreateAction).GetObject().(*corev1.ConfigMap).DeepCopy(), true
+	case "update":
+		return action.(ktesting.UpdateAction).GetObject().(*corev1.ConfigMap).DeepCopy(), true
+	default:
+		return nil, false
+	}
+}
+
+// configMapCASError enforces create-once and the resource-version match that
+// real ConfigMaps require on update.
+func configMapCASError(action ktesting.Action, previous runtime.Object, getErr error, configMap *corev1.ConfigMap, resourceID schema.GroupVersionResource) error {
+	switch action.GetVerb() {
+	case "create":
+		if getErr == nil {
+			return apierrors.NewAlreadyExists(resourceID.GroupResource(), configMap.Name)
+		}
+	case "update":
+		if getErr != nil {
+			return getErr
+		}
+		if previous.(*corev1.ConfigMap).ResourceVersion != configMap.ResourceVersion {
+			return apierrors.NewConflict(resourceID.GroupResource(), configMap.Name, fmt.Errorf("stale version"))
+		}
+	}
+	return nil
+}
+
+// storeConfigMap persists the intercepted create or update.
+func storeConfigMap(client *kubefake.Clientset, resourceID schema.GroupVersionResource, action ktesting.Action, configMap *corev1.ConfigMap) error {
+	if action.GetVerb() == "create" {
+		return client.Tracker().Create(resourceID, configMap, action.GetNamespace())
+	}
+	return client.Tracker().Update(resourceID, configMap, action.GetNamespace())
 }

--- a/pkg/sandboxmcp/interop_test.go
+++ b/pkg/sandboxmcp/interop_test.go
@@ -1,0 +1,68 @@
+package sandboxmcp
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/xiaods/k8e/pkg/sandbox/apikey"
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc"
+)
+
+type wireBackend struct{ testBackend }
+
+func (backend *wireBackend) PollRun(context.Context, *pb.PollRunRequest, ...grpc.CallOption) (*pb.PollRunResponse, error) {
+	return &pb.PollRunResponse{Status: "completed", ExitCode: 0}, nil
+}
+
+func TestIndependentPythonClient(t *testing.T) {
+	if os.Getenv("MCP_RUN_INTEROP") != "1" {
+		t.Skip("set MCP_RUN_INTEROP=1 for networked Python interoperability probe")
+	}
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is required for independent wire interoperability")
+	}
+	authenticate, err := NewAPIKeyAuthenticator(&secretFixture{records: map[string]apikey.Record{"alice": {Key: "test-token"}}}, "sandbox-apikeys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &testStore{records: map[string]Record{}}
+	backend := &wireBackend{}
+	directory := t.TempDir()
+	statePath := filepath.Join(directory, "state.json")
+	for _, phase := range []string{"before", "after"} {
+		service, err := NewService(backend, store)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler, err := New(Config{Authenticate: authenticate, Tools: service.Tools()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		endpoint := httptest.NewTLSServer(handler)
+		certificatePath := filepath.Join(directory, "ca.pem")
+		if err := os.WriteFile(certificatePath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: endpoint.Certificate().Raw}), 0600); err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		command := exec.CommandContext(ctx, python, "../../tests/mcp/client_smoke.py", "--endpoint", endpoint.URL, "--ca", certificatePath, "--state", statePath, "--phase", phase)
+		command.Env = append(os.Environ(), "MCP_TEST_API_KEY=test-token")
+		output, err := command.CombinedOutput()
+		cancel()
+		endpoint.Close()
+		t.Logf("%s", output)
+		if err != nil {
+			t.Fatalf("%s client: %v", phase, err)
+		}
+	}
+	if backend.creates != 1 || backend.execs != 1 {
+		t.Fatalf("replayed backend mutations: create=%d exec=%d", backend.creates, backend.execs)
+	}
+}

--- a/pkg/sandboxmcp/readiness_test.go
+++ b/pkg/sandboxmcp/readiness_test.go
@@ -3,14 +3,12 @@ package sandboxmcp
 import (
 	"context"
 	"errors"
-	"net"
 	"testing"
 	"time"
 
 	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -21,44 +19,37 @@ func (failingStore) Get(context.Context, string) (Record, error) {
 	return Record{}, errors.New("storage down")
 }
 
-// readinessBackend answers the probe RPC with an application error, proving the
-// gateway is reachable without performing real work.
-type readinessBackend struct {
-	pb.UnimplementedSandboxServiceServer
+// stubSandboxClient returns a fixed gateway error so the readiness check can be
+// exercised without opening a listener, which would need insecure credentials.
+type stubSandboxClient struct {
+	pb.SandboxServiceClient
+	err error
 }
 
-func (readinessBackend) GetSession(context.Context, *pb.GetSessionRequest) (*pb.GetSessionResponse, error) {
-	return nil, status.Error(codes.InvalidArgument, "session_id required")
+func (client stubSandboxClient) GetSession(context.Context, *pb.GetSessionRequest, ...grpc.CallOption) (*pb.GetSessionResponse, error) {
+	return nil, client.err
 }
 
 func TestReadinessChecksStateAndGateway(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := readiness(failingStore{}, nil)(ctx); err == nil {
+	store := &testStore{records: map[string]Record{}}
+	answered := status.Error(codes.InvalidArgument, "session_id required")
+
+	if err := readiness(failingStore{}, stubSandboxClient{err: answered})(ctx); err == nil {
 		t.Fatal("state store failure reported ready")
 	}
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
+	// Any application-level error proves the gateway answered.
+	if err := readiness(store, stubSandboxClient{err: answered})(ctx); err != nil {
+		t.Fatalf("reachable gateway reported unready: %v", err)
 	}
-	grpcServer := grpc.NewServer()
-	pb.RegisterSandboxServiceServer(grpcServer, readinessBackend{})
-	go grpcServer.Serve(listener)
-	connection, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		t.Fatal(err)
+	if err := readiness(store, stubSandboxClient{})(ctx); err != nil {
+		t.Fatalf("healthy gateway reported unready: %v", err)
 	}
-	defer connection.Close()
-
-	client := pb.NewSandboxServiceClient(connection)
-	store := &testStore{records: map[string]Record{}}
-	if err := readiness(store, client)(ctx); err != nil {
-		t.Fatalf("reachable dependencies reported unready: %v", err)
-	}
-
-	grpcServer.Stop()
-	if err := readiness(store, client)(ctx); err == nil {
-		t.Fatal("unreachable gateway reported ready")
+	// Transport and credential failures mean the adapter cannot serve tool calls.
+	for _, code := range []codes.Code{codes.Unavailable, codes.DeadlineExceeded, codes.Canceled, codes.Unauthenticated} {
+		if err := readiness(store, stubSandboxClient{err: status.Error(code, "gateway down")})(ctx); err == nil {
+			t.Fatalf("%v gateway reported ready", code)
+		}
 	}
 }

--- a/pkg/sandboxmcp/readiness_test.go
+++ b/pkg/sandboxmcp/readiness_test.go
@@ -1,0 +1,64 @@
+package sandboxmcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// failingStore makes the durable state lookup fail, as a Kubernetes outage would.
+type failingStore struct{ RecordStore }
+
+func (failingStore) Get(context.Context, string) (Record, error) {
+	return Record{}, errors.New("storage down")
+}
+
+// readinessBackend answers the probe RPC with an application error, proving the
+// gateway is reachable without performing real work.
+type readinessBackend struct {
+	pb.UnimplementedSandboxServiceServer
+}
+
+func (readinessBackend) GetSession(context.Context, *pb.GetSessionRequest) (*pb.GetSessionResponse, error) {
+	return nil, status.Error(codes.InvalidArgument, "session_id required")
+}
+
+func TestReadinessChecksStateAndGateway(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := readiness(failingStore{}, nil)(ctx); err == nil {
+		t.Fatal("state store failure reported ready")
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	grpcServer := grpc.NewServer()
+	pb.RegisterSandboxServiceServer(grpcServer, readinessBackend{})
+	go grpcServer.Serve(listener)
+	connection, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close()
+
+	client := pb.NewSandboxServiceClient(connection)
+	store := &testStore{records: map[string]Record{}}
+	if err := readiness(store, client)(ctx); err != nil {
+		t.Fatalf("reachable dependencies reported unready: %v", err)
+	}
+
+	grpcServer.Stop()
+	if err := readiness(store, client)(ctx); err == nil {
+		t.Fatal("unreachable gateway reported ready")
+	}
+}

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -73,8 +73,23 @@ type Server struct {
 // handler at /mcp on an HTTPS server with transport timeouts and request limits.
 // No listener is started, and there is no anonymous fallback.
 func New(c Config) (*Server, error) {
+	if err := normalizeConfig(&c); err != nil {
+		return nil, err
+	}
+	tools, err := snapshotTools(c.Tools)
+	if err != nil {
+		return nil, err
+	}
+	origins, err := explicitOrigins(c.AllowedOrigins)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{auth: c.Authenticate, tools: tools, origins: origins, version: c.Version, maxBytes: c.MaxRequestBytes, timeout: c.Timeout}, nil
+}
+
+func normalizeConfig(c *Config) error {
 	if c.Authenticate == nil {
-		return nil, errors.New("MCP authentication is required")
+		return errors.New("MCP authentication is required")
 	}
 	if c.MaxRequestBytes == 0 {
 		c.MaxRequestBytes = 1 << 20
@@ -83,11 +98,15 @@ func New(c Config) (*Server, error) {
 		c.Timeout = 30 * time.Second
 	}
 	if c.MaxRequestBytes < 1 || c.Timeout < 0 {
-		return nil, errors.New("invalid MCP limits")
+		return errors.New("invalid MCP limits")
 	}
-	s := &Server{auth: c.Authenticate, version: c.Version, maxBytes: c.MaxRequestBytes, timeout: c.Timeout, origins: map[string]bool{}}
+	return nil
+}
+
+func snapshotTools(configured []Tool) ([]Tool, error) {
+	var tools []Tool
 	seen := map[string]bool{}
-	for _, t := range c.Tools {
+	for _, t := range configured {
 		if t.Name == "" || seen[t.Name] || t.Call == nil {
 			return nil, fmt.Errorf("invalid or duplicate MCP tool %q", t.Name)
 		}
@@ -97,16 +116,21 @@ func New(c Config) (*Server, error) {
 		}
 		t.InputSchema = append(json.RawMessage(nil), t.InputSchema...)
 		seen[t.Name] = true
-		s.tools = append(s.tools, t)
+		tools = append(tools, t)
 	}
-	sort.Slice(s.tools, func(i, j int) bool { return s.tools[i].Name < s.tools[j].Name })
-	for _, o := range c.AllowedOrigins {
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+	return tools, nil
+}
+
+func explicitOrigins(configured []string) (map[string]bool, error) {
+	origins := map[string]bool{}
+	for _, o := range configured {
 		if o == "" || o == "*" || o == "null" {
 			return nil, errors.New("explicit origins required")
 		}
-		s.origins[o] = true
+		origins[o] = true
 	}
-	return s, nil
+	return origins, nil
 }
 
 type request struct {
@@ -146,38 +170,50 @@ func fail(w http.ResponseWriter, status int, id json.RawMessage, code int, msg s
 	reply(w, status, id, nil, &rpcError{Code: code, Message: msg})
 }
 
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *Server) validateTransport(w http.ResponseWriter, r *http.Request) bool {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", "POST")
 		fail(w, 405, nil, -32600, "Only POST is supported")
-		return
+		return false
 	}
 	if origins := r.Header.Values("Origin"); len(origins) > 0 && (len(origins) != 1 || !s.origins[origins[0]]) {
 		fail(w, 403, nil, -32600, "Origin rejected")
-		return
+		return false
 	}
-	principal, err := s.auth(r)
-	if err != nil || principal.ID == "" {
-		status := http.StatusUnauthorized
-		var authErr *authenticationError
-		if errors.As(err, &authErr) {
-			status = authErr.status
-			if authErr.challenge != "" {
-				w.Header().Set("WWW-Authenticate", authErr.challenge)
-			}
-		}
-		fail(w, status, nil, -32000, "Authentication required")
-		return
-	}
+	return true
+}
+
+func validateMediaHeaders(w http.ResponseWriter, r *http.Request) bool {
 	media, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil || media != "application/json" {
 		fail(w, 415, nil, -32600, "Content-Type must be application/json")
-		return
+		return false
 	}
 	if !accepts(r, "application/json") || !accepts(r, "text/event-stream") {
 		fail(w, 406, nil, -32600, "Accept must include application/json and text/event-stream")
-		return
+		return false
 	}
+	return true
+}
+
+func (s *Server) authenticateRequest(w http.ResponseWriter, r *http.Request) (Principal, bool) {
+	principal, err := s.auth(r)
+	if err == nil && principal.ID != "" {
+		return principal, true
+	}
+	status := http.StatusUnauthorized
+	var authErr *authenticationError
+	if errors.As(err, &authErr) {
+		status = authErr.status
+		if authErr.challenge != "" {
+			w.Header().Set("WWW-Authenticate", authErr.challenge)
+		}
+	}
+	fail(w, status, nil, -32000, "Authentication required")
+	return Principal{}, false
+}
+
+func (s *Server) decodeRequest(w http.ResponseWriter, r *http.Request) (request, map[string]json.RawMessage, bool) {
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.maxBytes))
 	if err != nil {
 		var tooLarge *http.MaxBytesError
@@ -186,39 +222,65 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			fail(w, 400, nil, -32700, "Cannot read request")
 		}
-		return
+		return request{}, nil, false
 	}
 	if !utf8.Valid(body) || !json.Valid(body) {
 		fail(w, 400, nil, -32700, "Invalid JSON")
-		return
+		return request{}, nil, false
 	}
 	var req request
 	if err := json.Unmarshal(body, &req); err != nil || req.JSONRPC != "2.0" || req.Method == "" || !validID(req.ID) {
 		fail(w, 400, nil, -32600, "Invalid request")
-		return
+		return request{}, nil, false
 	}
 	var params map[string]json.RawMessage
 	if json.Unmarshal(req.Params, &params) != nil || params == nil {
 		fail(w, 400, req.ID, -32602, "Object params required")
-		return
+		return request{}, nil, false
 	}
+	return req, params, true
+}
+
+func validateRequestMetadata(w http.ResponseWriter, r *http.Request, req request, params map[string]json.RawMessage) bool {
 	var meta map[string]json.RawMessage
 	if json.Unmarshal(params["_meta"], &meta) != nil || meta == nil {
 		fail(w, 400, req.ID, -32602, "Request metadata required")
-		return
+		return false
 	}
 	var version string
-	var capabilities map[string]json.RawMessage
-	if json.Unmarshal(meta[metaPrefix+"protocolVersion"], &version) != nil || version == "" || json.Unmarshal(meta[metaPrefix+"clientCapabilities"], &capabilities) != nil || capabilities == nil {
+	if json.Unmarshal(meta[metaPrefix+"protocolVersion"], &version) != nil || version == "" {
 		fail(w, 400, req.ID, -32602, "Version and client capabilities required")
-		return
+		return false
+	}
+	var capabilities map[string]json.RawMessage
+	if json.Unmarshal(meta[metaPrefix+"clientCapabilities"], &capabilities) != nil || capabilities == nil {
+		fail(w, 400, req.ID, -32602, "Version and client capabilities required")
+		return false
 	}
 	if !matchesHeader(r, "MCP-Protocol-Version", version) || !matchesHeader(r, "Mcp-Method", req.Method) {
 		fail(w, 400, req.ID, -32020, "Request header mismatch")
-		return
+		return false
 	}
 	if version != ProtocolVersion {
 		reply(w, 400, req.ID, nil, &rpcError{Code: -32022, Message: "Unsupported protocol version", Data: map[string]any{"supported": []string{ProtocolVersion}, "requested": version}})
+		return false
+	}
+	return true
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !s.validateTransport(w, r) {
+		return
+	}
+	principal, ok := s.authenticateRequest(w, r)
+	if !ok {
+		return
+	}
+	if !validateMediaHeaders(w, r) {
+		return
+	}
+	req, params, ok := s.decodeRequest(w, r)
+	if !ok || !validateRequestMetadata(w, r, req, params) {
 		return
 	}
 	info := map[string]any{metaPrefix + "serverInfo": map[string]string{"name": "k8e-sandbox", "version": s.version}}
@@ -236,48 +298,39 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		reply(w, 200, req.ID, map[string]any{"resultType": "complete", "tools": tools, "ttlMs": 0, "cacheScope": "private", "_meta": info}, nil)
 	case "tools/call":
-		var name string
-		if json.Unmarshal(params["name"], &name) != nil || name == "" {
-			fail(w, 400, req.ID, -32602, "Tool name required")
+		name, args, valid := toolCallArguments(w, r, req.ID, params)
+		if !valid {
 			return
 		}
-		if !matchesHeader(r, "Mcp-Name", name) {
-			fail(w, 400, req.ID, -32020, "Tool header mismatch")
-			return
-		}
-		args := params["arguments"]
-		if len(args) == 0 {
-			args = json.RawMessage(`{}`)
-		}
-		var object map[string]json.RawMessage
-		if json.Unmarshal(args, &object) != nil || object == nil {
-			fail(w, 400, req.ID, -32602, "Object arguments required")
-			return
-		}
-		for _, t := range s.tools {
-			if t.Name == name {
-				ctx, cancel := context.WithTimeout(r.Context(), s.timeout)
-				defer cancel()
-				result, err := t.Call(ctx, principal, args)
-				if err != nil {
-					var invalid *InvalidParams
-					if errors.As(err, &invalid) {
-						fail(w, 400, req.ID, -32602, invalid.Message)
-						return
-					}
-					result = CallResult{IsError: true, Content: []TextContent{{Type: "text", Text: "Sandbox operation failed"}}}
-				}
-				if result.Content == nil {
-					result.Content = []TextContent{}
-				}
-				reply(w, 200, req.ID, map[string]any{"resultType": "complete", "content": result.Content, "structuredContent": result.StructuredContent, "isError": result.IsError, "_meta": info}, nil)
-				return
-			}
-		}
-		fail(w, 400, req.ID, -32602, "Unknown tool")
+		s.invokeTool(w, r, principal, req.ID, name, args, info)
 	default:
 		fail(w, 404, req.ID, -32601, "Method not found")
 	}
+}
+
+func (s *Server) invokeTool(w http.ResponseWriter, r *http.Request, principal Principal, id json.RawMessage, name string, args json.RawMessage, info map[string]any) {
+	for _, tool := range s.tools {
+		if tool.Name != name {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), s.timeout)
+		defer cancel()
+		result, err := tool.Call(ctx, principal, args)
+		if err != nil {
+			var invalid *InvalidParams
+			if errors.As(err, &invalid) {
+				fail(w, 400, id, -32602, invalid.Message)
+				return
+			}
+			result = CallResult{IsError: true, Content: []TextContent{{Type: "text", Text: "Sandbox operation failed"}}}
+		}
+		if result.Content == nil {
+			result.Content = []TextContent{}
+		}
+		reply(w, 200, id, map[string]any{"resultType": "complete", "content": result.Content, "structuredContent": result.StructuredContent, "isError": result.IsError, "_meta": info}, nil)
+		return
+	}
+	fail(w, 400, id, -32602, "Unknown tool")
 }
 
 func validID(id json.RawMessage) bool {
@@ -293,6 +346,28 @@ func validID(id json.RawMessage) bool {
 		return true
 	}
 	return false
+}
+
+func toolCallArguments(w http.ResponseWriter, r *http.Request, id json.RawMessage, params map[string]json.RawMessage) (string, json.RawMessage, bool) {
+	var name string
+	if json.Unmarshal(params["name"], &name) != nil || name == "" {
+		fail(w, 400, id, -32602, "Tool name required")
+		return "", nil, false
+	}
+	if !matchesHeader(r, "Mcp-Name", name) {
+		fail(w, 400, id, -32020, "Tool header mismatch")
+		return "", nil, false
+	}
+	args := params["arguments"]
+	if len(args) == 0 {
+		args = json.RawMessage(`{}`)
+	}
+	var object map[string]json.RawMessage
+	if json.Unmarshal(args, &object) != nil || object == nil {
+		fail(w, 400, id, -32602, "Object arguments required")
+		return "", nil, false
+	}
+	return name, args, true
 }
 func matchesHeader(r *http.Request, key, want string) bool {
 	values := r.Header.Values(key)

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -1,0 +1,322 @@
+// Package sandboxmcp implements the MCP 2026-07-28 HTTP boundary. It does not
+// authenticate users or own sandbox state: both are explicit dependencies.
+package sandboxmcp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const ProtocolVersion = "2026-07-28"
+const metaPrefix = "io.modelcontextprotocol/"
+
+// Principal is established by authentication, never by tool arguments.
+type Principal struct{ ID string }
+type Authenticate func(*http.Request) (Principal, error)
+
+type TextContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+type CallResult struct {
+	Content           []TextContent `json:"content"`
+	StructuredContent any           `json:"structuredContent,omitempty"`
+	IsError           bool          `json:"isError,omitempty"`
+}
+
+// Tool handlers must validate arguments and enforce principal ownership before
+// side effects. InputSchema is descriptive; the protocol boundary is not a
+// general-purpose JSON Schema interpreter.
+type Tool struct {
+	Name        string                                                                `json:"name"`
+	Description string                                                                `json:"description"`
+	InputSchema json.RawMessage                                                       `json:"inputSchema"`
+	Call        func(context.Context, Principal, json.RawMessage) (CallResult, error) `json:"-"`
+}
+
+// InvalidParams is a public-safe argument validation failure from a handler.
+// Other errors are deliberately hidden to avoid leaking backend internals.
+type InvalidParams struct{ Message string }
+
+func (e *InvalidParams) Error() string { return e.Message }
+
+type Config struct {
+	Authenticate    Authenticate
+	Tools           []Tool
+	AllowedOrigins  []string
+	Version         string
+	MaxRequestBytes int64
+	Timeout         time.Duration
+}
+
+type Server struct {
+	auth     Authenticate
+	tools    []Tool
+	origins  map[string]bool
+	version  string
+	maxBytes int64
+	timeout  time.Duration
+}
+
+// New validates configuration and snapshots tool schemas. Mount the returned
+// handler at /mcp on an HTTPS server with transport timeouts and request limits.
+// No listener is started, and there is no anonymous fallback.
+func New(c Config) (*Server, error) {
+	if c.Authenticate == nil {
+		return nil, errors.New("MCP authentication is required")
+	}
+	if c.MaxRequestBytes == 0 {
+		c.MaxRequestBytes = 1 << 20
+	}
+	if c.Timeout == 0 {
+		c.Timeout = 30 * time.Second
+	}
+	if c.MaxRequestBytes < 1 || c.Timeout < 0 {
+		return nil, errors.New("invalid MCP limits")
+	}
+	s := &Server{auth: c.Authenticate, version: c.Version, maxBytes: c.MaxRequestBytes, timeout: c.Timeout, origins: map[string]bool{}}
+	seen := map[string]bool{}
+	for _, t := range c.Tools {
+		if t.Name == "" || seen[t.Name] || t.Call == nil {
+			return nil, fmt.Errorf("invalid or duplicate MCP tool %q", t.Name)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(t.InputSchema, &schema); err != nil || schema == nil {
+			return nil, fmt.Errorf("invalid schema for %q", t.Name)
+		}
+		t.InputSchema = append(json.RawMessage(nil), t.InputSchema...)
+		seen[t.Name] = true
+		s.tools = append(s.tools, t)
+	}
+	sort.Slice(s.tools, func(i, j int) bool { return s.tools[i].Name < s.tools[j].Name })
+	for _, o := range c.AllowedOrigins {
+		if o == "" || o == "*" || o == "null" {
+			return nil, errors.New("explicit origins required")
+		}
+		s.origins[o] = true
+	}
+	return s, nil
+}
+
+type request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func reply(w http.ResponseWriter, status int, id json.RawMessage, result any, err *rpcError) {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	body := map[string]any{"jsonrpc": "2.0", "id": id}
+	if err != nil {
+		body["error"] = err
+	} else {
+		body["result"] = result
+	}
+	data, encodeErr := json.Marshal(body)
+	if encodeErr != nil {
+		status = http.StatusInternalServerError
+		data = []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Response encoding failed"}}`)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_, _ = w.Write(data)
+}
+func fail(w http.ResponseWriter, status int, id json.RawMessage, code int, msg string) {
+	reply(w, status, id, nil, &rpcError{Code: code, Message: msg})
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		fail(w, 405, nil, -32600, "Only POST is supported")
+		return
+	}
+	if origins := r.Header.Values("Origin"); len(origins) > 0 && (len(origins) != 1 || !s.origins[origins[0]]) {
+		fail(w, 403, nil, -32600, "Origin rejected")
+		return
+	}
+	principal, err := s.auth(r)
+	if err != nil || principal.ID == "" {
+		fail(w, 401, nil, -32000, "Authentication required")
+		return
+	}
+	media, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || media != "application/json" {
+		fail(w, 415, nil, -32600, "Content-Type must be application/json")
+		return
+	}
+	if !accepts(r, "application/json") || !accepts(r, "text/event-stream") {
+		fail(w, 406, nil, -32600, "Accept must include application/json and text/event-stream")
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, s.maxBytes))
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			fail(w, 413, nil, -32600, "Request too large")
+		} else {
+			fail(w, 400, nil, -32700, "Cannot read request")
+		}
+		return
+	}
+	if !utf8.Valid(body) || !json.Valid(body) {
+		fail(w, 400, nil, -32700, "Invalid JSON")
+		return
+	}
+	var req request
+	if err := json.Unmarshal(body, &req); err != nil || req.JSONRPC != "2.0" || req.Method == "" || !validID(req.ID) {
+		fail(w, 400, nil, -32600, "Invalid request")
+		return
+	}
+	var params map[string]json.RawMessage
+	if json.Unmarshal(req.Params, &params) != nil || params == nil {
+		fail(w, 400, req.ID, -32602, "Object params required")
+		return
+	}
+	var meta map[string]json.RawMessage
+	if json.Unmarshal(params["_meta"], &meta) != nil || meta == nil {
+		fail(w, 400, req.ID, -32602, "Request metadata required")
+		return
+	}
+	var version string
+	var capabilities map[string]json.RawMessage
+	if json.Unmarshal(meta[metaPrefix+"protocolVersion"], &version) != nil || version == "" || json.Unmarshal(meta[metaPrefix+"clientCapabilities"], &capabilities) != nil || capabilities == nil {
+		fail(w, 400, req.ID, -32602, "Version and client capabilities required")
+		return
+	}
+	if !matchesHeader(r, "MCP-Protocol-Version", version) || !matchesHeader(r, "Mcp-Method", req.Method) {
+		fail(w, 400, req.ID, -32020, "Request header mismatch")
+		return
+	}
+	if version != ProtocolVersion {
+		reply(w, 400, req.ID, nil, &rpcError{Code: -32022, Message: "Unsupported protocol version", Data: map[string]any{"supported": []string{ProtocolVersion}, "requested": version}})
+		return
+	}
+	info := map[string]any{metaPrefix + "serverInfo": map[string]string{"name": "k8e-sandbox", "version": s.version}}
+	switch req.Method {
+	case "server/discover":
+		reply(w, 200, req.ID, map[string]any{"resultType": "complete", "supportedVersions": []string{ProtocolVersion}, "capabilities": map[string]any{"tools": map[string]any{}}, "_meta": info, "ttlMs": 0, "cacheScope": "private"}, nil)
+	case "tools/list":
+		if cursor, ok := params["cursor"]; ok && string(cursor) != `""` {
+			fail(w, 400, req.ID, -32602, "Unsupported cursor")
+			return
+		}
+		tools := s.tools
+		if tools == nil {
+			tools = []Tool{}
+		}
+		reply(w, 200, req.ID, map[string]any{"resultType": "complete", "tools": tools, "ttlMs": 0, "cacheScope": "private", "_meta": info}, nil)
+	case "tools/call":
+		var name string
+		if json.Unmarshal(params["name"], &name) != nil || name == "" {
+			fail(w, 400, req.ID, -32602, "Tool name required")
+			return
+		}
+		if !matchesHeader(r, "Mcp-Name", name) {
+			fail(w, 400, req.ID, -32020, "Tool header mismatch")
+			return
+		}
+		args := params["arguments"]
+		if len(args) == 0 {
+			args = json.RawMessage(`{}`)
+		}
+		var object map[string]json.RawMessage
+		if json.Unmarshal(args, &object) != nil || object == nil {
+			fail(w, 400, req.ID, -32602, "Object arguments required")
+			return
+		}
+		for _, t := range s.tools {
+			if t.Name == name {
+				ctx, cancel := context.WithTimeout(r.Context(), s.timeout)
+				defer cancel()
+				result, err := t.Call(ctx, principal, args)
+				if err != nil {
+					var invalid *InvalidParams
+					if errors.As(err, &invalid) {
+						fail(w, 400, req.ID, -32602, invalid.Message)
+						return
+					}
+					result = CallResult{IsError: true, Content: []TextContent{{Type: "text", Text: "Sandbox operation failed"}}}
+				}
+				if result.Content == nil {
+					result.Content = []TextContent{}
+				}
+				reply(w, 200, req.ID, map[string]any{"resultType": "complete", "content": result.Content, "structuredContent": result.StructuredContent, "isError": result.IsError, "_meta": info}, nil)
+				return
+			}
+		}
+		fail(w, 400, req.ID, -32602, "Unknown tool")
+	default:
+		fail(w, 404, req.ID, -32601, "Method not found")
+	}
+}
+
+func validID(id json.RawMessage) bool {
+	if len(id) == 0 || string(id) == "null" {
+		return false
+	}
+	var v any
+	if json.Unmarshal(id, &v) != nil {
+		return false
+	}
+	switch v.(type) {
+	case string, float64:
+		return true
+	}
+	return false
+}
+func matchesHeader(r *http.Request, key, want string) bool {
+	values := r.Header.Values(key)
+	if len(values) != 1 {
+		return false
+	}
+	value := values[0]
+	if strings.HasPrefix(value, "=?base64?") && strings.HasSuffix(value, "?=") {
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSuffix(strings.TrimPrefix(value, "=?base64?"), "?="))
+		if err != nil || !utf8.Valid(decoded) {
+			return false
+		}
+		value = string(decoded)
+	}
+	return value == want
+}
+func accepts(r *http.Request, want string) bool {
+	for _, line := range r.Header.Values("Accept") {
+		for _, part := range strings.Split(line, ",") {
+			typ, p, err := mime.ParseMediaType(strings.TrimSpace(part))
+			quality := 1.0
+			if raw, ok := p["q"]; ok {
+				var qerr error
+				quality, qerr = strconv.ParseFloat(raw, 64)
+				if qerr != nil {
+					continue
+				}
+			}
+			if err == nil && typ == want && quality > 0 && quality <= 1 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -20,7 +20,12 @@ import (
 
 // ProtocolVersion is the MCP revision implemented by this HTTP boundary.
 const ProtocolVersion = "2026-07-28"
-const metaPrefix = "io.modelcontextprotocol/"
+
+const (
+	metaPrefix           = "io.modelcontextprotocol/"
+	mediaTypeJSON        = "application/json"
+	mediaTypeEventStream = "text/event-stream"
+)
 
 // Principal is established by authentication, never by tool arguments.
 type Principal struct{ ID string }
@@ -199,7 +204,7 @@ func reply(w http.ResponseWriter, status int, id json.RawMessage, result any, er
 		status = http.StatusInternalServerError
 		data = []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Response encoding failed"}}`)
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", mediaTypeJSON)
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
@@ -223,11 +228,11 @@ func (s *Server) validateTransport(w http.ResponseWriter, r *http.Request) bool 
 
 func validateMediaHeaders(w http.ResponseWriter, r *http.Request) bool {
 	media, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if err != nil || media != "application/json" {
+	if err != nil || media != mediaTypeJSON {
 		fail(w, 415, nil, -32600, "Content-Type must be application/json")
 		return false
 	}
-	if !accepts(r, "application/json") || !accepts(r, "text/event-stream") {
+	if !accepts(r, mediaTypeJSON) || !accepts(r, mediaTypeEventStream) {
 		fail(w, 406, nil, -32600, "Accept must include application/json and text/event-stream")
 		return false
 	}

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -94,8 +94,8 @@ type Server struct {
 }
 
 // New validates configuration and snapshots tool schemas. Mount the returned
-// handler at /mcp on an HTTPS server with transport timeouts and request limits.
-// No listener is started, and there is no anonymous fallback.
+// handler at /mcp behind an HTTPS listener with transport timeouts and request
+// limits. No listener is started, and there is no anonymous fallback.
 func New(c Config) (*Server, error) {
 	if err := normalizeConfig(&c); err != nil {
 		return nil, err

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -18,48 +18,72 @@ import (
 	"unicode/utf8"
 )
 
+// ProtocolVersion is the MCP revision implemented by this HTTP boundary.
 const ProtocolVersion = "2026-07-28"
 const metaPrefix = "io.modelcontextprotocol/"
 
 // Principal is established by authentication, never by tool arguments.
 type Principal struct{ ID string }
+
+// Authenticate validates an HTTP request and returns its stable caller identity.
 type Authenticate func(*http.Request) (Principal, error)
 
+// TextContent is a plain-text MCP content item.
 type TextContent struct {
+	// Type is the MCP content discriminator and is normally "text".
 	Type string `json:"type"`
+	// Text contains the public-safe tool response.
 	Text string `json:"text"`
 }
+
+// CallResult is the result returned by an MCP tool handler.
 type CallResult struct {
-	Content           []TextContent `json:"content"`
-	StructuredContent any           `json:"structuredContent,omitempty"`
-	IsError           bool          `json:"isError,omitempty"`
+	// Content is the human-readable MCP result content.
+	Content []TextContent `json:"content"`
+	// StructuredContent carries the machine-readable result when available.
+	StructuredContent any `json:"structuredContent,omitempty"`
+	// IsError reports a tool-level failure inside a successful JSON-RPC response.
+	IsError bool `json:"isError,omitempty"`
 }
 
 // Tool handlers must validate arguments and enforce principal ownership before
 // side effects. InputSchema is descriptive; the protocol boundary is not a
 // general-purpose JSON Schema interpreter.
 type Tool struct {
-	Name        string                                                                `json:"name"`
-	Description string                                                                `json:"description"`
-	InputSchema json.RawMessage                                                       `json:"inputSchema"`
-	Call        func(context.Context, Principal, json.RawMessage) (CallResult, error) `json:"-"`
+	// Name is the stable identifier clients use with tools/call.
+	Name string `json:"name"`
+	// Description explains the operation and its retry behavior.
+	Description string `json:"description"`
+	// InputSchema describes the accepted JSON arguments.
+	InputSchema json.RawMessage `json:"inputSchema"`
+	// Call executes the tool for an authenticated principal.
+	Call func(context.Context, Principal, json.RawMessage) (CallResult, error) `json:"-"`
 }
 
 // InvalidParams is a public-safe argument validation failure from a handler.
 // Other errors are deliberately hidden to avoid leaking backend internals.
 type InvalidParams struct{ Message string }
 
+// Error returns the public-safe validation message.
 func (e *InvalidParams) Error() string { return e.Message }
 
+// Config defines the authenticated MCP handler and its transport limits.
 type Config struct {
-	Authenticate    Authenticate
-	Tools           []Tool
-	AllowedOrigins  []string
-	Version         string
+	// Authenticate is required and runs for every request.
+	Authenticate Authenticate
+	// Tools is snapshotted and sorted when the server is constructed.
+	Tools []Tool
+	// AllowedOrigins lists explicit browser origins accepted by the handler.
+	AllowedOrigins []string
+	// Version identifies the server implementation in MCP metadata.
+	Version string
+	// MaxRequestBytes caps the JSON request body size.
 	MaxRequestBytes int64
-	Timeout         time.Duration
+	// Timeout caps each tool invocation.
+	Timeout time.Duration
 }
 
+// Server is an authenticated MCP HTTP handler with immutable tool schemas.
 type Server struct {
 	auth     Authenticate
 	tools    []Tool
@@ -268,6 +292,7 @@ func validateRequestMetadata(w http.ResponseWriter, r *http.Request, req request
 	return true
 }
 
+// ServeHTTP validates the MCP transport envelope and dispatches one JSON-RPC request.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !s.validateTransport(w, r) {
 		return

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -81,6 +81,10 @@ type Config struct {
 	MaxRequestBytes int64
 	// Timeout caps each tool invocation.
 	Timeout time.Duration
+	// Ready optionally verifies downstream dependencies (durable state and the
+	// sandbox gateway). A nil Ready keeps the handler process-health only, so
+	// /readyz reports ready whenever the process is serving.
+	Ready func(context.Context) error
 }
 
 // Server is an authenticated MCP HTTP handler with immutable tool schemas.
@@ -91,6 +95,7 @@ type Server struct {
 	version  string
 	maxBytes int64
 	timeout  time.Duration
+	ready    func(context.Context) error
 }
 
 // New validates configuration and snapshots tool schemas. Mount the returned
@@ -108,7 +113,16 @@ func New(c Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Server{auth: c.Authenticate, tools: tools, origins: origins, version: c.Version, maxBytes: c.MaxRequestBytes, timeout: c.Timeout}, nil
+	return &Server{auth: c.Authenticate, tools: tools, origins: origins, version: c.Version, maxBytes: c.MaxRequestBytes, timeout: c.Timeout, ready: c.Ready}, nil
+}
+
+// Ready reports whether the downstream dependencies this handler needs are
+// reachable. Callers should bound the context; a nil probe is always ready.
+func (s *Server) Ready(ctx context.Context) error {
+	if s.ready == nil {
+		return nil
+	}
+	return s.ready(ctx)
 }
 
 func normalizeConfig(c *Config) error {

--- a/pkg/sandboxmcp/server.go
+++ b/pkg/sandboxmcp/server.go
@@ -158,7 +158,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	principal, err := s.auth(r)
 	if err != nil || principal.ID == "" {
-		fail(w, 401, nil, -32000, "Authentication required")
+		status := http.StatusUnauthorized
+		var authErr *authenticationError
+		if errors.As(err, &authErr) {
+			status = authErr.status
+			if authErr.challenge != "" {
+				w.Header().Set("WWW-Authenticate", authErr.challenge)
+			}
+		}
+		fail(w, status, nil, -32000, "Authentication required")
 		return
 	}
 	media, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))

--- a/pkg/sandboxmcp/server_test.go
+++ b/pkg/sandboxmcp/server_test.go
@@ -1,6 +1,7 @@
 package sandboxmcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -121,6 +122,38 @@ func TestDiscoveryAndCallWithoutHandshake(t *testing.T) {
 		if method == "tools/call" && out.Result["isError"] != false {
 			t.Error("program failure became protocol error")
 		}
+	}
+}
+
+func TestGatewayTerminatedHTTP(t *testing.T) {
+	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
+		return CallResult{Content: []TextContent{{Type: "text", Text: "ready"}}}, nil
+	})
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", s)
+	original := newRequest("server/discover", nil)
+	body, err := io.ReadAll(original.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(body))
+	request.Host = "k8e-mcp.k8e-mcp.svc"
+	if request.TLS != nil {
+		t.Fatal("gateway backend request unexpectedly used TLS")
+	}
+	request.Header = original.Header.Clone()
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	var result struct {
+		Result struct {
+			ResultType string `json:"resultType"`
+		} `json:"result"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != http.StatusOK || result.Result.ResultType != "complete" {
+		t.Fatalf("status=%d result=%+v", response.Code, result)
 	}
 }
 func TestBackendErrorsAreSanitized(t *testing.T) {

--- a/pkg/sandboxmcp/server_test.go
+++ b/pkg/sandboxmcp/server_test.go
@@ -1,0 +1,255 @@
+package sandboxmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newRequest(method string, args any) *http.Request {
+	params := map[string]any{"_meta": map[string]any{metaPrefix + "protocolVersion": ProtocolVersion, metaPrefix + "clientCapabilities": map[string]any{}}}
+	if method == "tools/call" {
+		params["name"] = "exec"
+		params["arguments"] = args
+	}
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": "req-1", "method": method, "params": params})
+	r := httptest.NewRequest("POST", "/mcp", strings.NewReader(string(body)))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json, text/event-stream")
+	r.Header.Set("MCP-Protocol-Version", ProtocolVersion)
+	r.Header.Set("Mcp-Method", method)
+	if method == "tools/call" {
+		r.Header.Set("Mcp-Name", "exec")
+	}
+	r.Header.Set("Authorization", "alice")
+	return r
+}
+func testServer(t *testing.T, call func(context.Context, Principal, json.RawMessage) (CallResult, error)) *Server {
+	t.Helper()
+	s, err := New(Config{Version: "test", AllowedOrigins: []string{"https://allowed.example"}, Authenticate: func(r *http.Request) (Principal, error) {
+		id := r.Header.Get("Authorization")
+		if id == "" {
+			return Principal{}, errors.New("missing credential")
+		}
+		return Principal{ID: id}, nil
+	}, Tools: []Tool{{Name: "exec", Description: "Execute", InputSchema: json.RawMessage(`{"type":"object"}`), Call: call}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+func TestRejectedRequestsNeverInvokeBackend(t *testing.T) {
+	tests := []struct {
+		name         string
+		mutate       func(*http.Request)
+		status, code int
+	}{
+		{"anonymous", func(r *http.Request) { r.Header.Del("Authorization") }, 401, -32000},
+		{"origin", func(r *http.Request) { r.Header.Set("Origin", "https://evil.example") }, 403, -32600},
+		{"null origin", func(r *http.Request) { r.Header.Set("Origin", "null") }, 403, -32600},
+		{"duplicate origin", func(r *http.Request) {
+			r.Header.Add("Origin", "https://allowed.example")
+			r.Header.Add("Origin", "https://allowed.example")
+		}, 403, -32600},
+		{"wrong method header", func(r *http.Request) { r.Header.Set("Mcp-Method", "tools/list") }, 400, -32020},
+		{"wrong tool header", func(r *http.Request) { r.Header.Set("Mcp-Name", "destroy") }, 400, -32020},
+		{"duplicate version", func(r *http.Request) { r.Header.Add("MCP-Protocol-Version", ProtocolVersion) }, 400, -32020},
+		{"missing capabilities", func(r *http.Request) {
+			*r = *httptest.NewRequest("POST", "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{}}`))
+			r.Header = newRequest("tools/call", nil).Header
+		}, 400, -32602},
+		{"wrong content type", func(r *http.Request) { r.Header.Set("Content-Type", "text/plain") }, 415, -32600},
+		{"missing accept", func(r *http.Request) { r.Header.Del("Accept") }, 406, -32600},
+		{"null arguments", func(r *http.Request) { *r = *newRequest("tools/call", nil) }, 400, -32602},
+		{"GET", func(r *http.Request) { r.Method = "GET" }, 405, -32600},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
+				called = true
+				return CallResult{}, nil
+			})
+			r := newRequest("tools/call", map[string]any{})
+			tt.mutate(r)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, r)
+			var out struct{ Error rpcError }
+			if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+				t.Fatal(err)
+			}
+			if w.Code != tt.status || out.Error.Code != tt.code || called {
+				t.Fatalf("status=%d body=%s called=%v", w.Code, w.Body, called)
+			}
+		})
+	}
+}
+func TestDiscoveryAndCallWithoutHandshake(t *testing.T) {
+	s := testServer(t, func(ctx context.Context, p Principal, args json.RawMessage) (CallResult, error) {
+		if p.ID != "alice" {
+			t.Fatalf("principal=%v", p)
+		}
+		if _, ok := ctx.Deadline(); !ok {
+			t.Error("missing deadline")
+		}
+		return CallResult{Content: []TextContent{{Type: "text", Text: "failed"}}, StructuredContent: map[string]any{"exit_code": 17}}, nil
+	})
+	for _, method := range []string{"server/discover", "tools/list", "tools/call"} {
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, newRequest(method, map[string]any{}))
+		var out struct {
+			ID     string
+			Result map[string]any
+		}
+		json.Unmarshal(w.Body.Bytes(), &out)
+		if w.Code != 200 || out.ID != "req-1" || out.Result["resultType"] != "complete" {
+			t.Fatalf("%s: %s", method, w.Body)
+		}
+		if w.Header().Get("Mcp-Session-Id") != "" {
+			t.Error("protocol session created")
+		}
+		if method != "tools/call" && out.Result["cacheScope"] != "private" {
+			t.Error("unsafe caching")
+		}
+		if method == "tools/call" && out.Result["isError"] != false {
+			t.Error("program failure became protocol error")
+		}
+	}
+}
+func TestBackendErrorsAreSanitized(t *testing.T) {
+	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
+		return CallResult{}, errors.New("secret-backend-credential")
+	})
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, newRequest("tools/call", map[string]any{}))
+	if w.Code != 200 || strings.Contains(w.Body.String(), "secret-backend") || !strings.Contains(w.Body.String(), `"isError":true`) {
+		t.Fatal(w.Body)
+	}
+}
+func TestContextCancellationAndConcurrentIdentities(t *testing.T) {
+	s := testServer(t, func(ctx context.Context, p Principal, args json.RawMessage) (CallResult, error) {
+		if ctx.Err() == nil {
+			t.Error("cancelled request context not propagated")
+		}
+		var in struct{ ID string }
+		json.Unmarshal(args, &in)
+		if in.ID != p.ID {
+			t.Errorf("identity crossed requests: %s != %s", in.ID, p.ID)
+		}
+		return CallResult{}, ctx.Err()
+	})
+	var wg sync.WaitGroup
+	for _, id := range []string{"alice", "bob"} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			r := newRequest("tools/call", map[string]any{"ID": id})
+			r.Header.Set("Authorization", id)
+			ctx, cancel := context.WithCancel(r.Context())
+			cancel()
+			s.ServeHTTP(httptest.NewRecorder(), r.WithContext(ctx))
+		}(id)
+	}
+	wg.Wait()
+}
+func TestBodyLimitAndInvalidJSON(t *testing.T) {
+	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
+		t.Error("unexpected call")
+		return CallResult{}, nil
+	})
+	s.maxBytes = 8
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, newRequest("tools/call", map[string]any{}))
+	if w.Code != 413 {
+		t.Fatal(w.Code)
+	}
+	s.maxBytes = 1024
+	for _, body := range []string{`{`, `[]`, `null`, `{"jsonrpc":"2.0","id":null,"method":"tools/list"}`, "\xff"} {
+		r := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
+		r.Header = newRequest("tools/list", nil).Header
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, r)
+		if w.Code != 400 {
+			t.Fatalf("%q: %d", body, w.Code)
+		}
+	}
+}
+func TestSchemaSnapshotAndConfig(t *testing.T) {
+	if _, err := New(Config{}); err == nil {
+		t.Fatal("anonymous server allowed")
+	}
+	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) { return CallResult{}, nil })
+	if s.timeout != 30*time.Second {
+		t.Fatal("timeout default")
+	}
+}
+
+func TestUnsupportedVersionResponse(t *testing.T) {
+	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
+		t.Fatal("called")
+		return CallResult{}, nil
+	})
+	r := newRequest("server/discover", nil)
+	body := `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"1900-01-01","io.modelcontextprotocol/clientCapabilities":{}}}}`
+	r.Body = io.NopCloser(strings.NewReader(body))
+	r.Header.Set("MCP-Protocol-Version", "1900-01-01")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, r)
+	var out struct {
+		Error struct {
+			Code int
+			Data struct {
+				Supported []string
+				Requested string
+			}
+		}
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if w.Code != 400 || out.Error.Code != -32022 || len(out.Error.Data.Supported) != 1 || out.Error.Data.Supported[0] != ProtocolVersion || out.Error.Data.Requested != "1900-01-01" {
+		t.Fatal(w.Body)
+	}
+}
+func TestToolSchemaSnapshotAndStableOrder(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object"}`)
+	call := func(context.Context, Principal, json.RawMessage) (CallResult, error) { return CallResult{}, nil }
+	s, err := New(Config{Authenticate: func(*http.Request) (Principal, error) { return Principal{ID: "a"}, nil }, Tools: []Tool{
+		{Name: "z", InputSchema: schema, Call: call}, {Name: "a", InputSchema: schema, Call: call},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema[0] = '!'
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, newRequest("tools/list", nil))
+	var out struct{ Result struct{ Tools []Tool } }
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Result.Tools) != 2 || out.Result.Tools[0].Name != "a" || out.Result.Tools[1].Name != "z" {
+		t.Fatal(w.Body)
+	}
+}
+func TestInvalidParamsAndUnknownMethod(t *testing.T) {
+	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
+		return CallResult{}, &InvalidParams{Message: "session_id required"}
+	})
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, newRequest("tools/call", map[string]any{}))
+	if w.Code != 400 || !strings.Contains(w.Body.String(), `"code":-32602`) {
+		t.Fatal(w.Body)
+	}
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, newRequest("tasks/get", nil))
+	if w.Code != 404 || !strings.Contains(w.Body.String(), `"code":-32601`) {
+		t.Fatal(w.Body)
+	}
+}

--- a/pkg/sandboxmcp/server_test.go
+++ b/pkg/sandboxmcp/server_test.go
@@ -92,6 +92,32 @@ func TestRejectedRequestsNeverInvokeBackend(t *testing.T) {
 		})
 	}
 }
+
+// rpcEnvelope is the subset of a JSON-RPC response these tests assert on.
+type rpcEnvelope struct {
+	ID     string         `json:"id"`
+	Result map[string]any `json:"result"`
+}
+
+// assertCompleteResult verifies one stateless success response.
+func assertCompleteResult(t *testing.T, method string, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var out rpcEnvelope
+	json.Unmarshal(w.Body.Bytes(), &out)
+	if w.Code != 200 || out.ID != "req-1" || out.Result["resultType"] != "complete" {
+		t.Fatalf("%s: %s", method, w.Body)
+	}
+	if w.Header().Get("Mcp-Session-Id") != "" {
+		t.Error("protocol session created")
+	}
+	if method != "tools/call" && out.Result["cacheScope"] != "private" {
+		t.Error("unsafe caching")
+	}
+	if method == "tools/call" && out.Result["isError"] != false {
+		t.Error("program failure became protocol error")
+	}
+}
+
 func TestDiscoveryAndCallWithoutHandshake(t *testing.T) {
 	s := testServer(t, func(ctx context.Context, p Principal, _ json.RawMessage) (CallResult, error) {
 		if p.ID != "alice" {
@@ -105,23 +131,7 @@ func TestDiscoveryAndCallWithoutHandshake(t *testing.T) {
 	for _, method := range []string{"server/discover", "tools/list", "tools/call"} {
 		w := httptest.NewRecorder()
 		s.ServeHTTP(w, newRequest(method, map[string]any{}))
-		var out struct {
-			ID     string
-			Result map[string]any
-		}
-		json.Unmarshal(w.Body.Bytes(), &out)
-		if w.Code != 200 || out.ID != "req-1" || out.Result["resultType"] != "complete" {
-			t.Fatalf("%s: %s", method, w.Body)
-		}
-		if w.Header().Get("Mcp-Session-Id") != "" {
-			t.Error("protocol session created")
-		}
-		if method != "tools/call" && out.Result["cacheScope"] != "private" {
-			t.Error("unsafe caching")
-		}
-		if method == "tools/call" && out.Result["isError"] != false {
-			t.Error("program failure became protocol error")
-		}
+		assertCompleteResult(t, method, w)
 	}
 }
 
@@ -224,6 +234,21 @@ func TestSchemaSnapshotAndConfig(t *testing.T) {
 	}
 }
 
+// unsupportedVersionResponse mirrors the -32022 error payload asserted below.
+type unsupportedVersionResponse struct {
+	Error unsupportedVersionError `json:"error"`
+}
+
+type unsupportedVersionError struct {
+	Code int                    `json:"code"`
+	Data unsupportedVersionData `json:"data"`
+}
+
+type unsupportedVersionData struct {
+	Supported []string `json:"supported"`
+	Requested string   `json:"requested"`
+}
+
 func TestUnsupportedVersionResponse(t *testing.T) {
 	s := testServer(t, func(context.Context, Principal, json.RawMessage) (CallResult, error) {
 		t.Fatal("called")
@@ -235,15 +260,7 @@ func TestUnsupportedVersionResponse(t *testing.T) {
 	r.Header.Set("MCP-Protocol-Version", "1900-01-01")
 	w := httptest.NewRecorder()
 	s.ServeHTTP(w, r)
-	var out struct {
-		Error struct {
-			Code int
-			Data struct {
-				Supported []string
-				Requested string
-			}
-		}
-	}
+	var out unsupportedVersionResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sandboxmcp/server_test.go
+++ b/pkg/sandboxmcp/server_test.go
@@ -92,7 +92,7 @@ func TestRejectedRequestsNeverInvokeBackend(t *testing.T) {
 	}
 }
 func TestDiscoveryAndCallWithoutHandshake(t *testing.T) {
-	s := testServer(t, func(ctx context.Context, p Principal, args json.RawMessage) (CallResult, error) {
+	s := testServer(t, func(ctx context.Context, p Principal, _ json.RawMessage) (CallResult, error) {
 		if p.ID != "alice" {
 			t.Fatalf("principal=%v", p)
 		}

--- a/pkg/sandboxmcp/store.go
+++ b/pkg/sandboxmcp/store.go
@@ -14,26 +14,43 @@ import (
 	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-var ErrRecordMissing = errors.New("MCP record not found")
-var ErrRecordExists = errors.New("MCP record already exists")
+var (
+	// ErrRecordMissing indicates that durable MCP state does not exist.
+	ErrRecordMissing = errors.New("MCP record not found")
+	// ErrRecordExists indicates that an operation was already admitted atomically.
+	ErrRecordExists = errors.New("MCP record already exists")
+)
 
+// Record is a versioned ownership or operation result stored by the MCP service.
 type Record struct {
-	Owner     string          `json:"owner"`
-	Digest    string          `json:"digest,omitempty"`
-	State     string          `json:"state"`
-	SessionID string          `json:"session_id,omitempty"`
-	Result    json.RawMessage `json:"result,omitempty"`
-	Version   string          `json:"-"`
+	// Owner is the stable authenticated principal identifier.
+	Owner string `json:"owner"`
+	// Digest binds an admitted operation to its original arguments.
+	Digest string `json:"digest,omitempty"`
+	// State records whether an operation is admitted, complete, unknown, or owned.
+	State string `json:"state"`
+	// SessionID associates ownership and operation records with a sandbox.
+	SessionID string `json:"session_id,omitempty"`
+	// Result preserves a completed operation response for retry recovery.
+	Result json.RawMessage `json:"result,omitempty"`
+	// Version carries the storage resource version used for compare-and-swap updates.
+	Version string `json:"-"`
 }
 
+// RecordStore provides atomic creation and versioned updates for durable MCP state.
 type RecordStore interface {
+	// Create admits a new record and fails with ErrRecordExists on collision.
 	Create(context.Context, string, Record) (Record, error)
+	// Get loads an existing record.
 	Get(context.Context, string) (Record, error)
+	// Update replaces a record using its storage version.
 	Update(context.Context, string, Record) error
 }
 
+// KubernetesStore persists MCP records as Kubernetes ConfigMaps.
 type KubernetesStore struct{ maps typedcore.ConfigMapInterface }
 
+// NewKubernetesStore creates a record store using a namespace-scoped ConfigMap client.
 func NewKubernetesStore(maps typedcore.ConfigMapInterface) (*KubernetesStore, error) {
 	if maps == nil {
 		return nil, errors.New("ConfigMap client required")
@@ -70,6 +87,7 @@ func decodeRecord(configMap *corev1.ConfigMap) (Record, error) {
 	return record, nil
 }
 
+// Create atomically creates a ConfigMap-backed record.
 func (store *KubernetesStore) Create(ctx context.Context, key string, record Record) (Record, error) {
 	configMap, err := encodeRecord(key, record)
 	if err != nil {
@@ -85,6 +103,7 @@ func (store *KubernetesStore) Create(ctx context.Context, key string, record Rec
 	return decodeRecord(created)
 }
 
+// Get reads and validates a ConfigMap-backed record.
 func (store *KubernetesStore) Get(ctx context.Context, key string) (Record, error) {
 	configMap, err := store.maps.Get(ctx, key, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
@@ -96,6 +115,7 @@ func (store *KubernetesStore) Get(ctx context.Context, key string) (Record, erro
 	return decodeRecord(configMap)
 }
 
+// Update replaces a record using Kubernetes resource-version conflict detection.
 func (store *KubernetesStore) Update(ctx context.Context, key string, record Record) error {
 	if record.Version == "" {
 		return errors.New("record version required")

--- a/pkg/sandboxmcp/store.go
+++ b/pkg/sandboxmcp/store.go
@@ -1,0 +1,109 @@
+package sandboxmcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedcore "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var ErrRecordMissing = errors.New("MCP record not found")
+var ErrRecordExists = errors.New("MCP record already exists")
+
+type Record struct {
+	Owner     string          `json:"owner"`
+	Digest    string          `json:"digest,omitempty"`
+	State     string          `json:"state"`
+	SessionID string          `json:"session_id,omitempty"`
+	Result    json.RawMessage `json:"result,omitempty"`
+	Version   string          `json:"-"`
+}
+
+type RecordStore interface {
+	Create(context.Context, string, Record) (Record, error)
+	Get(context.Context, string) (Record, error)
+	Update(context.Context, string, Record) error
+}
+
+type KubernetesStore struct{ maps typedcore.ConfigMapInterface }
+
+func NewKubernetesStore(maps typedcore.ConfigMapInterface) (*KubernetesStore, error) {
+	if maps == nil {
+		return nil, errors.New("ConfigMap client required")
+	}
+	return &KubernetesStore{maps: maps}, nil
+}
+
+func recordKey(parts ...string) string {
+	encoded, _ := json.Marshal(parts)
+	digest := sha256.Sum256(encoded)
+	return "mcp-" + hex.EncodeToString(digest[:28])
+}
+
+func encodeRecord(key string, record Record) (*corev1.ConfigMap, error) {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 512*1024 {
+		return nil, errors.New("MCP record exceeds size limit")
+	}
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: key, ResourceVersion: record.Version, Labels: map[string]string{"k8e.sh/mcp-state": "true"}}, Data: map[string]string{"record": string(data)}}, nil
+}
+
+func decodeRecord(configMap *corev1.ConfigMap) (Record, error) {
+	var record Record
+	if err := json.Unmarshal([]byte(configMap.Data["record"]), &record); err != nil {
+		return record, fmt.Errorf("invalid MCP state: %w", err)
+	}
+	if record.Owner == "" || record.State == "" {
+		return record, errors.New("incomplete MCP state")
+	}
+	record.Version = configMap.ResourceVersion
+	return record, nil
+}
+
+func (store *KubernetesStore) Create(ctx context.Context, key string, record Record) (Record, error) {
+	configMap, err := encodeRecord(key, record)
+	if err != nil {
+		return Record{}, err
+	}
+	created, err := store.maps.Create(ctx, configMap, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return Record{}, ErrRecordExists
+	}
+	if err != nil {
+		return Record{}, err
+	}
+	return decodeRecord(created)
+}
+
+func (store *KubernetesStore) Get(ctx context.Context, key string) (Record, error) {
+	configMap, err := store.maps.Get(ctx, key, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return Record{}, ErrRecordMissing
+	}
+	if err != nil {
+		return Record{}, err
+	}
+	return decodeRecord(configMap)
+}
+
+func (store *KubernetesStore) Update(ctx context.Context, key string, record Record) error {
+	if record.Version == "" {
+		return errors.New("record version required")
+	}
+	configMap, err := encodeRecord(key, record)
+	if err != nil {
+		return err
+	}
+	_, err = store.maps.Update(ctx, configMap, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/sandboxmcp/tools.go
+++ b/pkg/sandboxmcp/tools.go
@@ -105,7 +105,7 @@ func parseArguments(raw json.RawMessage, fields, required []string) (arguments, 
 	if err := decoder.Decode(&parsed); err != nil {
 		return parsed, &InvalidParams{Message: "Invalid arguments"}
 	}
-	if err := decoder.Decode(new(any)); err != io.EOF {
+	if decoder.Decode(new(any)) != io.EOF {
 		return parsed, &InvalidParams{Message: "Invalid arguments"}
 	}
 	if _, ok := values["timeout"]; ok && (parsed.Timeout < 1 || parsed.Timeout > 3600) {

--- a/pkg/sandboxmcp/tools.go
+++ b/pkg/sandboxmcp/tools.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Service exposes sandbox gRPC operations as authenticated MCP tools.
 type Service struct {
 	backend pb.SandboxServiceClient
 	store   RecordStore
@@ -33,6 +34,7 @@ type arguments struct {
 	Timeout       int32  `json:"timeout,omitempty"`
 }
 
+// NewService creates a tool service backed by the sandbox gateway and durable state.
 func NewService(backend pb.SandboxServiceClient, store RecordStore) (*Service, error) {
 	if backend == nil || store == nil {
 		return nil, errors.New("backend and durable store required")
@@ -40,6 +42,7 @@ func NewService(backend pb.SandboxServiceClient, store RecordStore) (*Service, e
 	return &Service{backend: backend, store: store}, nil
 }
 
+// Tools returns the sandbox tool definitions bound to this service.
 func (service *Service) Tools() []Tool {
 	definitions := []struct {
 		name, description string

--- a/pkg/sandboxmcp/tools.go
+++ b/pkg/sandboxmcp/tools.go
@@ -1,0 +1,297 @@
+package sandboxmcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type Service struct {
+	backend pb.SandboxServiceClient
+	store   RecordStore
+}
+
+type arguments struct {
+	OperationID   string `json:"operation_id,omitempty"`
+	OperationKind string `json:"operation_kind,omitempty"`
+	SessionID     string `json:"session_id,omitempty"`
+	RunID         string `json:"run_id,omitempty"`
+	Command       string `json:"command,omitempty"`
+	Path          string `json:"path,omitempty"`
+	Content       string `json:"content,omitempty"`
+	Timeout       int32  `json:"timeout,omitempty"`
+}
+
+func NewService(backend pb.SandboxServiceClient, store RecordStore) (*Service, error) {
+	if backend == nil || store == nil {
+		return nil, errors.New("backend and durable store required")
+	}
+	return &Service{backend: backend, store: store}, nil
+}
+
+func (service *Service) Tools() []Tool {
+	definitions := []struct {
+		name, description string
+		fields, required  []string
+	}{
+		{"sandbox_create", "Create a gVisor sandbox; reuse operation_id on retries.", []string{"operation_id"}, []string{"operation_id"}},
+		{"sandbox_get", "Get an owned sandbox.", []string{"session_id"}, []string{"session_id"}},
+		{"sandbox_destroy", "Destroy an owned sandbox.", []string{"session_id", "operation_id"}, []string{"session_id", "operation_id"}},
+		{"sandbox_exec", "Submit a background shell command. Poll run_id; reuse operation_id on retries.", []string{"session_id", "operation_id", "command", "timeout"}, []string{"session_id", "operation_id", "command"}},
+		{"sandbox_poll", "Poll an owned background run.", []string{"run_id"}, []string{"run_id"}},
+		{"sandbox_read", "Read at most 256 KiB of an owned sandbox file as base64.", []string{"session_id", "path"}, []string{"session_id", "path"}},
+		{"sandbox_write", "Write UTF-8 text to an owned sandbox file.", []string{"session_id", "operation_id", "path", "content"}, []string{"session_id", "operation_id", "path", "content"}},
+		{"sandbox_list", "List files in an owned sandbox.", []string{"session_id"}, []string{"session_id"}},
+		{"sandbox_operation", "Recover a submission result using its operation_id and tool name as operation_kind. Unknown submissions are never automatically resubmitted.", []string{"operation_id", "operation_kind"}, []string{"operation_id", "operation_kind"}},
+	}
+	var tools []Tool
+	for _, definition := range definitions {
+		properties := map[string]any{}
+		for _, field := range definition.fields {
+			limit := 256
+			if field == "command" || field == "content" {
+				limit = 256 * 1024
+			}
+			minimum := 1
+			if field == "content" {
+				minimum = 0
+			}
+			properties[field] = map[string]any{"type": "string", "minLength": minimum, "maxLength": limit}
+			if field == "timeout" {
+				properties[field] = map[string]any{"type": "integer", "minimum": 1, "maximum": 3600, "default": 30}
+			}
+		}
+		schema, _ := json.Marshal(map[string]any{"type": "object", "properties": properties, "required": definition.required, "additionalProperties": false})
+		name, fields, required := definition.name, definition.fields, definition.required
+		tools = append(tools, Tool{Name: name, Description: definition.description, InputSchema: schema, Call: func(ctx context.Context, principal Principal, raw json.RawMessage) (CallResult, error) {
+			parsed, err := parseArguments(raw, fields, required)
+			if err != nil {
+				return CallResult{}, err
+			}
+			return service.call(ctx, principal, name, parsed)
+		}})
+	}
+	return tools
+}
+
+func parseArguments(raw json.RawMessage, fields, required []string) (arguments, error) {
+	var parsed arguments
+	var values map[string]json.RawMessage
+	if json.Unmarshal(raw, &values) != nil || values == nil {
+		return parsed, &InvalidParams{Message: "Object arguments required"}
+	}
+	allowed := map[string]bool{}
+	for _, field := range fields {
+		allowed[field] = true
+	}
+	for field, value := range values {
+		if !allowed[field] || bytes.Equal(value, []byte("null")) {
+			return parsed, &InvalidParams{Message: "Unexpected or null argument: " + field}
+		}
+		if field != "timeout" {
+			var text string
+			limit := 256
+			if field == "command" || field == "content" {
+				limit = 256 * 1024
+			}
+			if json.Unmarshal(value, &text) != nil || len(text) > limit || (field != "content" && strings.TrimSpace(text) == "") {
+				return parsed, &InvalidParams{Message: "Invalid argument: " + field}
+			}
+		}
+	}
+	for _, field := range required {
+		if _, ok := values[field]; !ok {
+			return parsed, &InvalidParams{Message: "Missing argument: " + field}
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&parsed); err != nil {
+		return parsed, &InvalidParams{Message: "Invalid arguments"}
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return parsed, &InvalidParams{Message: "Invalid arguments"}
+	}
+	if _, ok := values["timeout"]; ok && (parsed.Timeout < 1 || parsed.Timeout > 3600) {
+		return parsed, &InvalidParams{Message: "timeout must be between 1 and 3600"}
+	}
+	if parsed.Timeout == 0 {
+		parsed.Timeout = 30
+	}
+	return parsed, nil
+}
+
+func dataResult(value any) (CallResult, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return CallResult{}, err
+	}
+	return CallResult{Content: []TextContent{{Type: "text", Text: string(encoded)}}, StructuredContent: json.RawMessage(encoded)}, nil
+}
+
+func protoResult(message proto.Message) (CallResult, error) {
+	encoded, err := (protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}).Marshal(message)
+	if err != nil {
+		return CallResult{}, err
+	}
+	return dataResult(json.RawMessage(encoded))
+}
+
+func (service *Service) owner(ctx context.Context, principal Principal, kind, handle string) (Record, error) {
+	record, err := service.store.Get(ctx, recordKey(kind, handle))
+	if err != nil || record.Owner != principal.ID {
+		return Record{}, errors.New("resource inaccessible")
+	}
+	return record, nil
+}
+
+func (service *Service) call(ctx context.Context, principal Principal, name string, parsed arguments) (CallResult, error) {
+	if principal.ID == "" {
+		return CallResult{}, errors.New("principal required")
+	}
+	if name == "sandbox_operation" {
+		record, err := service.store.Get(ctx, recordKey("operation", principal.ID, parsed.OperationKind, parsed.OperationID))
+		if err != nil || record.Owner != principal.ID {
+			return CallResult{}, errors.New("operation inaccessible")
+		}
+		return operationResult(record, parsed.OperationID)
+	}
+	if name == "sandbox_poll" {
+		if _, err := service.owner(ctx, principal, "run", parsed.RunID); err != nil {
+			return CallResult{}, err
+		}
+		response, err := service.backend.PollRun(ctx, &pb.PollRunRequest{RunId: parsed.RunID})
+		if err != nil {
+			return CallResult{}, err
+		}
+		return protoResult(response)
+	}
+	if name != "sandbox_create" {
+		if _, err := service.owner(ctx, principal, "session", parsed.SessionID); err != nil {
+			return CallResult{}, err
+		}
+	}
+	switch name {
+	case "sandbox_get":
+		response, err := service.backend.GetSession(ctx, &pb.GetSessionRequest{SessionId: parsed.SessionID})
+		if err != nil {
+			return CallResult{}, err
+		}
+		return protoResult(response)
+	case "sandbox_read":
+		response, err := service.backend.ReadFile(ctx, &pb.ReadFileRequest{SessionId: parsed.SessionID, Path: parsed.Path, Length: 256 * 1024, Encoding: "base64"})
+		if err != nil {
+			return CallResult{}, err
+		}
+		return protoResult(response)
+	case "sandbox_list":
+		response, err := service.backend.ListFiles(ctx, &pb.ListFilesRequest{SessionId: parsed.SessionID})
+		if err != nil {
+			return CallResult{}, err
+		}
+		return protoResult(response)
+	default:
+		return service.mutate(ctx, principal, name, parsed)
+	}
+}
+
+func operationResult(record Record, operationID string) (CallResult, error) {
+	if record.State == "complete" {
+		return dataResult(record.Result)
+	}
+	return dataResult(map[string]any{"status": "unknown", "operation_id": operationID, "session_id": record.SessionID, "retry_safe": false})
+}
+
+func (service *Service) mutate(ctx context.Context, principal Principal, name string, parsed arguments) (CallResult, error) {
+	encoded, _ := json.Marshal(parsed)
+	digest := sha256.Sum256(encoded)
+	key := recordKey("operation", principal.ID, name, parsed.OperationID)
+	record := Record{Owner: principal.ID, Digest: hex.EncodeToString(digest[:]), State: "unknown", SessionID: parsed.SessionID}
+	if name == "sandbox_create" {
+		identifier := make([]byte, 16)
+		if _, err := rand.Read(identifier); err != nil {
+			return CallResult{}, err
+		}
+		record.SessionID = "mcp-" + hex.EncodeToString(identifier)
+	}
+	created, err := service.store.Create(ctx, key, record)
+	if errors.Is(err, ErrRecordExists) {
+		previous, readErr := service.store.Get(ctx, key)
+		if readErr != nil {
+			return CallResult{}, readErr
+		}
+		if previous.Owner != principal.ID || previous.Digest != record.Digest {
+			return CallResult{}, &InvalidParams{Message: "operation_id already used with different arguments"}
+		}
+		return operationResult(previous, parsed.OperationID)
+	}
+	if err != nil {
+		return CallResult{}, err
+	}
+	record = created
+	var result CallResult
+	switch name {
+	case "sandbox_create":
+		_, err = service.store.Create(ctx, recordKey("session", record.SessionID), Record{Owner: principal.ID, State: "owned", SessionID: record.SessionID})
+		if err == nil {
+			var response *pb.CreateSessionResponse
+			response, err = service.backend.CreateSession(ctx, &pb.CreateSessionRequest{SessionId: record.SessionID, RuntimeClass: "gvisor"})
+			if err == nil && (response == nil || response.SessionId != record.SessionID) {
+				err = errors.New("backend changed session handle")
+			}
+			if err == nil {
+				result, err = dataResult(map[string]any{"session_id": record.SessionID})
+			}
+		}
+	case "sandbox_exec":
+		var response *pb.ExecResponse
+		response, err = service.backend.Exec(ctx, &pb.ExecRequest{SessionId: parsed.SessionID, Command: parsed.Command, Timeout: parsed.Timeout, Workdir: "/workspace", Background: true})
+		if err == nil && (response == nil || response.RunId == "") {
+			err = errors.New("missing run handle")
+		}
+		if err == nil {
+			_, err = service.store.Create(ctx, recordKey("run", response.RunId), Record{Owner: principal.ID, State: "owned", SessionID: parsed.SessionID})
+		}
+		if err == nil {
+			result, err = protoResult(response)
+		}
+	case "sandbox_destroy":
+		var response *pb.DestroySessionResponse
+		response, err = service.backend.DestroySession(ctx, &pb.DestroySessionRequest{SessionId: parsed.SessionID})
+		if err == nil {
+			result, err = protoResult(response)
+		}
+	case "sandbox_write":
+		var response *pb.WriteFileResponse
+		response, err = service.backend.WriteFile(ctx, &pb.WriteFileRequest{SessionId: parsed.SessionID, Path: parsed.Path, Content: parsed.Content, Mode: "w"})
+		if err == nil {
+			result, err = protoResult(response)
+		}
+	default:
+		err = fmt.Errorf("unsupported mutation")
+	}
+	if err != nil {
+		return operationResult(record, parsed.OperationID)
+	}
+	record.Result, err = json.Marshal(result.StructuredContent)
+	if err != nil {
+		return operationResult(record, parsed.OperationID)
+	}
+	record.State = "complete"
+	if err = service.store.Update(ctx, key, record); err != nil {
+		record.State = "unknown"
+		return operationResult(record, parsed.OperationID)
+	}
+	return result, nil
+}

--- a/pkg/sandboxmcp/tools.go
+++ b/pkg/sandboxmcp/tools.go
@@ -87,33 +87,15 @@ func (service *Service) Tools() []Tool {
 
 func parseArguments(raw json.RawMessage, fields, required []string) (arguments, error) {
 	var parsed arguments
-	var values map[string]json.RawMessage
-	if json.Unmarshal(raw, &values) != nil || values == nil {
-		return parsed, &InvalidParams{Message: "Object arguments required"}
+	values, err := decodeArgumentMap(raw)
+	if err != nil {
+		return parsed, err
 	}
-	allowed := map[string]bool{}
-	for _, field := range fields {
-		allowed[field] = true
+	if err := validateArgumentValues(values, fields); err != nil {
+		return parsed, err
 	}
-	for field, value := range values {
-		if !allowed[field] || bytes.Equal(value, []byte("null")) {
-			return parsed, &InvalidParams{Message: "Unexpected or null argument: " + field}
-		}
-		if field != "timeout" {
-			var text string
-			limit := 256
-			if field == "command" || field == "content" {
-				limit = 256 * 1024
-			}
-			if json.Unmarshal(value, &text) != nil || len(text) > limit || (field != "content" && strings.TrimSpace(text) == "") {
-				return parsed, &InvalidParams{Message: "Invalid argument: " + field}
-			}
-		}
-	}
-	for _, field := range required {
-		if _, ok := values[field]; !ok {
-			return parsed, &InvalidParams{Message: "Missing argument: " + field}
-		}
+	if err := requireArguments(values, required); err != nil {
+		return parsed, err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.DisallowUnknownFields()
@@ -130,6 +112,48 @@ func parseArguments(raw json.RawMessage, fields, required []string) (arguments, 
 		parsed.Timeout = 30
 	}
 	return parsed, nil
+}
+
+func decodeArgumentMap(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var values map[string]json.RawMessage
+	if json.Unmarshal(raw, &values) != nil || values == nil {
+		return nil, &InvalidParams{Message: "Object arguments required"}
+	}
+	return values, nil
+}
+
+func validateArgumentValues(values map[string]json.RawMessage, fields []string) error {
+	allowed := map[string]bool{}
+	for _, field := range fields {
+		allowed[field] = true
+	}
+	for field, value := range values {
+		if !allowed[field] || bytes.Equal(value, []byte("null")) {
+			return &InvalidParams{Message: "Unexpected or null argument: " + field}
+		}
+		if field != "timeout" && !validTextArgument(field, value) {
+			return &InvalidParams{Message: "Invalid argument: " + field}
+		}
+	}
+	return nil
+}
+
+func validTextArgument(field string, value json.RawMessage) bool {
+	var text string
+	limit := 256
+	if field == "command" || field == "content" {
+		limit = 256 * 1024
+	}
+	return json.Unmarshal(value, &text) == nil && len(text) <= limit && (field == "content" || strings.TrimSpace(text) != "")
+}
+
+func requireArguments(values map[string]json.RawMessage, required []string) error {
+	for _, field := range required {
+		if _, ok := values[field]; !ok {
+			return &InvalidParams{Message: "Missing argument: " + field}
+		}
+	}
+	return nil
 }
 
 func dataResult(value any) (CallResult, error) {
@@ -161,21 +185,10 @@ func (service *Service) call(ctx context.Context, principal Principal, name stri
 		return CallResult{}, errors.New("principal required")
 	}
 	if name == "sandbox_operation" {
-		record, err := service.store.Get(ctx, recordKey("operation", principal.ID, parsed.OperationKind, parsed.OperationID))
-		if err != nil || record.Owner != principal.ID {
-			return CallResult{}, errors.New("operation inaccessible")
-		}
-		return operationResult(record, parsed.OperationID)
+		return service.recoverOperation(ctx, principal, parsed)
 	}
 	if name == "sandbox_poll" {
-		if _, err := service.owner(ctx, principal, "run", parsed.RunID); err != nil {
-			return CallResult{}, err
-		}
-		response, err := service.backend.PollRun(ctx, &pb.PollRunRequest{RunId: parsed.RunID})
-		if err != nil {
-			return CallResult{}, err
-		}
-		return protoResult(response)
+		return service.pollRun(ctx, principal, parsed.RunID)
 	}
 	if name != "sandbox_create" {
 		if _, err := service.owner(ctx, principal, "session", parsed.SessionID); err != nil {
@@ -204,6 +217,84 @@ func (service *Service) call(ctx context.Context, principal Principal, name stri
 	default:
 		return service.mutate(ctx, principal, name, parsed)
 	}
+}
+
+func (service *Service) recoverOperation(ctx context.Context, principal Principal, parsed arguments) (CallResult, error) {
+	record, err := service.store.Get(ctx, recordKey("operation", principal.ID, parsed.OperationKind, parsed.OperationID))
+	if err != nil || record.Owner != principal.ID {
+		return CallResult{}, errors.New("operation inaccessible")
+	}
+	return operationResult(record, parsed.OperationID)
+}
+
+func (service *Service) pollRun(ctx context.Context, principal Principal, runID string) (CallResult, error) {
+	if _, err := service.owner(ctx, principal, "run", runID); err != nil {
+		return CallResult{}, err
+	}
+	response, err := service.backend.PollRun(ctx, &pb.PollRunRequest{RunId: runID})
+	if err != nil {
+		return CallResult{}, err
+	}
+	return protoResult(response)
+}
+
+func (service *Service) executeMutation(ctx context.Context, principal Principal, name string, parsed arguments, record Record) (CallResult, error) {
+	switch name {
+	case "sandbox_create":
+		return service.createSandbox(ctx, principal, record)
+	case "sandbox_exec":
+		return service.execSandbox(ctx, principal, parsed)
+	case "sandbox_destroy":
+		return service.destroySandbox(ctx, parsed)
+	case "sandbox_write":
+		return service.writeSandbox(ctx, parsed)
+	default:
+		return CallResult{}, fmt.Errorf("unsupported mutation")
+	}
+}
+
+func (service *Service) createSandbox(ctx context.Context, principal Principal, record Record) (CallResult, error) {
+	if _, err := service.store.Create(ctx, recordKey("session", record.SessionID), Record{Owner: principal.ID, State: "owned", SessionID: record.SessionID}); err != nil {
+		return CallResult{}, err
+	}
+	response, err := service.backend.CreateSession(ctx, &pb.CreateSessionRequest{SessionId: record.SessionID, RuntimeClass: "gvisor"})
+	if err != nil {
+		return CallResult{}, err
+	}
+	if response == nil || response.SessionId != record.SessionID {
+		return CallResult{}, errors.New("backend changed session handle")
+	}
+	return dataResult(map[string]any{"session_id": record.SessionID})
+}
+
+func (service *Service) execSandbox(ctx context.Context, principal Principal, parsed arguments) (CallResult, error) {
+	response, err := service.backend.Exec(ctx, &pb.ExecRequest{SessionId: parsed.SessionID, Command: parsed.Command, Timeout: parsed.Timeout, Workdir: "/workspace", Background: true})
+	if err != nil {
+		return CallResult{}, err
+	}
+	if response == nil || response.RunId == "" {
+		return CallResult{}, errors.New("missing run handle")
+	}
+	if _, err := service.store.Create(ctx, recordKey("run", response.RunId), Record{Owner: principal.ID, State: "owned", SessionID: parsed.SessionID}); err != nil {
+		return CallResult{}, err
+	}
+	return protoResult(response)
+}
+
+func (service *Service) destroySandbox(ctx context.Context, parsed arguments) (CallResult, error) {
+	response, err := service.backend.DestroySession(ctx, &pb.DestroySessionRequest{SessionId: parsed.SessionID})
+	if err != nil {
+		return CallResult{}, err
+	}
+	return protoResult(response)
+}
+
+func (service *Service) writeSandbox(ctx context.Context, parsed arguments) (CallResult, error) {
+	response, err := service.backend.WriteFile(ctx, &pb.WriteFileRequest{SessionId: parsed.SessionID, Path: parsed.Path, Content: parsed.Content, Mode: "w"})
+	if err != nil {
+		return CallResult{}, err
+	}
+	return protoResult(response)
 }
 
 func operationResult(record Record, operationID string) (CallResult, error) {
@@ -240,47 +331,7 @@ func (service *Service) mutate(ctx context.Context, principal Principal, name st
 		return CallResult{}, err
 	}
 	record = created
-	var result CallResult
-	switch name {
-	case "sandbox_create":
-		_, err = service.store.Create(ctx, recordKey("session", record.SessionID), Record{Owner: principal.ID, State: "owned", SessionID: record.SessionID})
-		if err == nil {
-			var response *pb.CreateSessionResponse
-			response, err = service.backend.CreateSession(ctx, &pb.CreateSessionRequest{SessionId: record.SessionID, RuntimeClass: "gvisor"})
-			if err == nil && (response == nil || response.SessionId != record.SessionID) {
-				err = errors.New("backend changed session handle")
-			}
-			if err == nil {
-				result, err = dataResult(map[string]any{"session_id": record.SessionID})
-			}
-		}
-	case "sandbox_exec":
-		var response *pb.ExecResponse
-		response, err = service.backend.Exec(ctx, &pb.ExecRequest{SessionId: parsed.SessionID, Command: parsed.Command, Timeout: parsed.Timeout, Workdir: "/workspace", Background: true})
-		if err == nil && (response == nil || response.RunId == "") {
-			err = errors.New("missing run handle")
-		}
-		if err == nil {
-			_, err = service.store.Create(ctx, recordKey("run", response.RunId), Record{Owner: principal.ID, State: "owned", SessionID: parsed.SessionID})
-		}
-		if err == nil {
-			result, err = protoResult(response)
-		}
-	case "sandbox_destroy":
-		var response *pb.DestroySessionResponse
-		response, err = service.backend.DestroySession(ctx, &pb.DestroySessionRequest{SessionId: parsed.SessionID})
-		if err == nil {
-			result, err = protoResult(response)
-		}
-	case "sandbox_write":
-		var response *pb.WriteFileResponse
-		response, err = service.backend.WriteFile(ctx, &pb.WriteFileRequest{SessionId: parsed.SessionID, Path: parsed.Path, Content: parsed.Content, Mode: "w"})
-		if err == nil {
-			result, err = protoResult(response)
-		}
-	default:
-		err = fmt.Errorf("unsupported mutation")
-	}
+	result, err := service.executeMutation(ctx, principal, name, parsed, record)
 	if err != nil {
 		return operationResult(record, parsed.OperationID)
 	}

--- a/pkg/sandboxmcp/tools_test.go
+++ b/pkg/sandboxmcp/tools_test.go
@@ -1,0 +1,252 @@
+package sandboxmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	pb "github.com/xiaods/k8e/pkg/sandboxmatrix/grpc/pb/sandbox/v1"
+	"google.golang.org/grpc"
+)
+
+type testStore struct {
+	sync.Mutex
+	records    map[string]Record
+	failUpdate bool
+}
+
+func (store *testStore) Create(_ context.Context, key string, record Record) (Record, error) {
+	store.Lock()
+	defer store.Unlock()
+	if _, ok := store.records[key]; ok {
+		return Record{}, ErrRecordExists
+	}
+	record.Version = "1"
+	store.records[key] = record
+	return record, nil
+}
+func (store *testStore) Get(_ context.Context, key string) (Record, error) {
+	store.Lock()
+	defer store.Unlock()
+	record, ok := store.records[key]
+	if !ok {
+		return Record{}, ErrRecordMissing
+	}
+	return record, nil
+}
+func (store *testStore) Update(_ context.Context, key string, record Record) error {
+	store.Lock()
+	defer store.Unlock()
+	if store.failUpdate {
+		return errors.New("storage unavailable")
+	}
+	previous, ok := store.records[key]
+	if !ok || previous.Version != record.Version {
+		return errors.New("conflict")
+	}
+	record.Version = "2"
+	store.records[key] = record
+	return nil
+}
+
+type testBackend struct {
+	pb.SandboxServiceClient
+	sync.Mutex
+	creates, execs, polls int
+	lostReply             bool
+}
+
+func (backend *testBackend) CreateSession(_ context.Context, request *pb.CreateSessionRequest, _ ...grpc.CallOption) (*pb.CreateSessionResponse, error) {
+	backend.Lock()
+	defer backend.Unlock()
+	backend.creates++
+	return &pb.CreateSessionResponse{SessionId: request.SessionId}, nil
+}
+func (backend *testBackend) Exec(_ context.Context, request *pb.ExecRequest, _ ...grpc.CallOption) (*pb.ExecResponse, error) {
+	backend.Lock()
+	defer backend.Unlock()
+	backend.execs++
+	if !request.Background {
+		return nil, errors.New("expected background execution")
+	}
+	if backend.lostReply {
+		return nil, errors.New("reply lost after submission")
+	}
+	return &pb.ExecResponse{RunId: fmt.Sprintf("run-%d", backend.execs), SessionId: request.SessionId, Status: "started"}, nil
+}
+func (backend *testBackend) PollRun(_ context.Context, _ *pb.PollRunRequest, _ ...grpc.CallOption) (*pb.PollRunResponse, error) {
+	backend.Lock()
+	defer backend.Unlock()
+	backend.polls++
+	return &pb.PollRunResponse{Status: "completed", ExitCode: 7}, nil
+}
+
+func invoke(t *testing.T, service *Service, owner, name string, input any) (CallResult, error) {
+	t.Helper()
+	raw, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range service.Tools() {
+		if tool.Name == name {
+			return tool.Call(context.Background(), Principal{ID: owner}, raw)
+		}
+	}
+	t.Fatalf("missing tool %s", name)
+	return CallResult{}, nil
+}
+func resultObject(t *testing.T, result CallResult) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output map[string]any
+	if err = json.Unmarshal(raw, &output); err != nil {
+		t.Fatal(err)
+	}
+	return output
+}
+func serviceFixture(t *testing.T) (*Service, *testStore, *testBackend, string) {
+	t.Helper()
+	store := &testStore{records: map[string]Record{}}
+	backend := &testBackend{}
+	service, err := NewService(backend, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := invoke(t, service, "alice", "sandbox_create", map[string]any{"operation_id": "create-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return service, store, backend, resultObject(t, result)["session_id"].(string)
+}
+
+func TestSharedStoreDeduplicatesAcrossReplicas(t *testing.T) {
+	service, store, backend, sessionID := serviceFixture(t)
+	other, _ := NewService(backend, store)
+	var group sync.WaitGroup
+	for index := 0; index < 32; index++ {
+		group.Add(1)
+		go func(index int) {
+			defer group.Done()
+			selected := service
+			if index%2 == 0 {
+				selected = other
+			}
+			_, err := invoke(t, selected, "alice", "sandbox_exec", map[string]any{"session_id": sessionID, "operation_id": "exec-1", "command": "echo hello"})
+			if err != nil {
+				t.Error(err)
+			}
+		}(index)
+	}
+	group.Wait()
+	if backend.execs != 1 {
+		t.Fatalf("executed %d times", backend.execs)
+	}
+	result, err := invoke(t, other, "alice", "sandbox_operation", map[string]any{"operation_kind": "sandbox_exec", "operation_id": "exec-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resultObject(t, result)["run_id"] != "run-1" {
+		t.Fatal(result)
+	}
+	_, err = invoke(t, other, "alice", "sandbox_exec", map[string]any{"session_id": sessionID, "operation_id": "exec-1", "command": "different"})
+	var invalid *InvalidParams
+	if !errors.As(err, &invalid) {
+		t.Fatalf("expected idempotency conflict: %v", err)
+	}
+}
+
+func TestOwnershipPrecedesEveryBackendOperation(t *testing.T) {
+	service, _, backend, sessionID := serviceFixture(t)
+	for _, entry := range []struct {
+		name string
+		args map[string]any
+	}{
+		{"sandbox_get", map[string]any{"session_id": sessionID}},
+		{"sandbox_exec", map[string]any{"session_id": sessionID, "operation_id": "x", "command": "ls"}},
+		{"sandbox_destroy", map[string]any{"session_id": sessionID, "operation_id": "x"}},
+		{"sandbox_read", map[string]any{"session_id": sessionID, "path": "/workspace/a"}},
+		{"sandbox_write", map[string]any{"session_id": sessionID, "path": "/workspace/a", "operation_id": "x", "content": ""}},
+		{"sandbox_list", map[string]any{"session_id": sessionID}},
+	} {
+		if _, err := invoke(t, service, "bob", entry.name, entry.args); err == nil {
+			t.Errorf("%s allowed another owner", entry.name)
+		}
+	}
+	_, err := invoke(t, service, "alice", "sandbox_get", map[string]any{"session_id": "legacy-unowned"})
+	if err == nil {
+		t.Fatal("legacy resource accepted")
+	}
+	_, err = invoke(t, service, "alice", "sandbox_exec", map[string]any{"session_id": sessionID, "operation_id": "x", "command": "ls"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = invoke(t, service, "bob", "sandbox_poll", map[string]any{"run_id": "run-1"}); err == nil {
+		t.Fatal("cross-owner polling accepted")
+	}
+	if _, err = invoke(t, service, "bob", "sandbox_operation", map[string]any{"operation_id": "x", "operation_kind": "sandbox_exec"}); err == nil {
+		t.Fatal("cross-owner operation accepted")
+	}
+	if backend.polls != 0 {
+		t.Fatal("unauthorized poll reached backend")
+	}
+	result, err := invoke(t, service, "alice", "sandbox_poll", map[string]any{"run_id": "run-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resultObject(t, result)["exit_code"] != float64(7) {
+		t.Fatal(result)
+	}
+}
+
+func TestUnknownSubmissionNeverRunsAgain(t *testing.T) {
+	for _, failure := range []string{"backend", "store"} {
+		t.Run(failure, func(t *testing.T) {
+			service, store, backend, sessionID := serviceFixture(t)
+			if failure == "backend" {
+				backend.lostReply = true
+			} else {
+				store.failUpdate = true
+			}
+			args := map[string]any{"session_id": sessionID, "operation_id": "uncertain", "command": "side-effect"}
+			result, err := invoke(t, service, "alice", "sandbox_exec", args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resultObject(t, result)["status"] != "unknown" {
+				t.Fatal(result)
+			}
+			store.failUpdate = false
+			backend.lostReply = false
+			restarted, _ := NewService(backend, store)
+			result, err = invoke(t, restarted, "alice", "sandbox_exec", args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if backend.execs != 1 || resultObject(t, result)["status"] != "unknown" {
+				t.Fatalf("unknown operation resubmitted: %d", backend.execs)
+			}
+		})
+	}
+}
+
+func TestRejectForgedAndOutOfRangeArguments(t *testing.T) {
+	service, _, backend, sessionID := serviceFixture(t)
+	for _, extra := range []map[string]any{{"owner": "alice"}, {"tenant_id": "alice"}, {"endpoint": "attacker"}, {"timeout": 0}, {"timeout": 3601}, {"timeout": nil}} {
+		args := map[string]any{"session_id": sessionID, "operation_id": "x", "command": "ls"}
+		for key, value := range extra {
+			args[key] = value
+		}
+		if _, err := invoke(t, service, "alice", "sandbox_exec", args); err == nil {
+			t.Fatalf("accepted %v", extra)
+		}
+	}
+	if backend.execs != 0 {
+		t.Fatal("invalid args executed")
+	}
+}

--- a/tests/mcp/client_smoke.py
+++ b/tests/mcp/client_smoke.py
@@ -1,0 +1,100 @@
+"""Independent MCP 2026-07-28 wire probe; credentials are read from environment."""
+import argparse
+import json
+import os
+from pathlib import Path
+import ssl
+import time
+import urllib.request
+import uuid
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--ca")
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--phase", choices=["before", "after", "cleanup"], required=True)
+    args = parser.parse_args()
+    if not args.endpoint.startswith("https://"):
+        parser.error("HTTPS is required")
+    context = ssl.create_default_context(cafile=args.ca)
+    token = os.environ["MCP_TEST_API_KEY"]
+
+    def rpc(method, name=None, arguments=None):
+        params = {"_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+        }}
+        headers = {"Authorization": "Bearer " + token,
+                   "Content-Type": "application/json",
+                   "Accept": "application/json, text/event-stream",
+                   "MCP-Protocol-Version": "2026-07-28", "Mcp-Method": method}
+        if name:
+            params.update(name=name, arguments=arguments)
+            headers["Mcp-Name"] = name
+        request_id = str(uuid.uuid4())
+        request = urllib.request.Request(args.endpoint, headers=headers, data=json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}).encode())
+        with urllib.request.urlopen(request, context=context, timeout=45) as response:
+            if response.headers.get("Mcp-Session-Id"):
+                raise RuntimeError("unexpected protocol session")
+            message = json.load(response)
+        if message.get("id") != request_id or "error" in message:
+            raise RuntimeError("invalid RPC response: " + json.dumps(message))
+        result = message["result"]
+        if result.get("resultType") != "complete" or result.get("isError"):
+            raise RuntimeError("tool/protocol failure: " + json.dumps(result))
+        return result
+
+    def call(name, arguments):
+        return rpc("tools/call", name, arguments)["structuredContent"]
+
+    discovery = rpc("server/discover")
+    if "2026-07-28" not in discovery["supportedVersions"]:
+        raise RuntimeError("version not advertised")
+    names = {tool["name"] for tool in rpc("tools/list")["tools"]}
+    if not {"sandbox_create", "sandbox_exec", "sandbox_poll", "sandbox_operation"} <= names:
+        raise RuntimeError("missing required tools")
+    state_path = Path(args.state)
+    if args.phase == "before":
+        if state_path.exists():
+            raise RuntimeError("state file exists; use after or cleanup")
+        prefix = "wire-" + uuid.uuid4().hex
+        state = {"create": {"operation_id": prefix + "-create"}}
+        state["created"] = call("sandbox_create", state["create"])
+        state["exec"] = {"session_id": state["created"]["session_id"],
+                         "operation_id": prefix + "-exec", "command": "printf mcp-smoke-ok"}
+        state_path.write_text(json.dumps(state))
+        state["submitted"] = call("sandbox_exec", state["exec"])
+        state_path.write_text(json.dumps(state))
+    else:
+        state = json.loads(state_path.read_text())
+    if args.phase == "cleanup":
+        call("sandbox_destroy", {"session_id": state["created"]["session_id"],
+                                 "operation_id": state["create"]["operation_id"] + "-destroy"})
+        print("cleanup passed")
+        return
+    if call("sandbox_create", state["create"]) != state["created"]:
+        raise RuntimeError("create replay changed result")
+    if call("sandbox_exec", state["exec"]) != state["submitted"]:
+        raise RuntimeError("exec replay changed result")
+    recovered = call("sandbox_operation", {"operation_kind": "sandbox_exec",
+                                           "operation_id": state["exec"]["operation_id"]})
+    if recovered != state["submitted"]:
+        raise RuntimeError("operation recovery changed result")
+    deadline = time.monotonic() + 60
+    while True:
+        polled = call("sandbox_poll", {"run_id": recovered["run_id"]})
+        if polled["status"] == "completed":
+            if int(polled["exit_code"]) != 0:
+                raise RuntimeError("command failed")
+            break
+        if polled["status"] in ("failed", "cancelled") or time.monotonic() >= deadline:
+            raise RuntimeError("run did not complete: " + json.dumps(polled))
+        time.sleep(1)
+    print(args.phase + " passed: discovery, tools, deduplication, recovery, polling")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mcp/test_init.py
+++ b/tests/mcp/test_init.py
@@ -16,12 +16,17 @@ class InitTests(unittest.TestCase):
                 '#!/bin/bash\n'
                 'printf "%s\\n" "$*" >> "$MCP_INIT_TEST_LOG"\n'
                 'case "$*" in\n'
+                '  *"get secret sandbox-e2b -o jsonpath="*) printf "Y2VydA==" ;;\n'
+                '  *"get gateway e2b -o jsonpath="*) printf "203.0.113.10" ;;\n'
                 '  *" -f -"*) cat >/dev/null ;;\n'
                 '  *"--dry-run=client"*) printf "{}\\n" ;;\n'
                 'esac\n'
                 'exit 0\n'
             )
             kubectl.chmod(0o700)
+            curl = temporary / "curl"
+            curl.write_text('#!/bin/bash\nprintf "%s\\n" "$*" >> "$MCP_INIT_TEST_LOG"\nprintf "405"\n')
+            curl.chmod(0o700)
             credential = temporary / "input"
             credential.write_text("test-only-private-material")
             arguments = ["bash", str(root / "hack/init-sandbox-mcp.sh")]
@@ -35,11 +40,49 @@ class InitTests(unittest.TestCase):
             self.assertEqual(applied.returncode, 0, applied.stderr)
             calls = log.read_text()
             self.assertIn("-n sandbox-matrix get secret sandbox-apikeys", calls)
+            self.assertIn("-n sandbox-matrix get gateway e2b -o name", calls)
             self.assertNotIn("create secret generic sandbox-apikeys", calls)
             self.assertNotIn("oauth", calls)
+            self.assertIn("-n sandbox-matrix create secret tls sandbox-e2b", calls)
+            self.assertNotIn("create secret tls mcp-public-tls", calls)
             self.assertIn(str(root / "manifests/sandbox-mcp/deployment.yaml"), calls)
             self.assertIn("rollout status deployment/k8e-mcp", calls)
+            self.assertIn("condition=Programmed gateway/e2b", calls)
+            self.assertIn('status.listeners[?(@.name=="https")]', calls)
+            self.assertIn('conditions[?(@.type=="ResolvedRefs")]', calls)
+            self.assertIn("httproute/k8e-mcp", calls)
+            self.assertIn("--write-out %{http_code}", calls)
+            self.assertIn("https://203.0.113.10/mcp", calls)
+            self.assertIn("MCP endpoint: https://203.0.113.10/mcp", applied.stdout)
             self.assertNotIn(credential.read_text(), calls + applied.stdout + applied.stderr)
+
+            manifest = (root / "manifests/sandbox-mcp/deployment.yaml").read_text()
+            self.assertIn("kind: HTTPRoute", manifest)
+            self.assertIn("kind: ReferenceGrant", manifest)
+            self.assertIn("sectionName: https", manifest)
+            self.assertIn("value: /mcp", manifest)
+            self.assertIn("--listen=:8080", manifest)
+            self.assertNotIn("mcp-public-tls", manifest)
+
+            log.write_text("")
+            reuse_arguments = ["bash", str(root / "hack/init-sandbox-mcp.sh")]
+            for option in ["kubeconfig", "gateway-ca", "gateway-cert", "gateway-key"]:
+                reuse_arguments += ["--" + option, str(credential)]
+            reused = subprocess.run(reuse_arguments + ["--apply"], env=environment, cwd=temporary, capture_output=True, text=True)
+            self.assertEqual(reused.returncode, 0, reused.stderr)
+            reuse_calls = log.read_text()
+            self.assertIn("-n sandbox-matrix get secret sandbox-e2b -o name", reuse_calls)
+            self.assertNotIn("create secret tls sandbox-e2b", reuse_calls)
+
+            invalid_host = subprocess.run(
+                reuse_arguments + ["--hostname", "999.1.1.1"],
+                env=environment,
+                cwd=temporary,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(invalid_host.returncode, 2)
+            self.assertIn("DNS name or IPv4 address", invalid_host.stderr)
 
     def test_missing_option_value_fails_before_mutation(self):
         root = Path(__file__).resolve().parents[2]

--- a/tests/mcp/test_init.py
+++ b/tests/mcp/test_init.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class InitTests(unittest.TestCase):
+    def test_initialization_uses_existing_keys(self):
+        root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            log = temporary / "calls"
+            kubectl = temporary / "kubectl"
+            kubectl.write_text(
+                '#!/bin/bash\n'
+                'printf "%s\\n" "$*" >> "$MCP_INIT_TEST_LOG"\n'
+                'case "$*" in\n'
+                '  *" -f -"*) cat >/dev/null ;;\n'
+                '  *"--dry-run=client"*) printf "{}\\n" ;;\n'
+                'esac\n'
+                'exit 0\n'
+            )
+            kubectl.chmod(0o700)
+            credential = temporary / "input"
+            credential.write_text("test-only-private-material")
+            arguments = ["bash", str(root / "hack/init-sandbox-mcp.sh")]
+            for option in ["kubeconfig", "public-cert", "public-key", "gateway-ca", "gateway-cert", "gateway-key"]:
+                arguments += ["--" + option, str(credential)]
+            environment = dict(os.environ, PATH=str(temporary) + os.pathsep + os.environ["PATH"], MCP_INIT_TEST_LOG=str(log))
+            preview = subprocess.run(arguments, env=environment, cwd=temporary, capture_output=True, text=True)
+            self.assertEqual(preview.returncode, 0, preview.stderr)
+            self.assertFalse(log.exists(), "preview accessed Kubernetes")
+            applied = subprocess.run(arguments + ["--apply"], env=environment, cwd=temporary, capture_output=True, text=True)
+            self.assertEqual(applied.returncode, 0, applied.stderr)
+            calls = log.read_text()
+            self.assertIn("-n sandbox-matrix get secret sandbox-apikeys", calls)
+            self.assertNotIn("create secret generic sandbox-apikeys", calls)
+            self.assertNotIn("oauth", calls)
+            self.assertIn(str(root / "manifests/sandbox-mcp/deployment.yaml"), calls)
+            self.assertIn("rollout status deployment/k8e-mcp", calls)
+            self.assertNotIn(credential.read_text(), calls + applied.stdout + applied.stderr)
+
+    def test_missing_option_value_fails_before_mutation(self):
+        root = Path(__file__).resolve().parents[2]
+        result = subprocess.run(["bash", str(root / "hack/init-sandbox-mcp.sh"), "--kubeconfig"], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("missing option value", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a deployable, opt-in MCP entry alongside the existing CLI + Skill workflow. `k8e-sandbox-cli mcp-serve` accepts existing K8E API keys and calls the sandbox gRPC gateway through an independent mTLS connection. No OAuth authorization server is required.

- Implement MCP 2026-07-28 discovery, tool listing and calls with per-request metadata/header validation and nine sandbox tools.
- Validate API keys against `sandbox-matrix/sandbox-apikeys` on every request, enforcing expiration, revocation and persistent resource ownership.
- Persist ownership and operation admission in ConfigMaps. Duplicate operation IDs return the recorded outcome; uncertain submissions remain unknown and are never automatically replayed.
- Deploy two MCP replicas behind the existing `sandbox-matrix/e2b` Cilium Gateway. The Gateway terminates public HTTPS and an `HTTPRoute` forwards `/mcp` to the cluster-internal HTTP Service through a narrow cross-namespace `ReferenceGrant`.
- Reuse the Gateway's existing `sandbox-e2b` TLS Secret by default. Operators can explicitly provide a replacement certificate pair during initialization.
- Wait for the HTTPS listener and route conditions, then probe the public endpoint over TLS before printing the client URL.
- Add scoped RBAC, client smoke probes, an OrbStack K8E restart harness and a non-root scratch runtime image.

## Validation

- `GOCACHE=/tmp/k8e-mcp-gocache go test -race ./pkg/sandboxmcp ./cmd/sandboxcli -count=1` — passed.
- `go vet ./pkg/sandboxmcp ./cmd/sandboxcli`, `python3 tests/mcp/test_init.py`, shell syntax checks, revive, gocyclo and `git diff --check` — passed.
- The complete MCP manifest passed Kubernetes server-side dry-run against a native K8E API in OrbStack, including `HTTPRoute` and `ReferenceGrant` schemas.
- `MCP_RUN_INTEROP=1 go test -race ./pkg/sandboxmcp ./cmd/sandboxcli -count=1` — passed in OrbStack Linux.
- `go test -race -tags mcp_integration ./pkg/sandboxmcp -run '^TestGatewayWithKubernetesMock$' -count=1` — passed in OrbStack Linux using production gateway gRPC handlers with Kubernetes and sandboxd fixtures.
- `K8E_BINARY=/tmp/k8e-mcp-server hack/test-sandbox-mcp-orbstack.sh` — passed against a native K8E control plane started with `--cluster-init`, including an actual control-plane container restart. Completed outcomes, unknown non-replay and ownership persisted across restart.
- The repository-wide `make test` was also run locally. MCP tests passed; the suite retains unrelated baseline failures in `cmd/k8e` generated build symbols and macOS host certificate trust tests.

## Scope

This entry supports clients that can supply a Bearer API key and speak MCP 2026-07-28. OAuth login, browser CORS preflight, protocol sessions, SSE and Tasks extensions are deferred.

The manifest now configures Gateway routing automatically. Public DNS and a certificate valid for the client-visible hostname remain deployment inputs. Real gVisor workload execution and final public-network acceptance require an agent-enabled target environment.
