### PR TITLE
test(e2e): add the l1/l2 docker profile harness and run it in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -144,6 +144,7 @@ jobs:
         run: |
           bash -n hack/e2e/lib.sh hack/e2e/up.sh hack/e2e/down.sh \
                   hack/e2e/run.sh hack/e2e/dump-logs.sh hack/e2e/build-linux.sh \
+                  hack/e2e/entrypoint.sh \
                   hack/e2e/suites/l1.sh hack/e2e/suites/l2.sh hack/test-sandbox-mcp-orbstack.sh
           make e2e E2E_PROFILE=l1
       - name: Upload diagnostics
@@ -204,6 +205,7 @@ jobs:
         run: |
           bash -n hack/e2e/lib.sh hack/e2e/up.sh hack/e2e/down.sh \
                   hack/e2e/run.sh hack/e2e/dump-logs.sh hack/e2e/build-linux.sh \
+                  hack/e2e/entrypoint.sh \
                   hack/e2e/suites/l1.sh hack/e2e/suites/l2.sh hack/test-sandbox-mcp-orbstack.sh
           make e2e E2E_PROFILE=l2
       - name: Upload diagnostics

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -106,3 +106,110 @@ jobs:
           echo "--- sandboxcli binary (linux/amd64) ---"
           GOOS=linux   GOARCH=amd64   go build -o /dev/null ./cmd/sandboxcli/
           echo "All cross-compile targets OK"
+
+  e2e-l1:
+    name: E2E L1 (control plane)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      GOOS: linux
+      GOARCH: amd64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache-dependency-path: go.sum
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libc6-dev zlib1g-dev libseccomp-dev
+      # `zig build k8e` only needs the Go toolchain: cmd/server does not import
+      # pkg/data, so no code generation or containerd/runc sources are required
+      # for the control-plane profile.
+      - name: Build k8e (linux/amd64)
+        run: make k8e
+      - name: Verify binary
+        run: |
+          test -x bin/k8e
+          file bin/k8e
+      - name: Build E2E image
+        run: docker build -f hack/e2e/Dockerfile -t k8e-e2e:local hack/e2e
+      - name: Run E2E profile l1
+        env:
+          E2E_SKIP_IMAGE_BUILD: '1'
+        run: |
+          bash -n hack/e2e/lib.sh hack/e2e/up.sh hack/e2e/down.sh \
+                  hack/e2e/run.sh hack/e2e/dump-logs.sh hack/e2e/build-linux.sh \
+                  hack/e2e/suites/l1.sh hack/e2e/suites/l2.sh hack/test-sandbox-mcp-orbstack.sh
+          make e2e E2E_PROFILE=l1
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: e2e-l1-diagnostics
+          path: /tmp/k8e-e2e/l1/diagnostics
+          if-no-files-found: ignore
+
+  e2e-l2:
+    name: E2E L2 (control plane + agent)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      GOOS: linux
+      GOARCH: amd64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache-dependency-path: go.sum
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config build-essential libc6-dev zlib1g-dev libseccomp-dev
+      # Same control-plane binary as l1: the agent's runtime (containerd, runc)
+      # ships in the E2E image rather than in the k8e binary, so no code
+      # generation or pkg/data sources are involved here either.
+      - name: Build k8e (linux/amd64)
+        run: make k8e
+      - name: Verify binary
+        run: |
+          test -x bin/k8e
+          file bin/k8e
+      - name: Build E2E image
+        run: docker build -f hack/e2e/Dockerfile -t k8e-e2e:local hack/e2e
+      # The node has no registry access, so the suite's images are pulled here on
+      # the runner and imported into containerd by up.sh. The list is read from
+      # the harness so it cannot drift; pulling it up front turns registry
+      # problems (rate limits on shared runner IPs) into a fast, obvious failure
+      # instead of a late one inside the profile run.
+      - name: Pull suite images
+        run: |
+          . hack/e2e/lib.sh
+          e2e_set_profile l2
+          for image in ${E2E_PRELOAD_IMAGES}; do
+            echo "--- pulling ${image}"
+            docker pull -q "${image}"
+          done
+      - name: Run E2E profile l2
+        env:
+          E2E_SKIP_IMAGE_BUILD: '1'
+        run: |
+          bash -n hack/e2e/lib.sh hack/e2e/up.sh hack/e2e/down.sh \
+                  hack/e2e/run.sh hack/e2e/dump-logs.sh hack/e2e/build-linux.sh \
+                  hack/e2e/suites/l1.sh hack/e2e/suites/l2.sh hack/test-sandbox-mcp-orbstack.sh
+          make e2e E2E_PROFILE=l2
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: e2e-l2-diagnostics
+          path: /tmp/k8e-e2e/l2/diagnostics
+          if-no-files-found: ignore

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,7 +52,7 @@ jobs:
           check-latest: true
           cache-dependency-path: go.sum
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
       - name: Install dependencies
@@ -122,7 +122,7 @@ jobs:
           check-latest: true
           cache-dependency-path: go.sum
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
       - name: Install dependencies
@@ -169,7 +169,7 @@ jobs:
           check-latest: true
           cache-dependency-path: go.sum
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
       - name: Install dependencies

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,15 @@
+# Configuration for SonarQube Cloud's automatic analysis, which reads this file and
+# ignores sonar-project.properties -- it takes this one from the default branch, so
+# the values below mirror the settings that file would apply. Automatic analysis
+# also cannot per-issue-ignore rules (sonar.issue.ignore.multicriteria is not among
+# its supported parameters), which is why the file below is excluded rather than
+# the rule.
+#
+# hack/e2e/Dockerfile builds the E2E node image: a throwaway single-node control
+# plane that has to run as root to start kubelet and containerd and to write their
+# state under /var/lib. docker:S6471 ("the base image runs with root as the default
+# user") is a permanent false positive there, and as a vulnerability on new code it
+# pins the Quality Gate's security rating at B. Its other Docker findings are
+# handled in the Dockerfile itself.
+sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go,**/package-lock.json,**/pnpm-lock.yaml,hack/e2e/Dockerfile
+sonar.cpd.exclusions=plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/**,**/package-lock.json,**/pnpm-lock.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .DEFAULT_GOAL := all
 
-.PHONY: all k8e clean deps format generate package package-cli package-airgap test
+# End-to-end profile run by `make e2e` (l1 | l2 | l3). Requires a linux/amd64
+# bin/k8e and a running docker daemon.
+E2E_PROFILE ?= l1
+
+.PHONY: all k8e clean deps format generate package package-cli package-airgap test e2e
 
 all:
 	zig build all
@@ -31,3 +35,6 @@ package-airgap:
 
 test:
 	zig build test
+
+e2e:
+	hack/e2e/run.sh $(E2E_PROFILE)

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-test/deep v1.0.7
+	github.com/google/cadvisor/lib v0.60.5
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -254,7 +255,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/cadvisor/lib v0.60.5 // indirect
 	github.com/google/cel-go v0.29.2 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/hack/download
+++ b/hack/download
@@ -11,6 +11,9 @@ DATA_DIR=build/data
 CHARTS_DIR=build/static/charts
 NERDCTL_VERSION=2.0.0
 CILIUM_CHART_VERSION=${VERSION_CILIUM_CHART}
+# The release CDNs queried below occasionally drop a connection mid-transfer,
+# and a single transient error should not fail the whole build.
+FETCH_ATTEMPTS=${FETCH_ATTEMPTS:-5}
 
 umask 022
 rm -rf ${CHARTS_DIR}
@@ -21,12 +24,55 @@ mkdir -p ${DATA_DIR}
 mkdir -p ${CHARTS_DIR}
 mkdir -p bin
 
+# retry runs a command until it succeeds, backing off between attempts.
+retry() {
+  local attempt
+  for ((attempt = 1; attempt <= FETCH_ATTEMPTS; attempt++)); do
+    if "$@"; then
+      return 0
+    fi
+    echo "[WARN] attempt ${attempt}/${FETCH_ATTEMPTS} failed: $*" >&2
+    sleep $((attempt * 2))
+  done
+  echo "[ERROR] gave up after ${FETCH_ATTEMPTS} attempts: $*" >&2
+  return 1
+}
+
+# clone_repo drops any partial checkout first, because git clone refuses to
+# write into a directory that a failed attempt already created.
+clone_repo() {
+  local url="$1" dir="$2" branch="$3"
+  rm -rf "${dir}"
+  retry git clone --single-branch --branch="${branch}" --depth=1 "${url}" "${dir}"
+}
+
+# fetch_to_file downloads to a file and only reports success for a complete
+# gzip stream. Piping curl straight into tar hid curl's exit status, so a
+# truncated transfer surfaced as a "gzip: stdin: unexpected end of file"
+# error far away from the actual cause.
+fetch_to_file() {
+  local url="$1" dest="$2"
+  rm -f "${dest}"
+  if curl --compressed -sfL \
+    --retry 3 --retry-delay 2 --connect-timeout 15 \
+    -o "${dest}" "${url}" \
+    && gzip -t "${dest}"; then
+    return 0
+  fi
+  rm -f "${dest}"
+  return 1
+}
+
+download_artifact() {
+  retry fetch_to_file "$1" "$2"
+}
+
 case ${OS} in
   linux)
-     git clone --single-branch --branch=${VERSION_RUNC} --depth=1 https://github.com/opencontainers/runc ${RUNC_DIR}
+     clone_repo https://github.com/opencontainers/runc "${RUNC_DIR}" "${VERSION_RUNC}"
     ;;
   windows)
-    git clone --single-branch --branch=${VERSION_HCSSHIM} --depth=1 https://github.com/microsoft/hcsshim ${HCSSHIM_DIR}
+    clone_repo https://github.com/microsoft/hcsshim "${HCSSHIM_DIR}" "${VERSION_HCSSHIM}"
     ;;
   *)
     echo "[ERROR] unrecognized opertaing system: ${OS}"
@@ -34,21 +80,35 @@ case ${OS} in
     ;;
 esac
 
-git clone --single-branch --branch=${VERSION_CONTAINERD} --depth=1 https://${PKG_CONTAINERD_K8E/\/v*/} ${CONTAINERD_DIR}
+clone_repo "https://${PKG_CONTAINERD_K8E/\/v*/}" "${CONTAINERD_DIR}" "${VERSION_CONTAINERD}"
 
 download_and_package_nerdctl() {
-echo "download nerdctl..."
-if [ ${ARCH} = amd64 ]; then
-  curl --compressed -sfL https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-amd64.tar.gz | tar -zxf - -C bin
-elif [ ${ARCH} = aarch64 ] || [ ${ARCH} = arm64 ]; then
-  curl --compressed -sfL https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-arm64.tar.gz | tar -zxf - -C bin
-fi
+  echo "download nerdctl..."
+  local arch
+  case ${ARCH} in
+    amd64)
+      arch=amd64
+      ;;
+    aarch64 | arm64)
+      arch=arm64
+      ;;
+    *)
+      echo "[ERROR] nerdctl has no prebuilt binary for ${ARCH}"
+      exit 1
+      ;;
+  esac
+  local tarball=${DATA_DIR}/nerdctl-${NERDCTL_VERSION}-linux-${arch}.tar.gz
+  download_artifact \
+    "https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${arch}.tar.gz" \
+    "${tarball}"
+  tar -xzf "${tarball}" -C bin
 }
 
 download_and_package_cilium() {
   echo "download Cilium Helm chart..."
-  curl --compressed -sfL -o ${CHARTS_DIR}/cilium-${CILIUM_CHART_VERSION}.tgz \
-    https://helm.cilium.io/cilium-${CILIUM_CHART_VERSION}.tgz
+  download_artifact \
+    "https://helm.cilium.io/cilium-${CILIUM_CHART_VERSION}.tgz" \
+    "${CHARTS_DIR}/cilium-${CILIUM_CHART_VERSION}.tgz"
 }
 
 download_and_package_nerdctl

--- a/hack/e2e/Dockerfile
+++ b/hack/e2e/Dockerfile
@@ -41,24 +41,27 @@ RUN apt-get update \
 # plugins."io.containerd.grpc.v1.cri" config, which containerd 2.x rejects.
 ENV CONTAINERD_VERSION=1.7.28
 ENV RUNC_VERSION=1.5.1
+# The two runtime releases are the only downloads here, so every hop -- including
+# redirects -- is pinned to HTTPS. containerd and kubelet also probe /run,
+# /var/lib/kubelet and /var/log/pods; creating them keeps the container usable
+# even when the runtime does not pre-create them.
 RUN set -eux; \
+    mkdir -p /run /var/lib/kubelet /var/log/pods; \
     arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
     case "${arch}" in \
         amd64) containerd_arch=amd64; runc_arch=amd64 ;; \
         arm64) containerd_arch=arm64; runc_arch=arm64 ;; \
         *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${containerd_arch}.tar.gz" \
+    curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
+        "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${containerd_arch}.tar.gz" \
         | tar -xz -C /usr/local; \
-    curl -fsSL -o /usr/local/bin/runc \
+    curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
+        -o /usr/local/bin/runc \
         "https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.${runc_arch}"; \
     chmod 0755 /usr/local/bin/runc; \
     containerd --version; \
     runc --version
-
-# containerd and kubelet probe these; making them explicit keeps the
-# container usable even when the runtime does not pre-create them.
-RUN mkdir -p /run /var/lib/kubelet /var/log/pods
 
 # Prepares the kubelet cgroup root (see entrypoint.sh) before k8e starts.
 COPY entrypoint.sh /usr/local/bin/k8e-e2e-entrypoint

--- a/hack/e2e/Dockerfile
+++ b/hack/e2e/Dockerfile
@@ -1,0 +1,68 @@
+# k8e end-to-end test image.
+#
+# The k8e binary is bind-mounted at runtime, so this image only carries the
+# userland that k8e, containerd, runc, kubelet and Cilium expect to exist.
+# Keep it close to a stock Ubuntu node: no systemd.
+FROM ubuntu:24.04
+
+# Set by BuildKit; fall back to the container's own architecture.
+ARG TARGETARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apparmor \
+        bash \
+        ca-certificates \
+        conntrack \
+        curl \
+        ebtables \
+        ethtool \
+        iproute2 \
+        iptables \
+        iputils-ping \
+        jq \
+        kmod \
+        less \
+        libseccomp2 \
+        mount \
+        procps \
+        socat \
+        tcpdump \
+        tzdata \
+        util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
+# containerd, its shims and runc are resolved on PATH. `zig build k8e` produces
+# cmd/server, which -- unlike the release cmd/k8e multicall binary -- stages no
+# bundled runtimes, so the image has to supply them for the agent profiles.
+# containerd stays on the 1.7 series: k8e renders a
+# plugins."io.containerd.grpc.v1.cri" config, which containerd 2.x rejects.
+ENV CONTAINERD_VERSION=1.7.28
+ENV RUNC_VERSION=1.5.1
+RUN set -eux; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    case "${arch}" in \
+        amd64) containerd_arch=amd64; runc_arch=amd64 ;; \
+        arm64) containerd_arch=arm64; runc_arch=arm64 ;; \
+        *) echo "unsupported architecture: ${arch}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${containerd_arch}.tar.gz" \
+        | tar -xz -C /usr/local; \
+    curl -fsSL -o /usr/local/bin/runc \
+        "https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.${runc_arch}"; \
+    chmod 0755 /usr/local/bin/runc; \
+    containerd --version; \
+    runc --version
+
+# containerd and kubelet probe these; making them explicit keeps the
+# container usable even when the runtime does not pre-create them.
+RUN mkdir -p /run /var/lib/kubelet /var/log/pods
+
+# Prepares the kubelet cgroup root (see entrypoint.sh) before k8e starts.
+COPY entrypoint.sh /usr/local/bin/k8e-e2e-entrypoint
+RUN chmod 0755 /usr/local/bin/k8e-e2e-entrypoint
+ENTRYPOINT ["/usr/local/bin/k8e-e2e-entrypoint"]
+
+WORKDIR /test

--- a/hack/e2e/build-linux.sh
+++ b/hack/e2e/build-linux.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 . "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+if [[ "${1:-}" = "-h" ]] || [[ "${1:-}" = "--help" ]]; then
     e2e_usage
     exit 0
 fi
@@ -40,7 +40,7 @@ extra_docker_args=()
 docker_env=(-e GOCACHE=/gocache)
 if command -v go >/dev/null 2>&1; then
     host_cache="$(go env GOMODCACHE 2>/dev/null || true)"
-    if [ -n "${host_cache}" ] && [ -d "${host_cache}" ]; then
+    if [[ -n "${host_cache}" ]] && [[ -d "${host_cache}" ]]; then
         extra_docker_args+=(-v "${host_cache}":/go/pkg/mod)
         e2e_log "reusing host module cache ${host_cache}"
     fi

--- a/hack/e2e/build-linux.sh
+++ b/hack/e2e/build-linux.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build a linux k8e binary from a non-Linux workstation (convenience).
+#
+#   hack/e2e/build-linux.sh
+#   E2E_BINARY=$PWD/bin/k8e-linux-arm64 hack/e2e/run.sh l1
+#
+# CI uses `make k8e` on a Linux runner instead; this script only exists so that
+# macOS contributors can run the harness. It mirrors the flags used by
+# `zig build k8e` (same build tags, CGO on, statically linked) so the resulting
+# binary runs inside the stock E2E image.
+set -euo pipefail
+
+. "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    e2e_usage
+    exit 0
+fi
+
+e2e_require_cmds docker
+
+image="${E2E_GOLANG_IMAGE:-golang:1.26.7}"
+# Match the host architecture by default: emulating a foreign arch would make
+# the k8s build painfully slow. CI builds amd64 through `make k8e` instead.
+host_arch="$(docker info --format '{{.Architecture}}' 2>/dev/null || echo amd64)"
+case "${host_arch}" in
+aarch64 | arm64) default_arch="arm64" ;;
+*) default_arch="amd64" ;;
+esac
+goarch="${E2E_GOARCH:-${default_arch}}"
+out="bin/k8e-linux-${goarch}"
+tags="ctrd netcgo osusergo providerless urfave_cli_no_docs static_build apparmor seccomp"
+ldflags="-w -s -extldflags '-static -lm -ldl -lz -lpthread'"
+go_cache="${E2E_STATE_DIR:-/tmp/k8e-e2e}/gocache"
+mkdir -p "${go_cache}"
+
+# Reuse the host module cache and GOPROXY when a matching Go toolchain exists;
+# otherwise the build would re-download the whole k8s dependency tree.
+extra_docker_args=()
+docker_env=(-e GOCACHE=/gocache)
+if command -v go >/dev/null 2>&1; then
+    host_cache="$(go env GOMODCACHE 2>/dev/null || true)"
+    if [ -n "${host_cache}" ] && [ -d "${host_cache}" ]; then
+        extra_docker_args+=(-v "${host_cache}":/go/pkg/mod)
+        e2e_log "reusing host module cache ${host_cache}"
+    fi
+    docker_env+=(-e "GOPROXY=$(go env GOPROXY)")
+fi
+
+# gcc ships with the golang image; the static extldflags additionally need the
+# zlib and seccomp development packages.
+e2e_log "building ./cmd/server for linux/${goarch} with ${image} (output ${out})"
+docker run --rm \
+    -v "${E2E_REPO}":/src \
+    -v "${go_cache}":/gocache \
+    "${extra_docker_args[@]+"${extra_docker_args[@]}"}" \
+    -w /src \
+    -e DEBIAN_FRONTEND=noninteractive \
+    -e GOOS=linux -e GOARCH="${goarch}" -e CGO_ENABLED=1 \
+    "${docker_env[@]}" \
+    "${image}" \
+    sh -c "apt-get update -qq \
+        && apt-get install -y -qq --no-install-recommends zlib1g-dev libseccomp-dev >/dev/null \
+        && go build -tags '${tags}' -buildvcs=false -ldflags \"${ldflags}\" -o ${out} ./cmd/server"
+
+e2e_log "built ${E2E_REPO}/${out}"
+e2e_log "run: E2E_BINARY=${E2E_REPO}/${out} hack/e2e/run.sh l1"
+e2e_log "override the target architecture with E2E_GOARCH=amd64|arm64"

--- a/hack/e2e/down.sh
+++ b/hack/e2e/down.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 . "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+if [[ "${1:-}" = "-h" ]] || [[ "${1:-}" = "--help" ]]; then
     e2e_usage
     exit 0
 fi
@@ -23,7 +23,7 @@ else
     e2e_log "container ${E2E_CONTAINER} already gone"
 fi
 
-if [ "${E2E_PURGE}" = "1" ]; then
+if [[ "${E2E_PURGE}" = "1" ]]; then
     e2e_log "purging ${E2E_STATE_DIR}"
     rm -rf "${E2E_STATE_DIR}"
     # Runtime storage lives on its own volume (see E2E_CONTAINERD_ROOT in lib.sh).

--- a/hack/e2e/down.sh
+++ b/hack/e2e/down.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Stop and remove an E2E cluster.
+#
+#   hack/e2e/down.sh [profile]
+#
+# The state directory is kept for post-mortem inspection unless E2E_PURGE=1.
+set -euo pipefail
+
+. "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    e2e_usage
+    exit 0
+fi
+
+e2e_set_profile "${1:-${E2E_PROFILE}}"
+e2e_require_cmds docker
+
+if e2e_container_exists; then
+    e2e_log "removing container ${E2E_CONTAINER}"
+    docker rm -f "${E2E_CONTAINER}" >/dev/null
+else
+    e2e_log "container ${E2E_CONTAINER} already gone"
+fi
+
+if [ "${E2E_PURGE}" = "1" ]; then
+    e2e_log "purging ${E2E_STATE_DIR}"
+    rm -rf "${E2E_STATE_DIR}"
+    # Runtime storage lives on its own volume (see E2E_CONTAINERD_ROOT in lib.sh).
+    if docker volume inspect "${E2E_CONTAINERD_ROOT_VOLUME}" >/dev/null 2>&1; then
+        e2e_log "purging volume ${E2E_CONTAINERD_ROOT_VOLUME}"
+        docker volume rm -f "${E2E_CONTAINERD_ROOT_VOLUME}" >/dev/null 2>&1 || true
+    fi
+fi

--- a/hack/e2e/dump-logs.sh
+++ b/hack/e2e/dump-logs.sh
@@ -67,15 +67,26 @@ else
 fi
 
 # 14 — staged manifests and data directory (reveals addon/disable regressions)
-if [ -d "${E2E_DATA_DIR}" ]; then
+#
+# The server owns the data directory as root with mode 0700, so on a plain Linux
+# host only the container can read it. Listing it from the outside reports an empty
+# tree for a cluster that staged everything, which is how the addon-staging
+# regression this file exists to explain stayed invisible.
+if e2e_container_running; then
     {
-        printf '### staged manifests\n'
-        find "${E2E_DATA_DIR}" -maxdepth 4 -type d -name manifests -exec ls -la {} \; 2>/dev/null || true
+        printf '### staged manifests (%s)\n' "${E2E_IN_CONTAINER_MANIFESTS_DIR}"
+        docker exec "${E2E_CONTAINER}" sh -c 'ls -la "$1" 2>&1' e2e-diag \
+            "${E2E_IN_CONTAINER_MANIFESTS_DIR}" || true
         printf '\n### data directory (depth 2)\n'
-        find "${E2E_DATA_DIR}" -maxdepth 2 2>/dev/null | head -200 || true
+        docker exec "${E2E_CONTAINER}" sh -c 'find "$1" -maxdepth 2 2>&1 | head -200' e2e-diag \
+            "${E2E_IN_CONTAINER_DATA_DIR}/data" || true
         printf '\n### log files\n'
-        find "${E2E_DATA_DIR}" -maxdepth 4 -name '*.log' -type f 2>/dev/null | head -40 || true
+        docker exec "${E2E_CONTAINER}" sh -c 'find "$1" -maxdepth 4 -name "*.log" -type f 2>&1 | head -40' e2e-diag \
+            "${E2E_IN_CONTAINER_DATA_DIR}/data" || true
     } >"${E2E_DIAG_DIR}/14-data-dir.txt" 2>&1 || true
+elif [ -d "${E2E_DATA_DIR}" ]; then
+    # Container gone: fall back to whatever the host user is allowed to see.
+    find "${E2E_DATA_DIR}" -maxdepth 3 2>&1 | head -200 >"${E2E_DIAG_DIR}/14-data-dir.txt" 2>&1 || true
 fi
 
 # 15 — in-container network state

--- a/hack/e2e/dump-logs.sh
+++ b/hack/e2e/dump-logs.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 
 . "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+if [[ "${1:-}" = "-h" ]] || [[ "${1:-}" = "--help" ]]; then
     e2e_usage
     exit 0
 fi
@@ -47,7 +47,7 @@ capture 02-container-inspect.txt docker inspect "${E2E_CONTAINER}"
 capture 03-container-logs.txt docker logs --timestamps --tail 4000 "${E2E_CONTAINER}"
 
 # 04 — cluster inventory
-if [ -f "${E2E_KUBECONFIG}" ] && kubectl --kubeconfig "${E2E_KUBECONFIG}" --request-timeout=5s version >/dev/null 2>&1; then
+if [[ -f "${E2E_KUBECONFIG}" ]] && kubectl --kubeconfig "${E2E_KUBECONFIG}" --request-timeout=5s version >/dev/null 2>&1; then
     capture 04-nodes.txt e2e_kubectl get nodes -o wide
     capture 05-pods.txt e2e_kubectl get pods -A -o wide
     capture 06-events.txt e2e_kubectl get events -A --sort-by=.lastTimestamp
@@ -57,7 +57,7 @@ if [ -f "${E2E_KUBECONFIG}" ] && kubectl --kubeconfig "${E2E_KUBECONFIG}" --requ
     capture 10-endpointslices.txt e2e_kubectl get endpointslices -A
     capture 11-leases.txt e2e_kubectl get leases -A
     capture 12-sandbox-crs.txt e2e_kubectl get sandboxsessions,sandboxwarmpools -A
-    if [ "${E2E_PROFILE}" = "l3" ] && e2e_container_running; then
+    if [[ "${E2E_PROFILE}" = "l3" ]] && e2e_container_running; then
         capture 13-cilium-status.txt docker exec "${E2E_CONTAINER}" /usr/local/bin/k8e kubectl \
             -n kube-system exec ds/cilium -- cilium status --verbose
     fi
@@ -84,7 +84,7 @@ if e2e_container_running; then
         docker exec "${E2E_CONTAINER}" sh -c 'find "$1" -maxdepth 4 -name "*.log" -type f 2>&1 | head -40' e2e-diag \
             "${E2E_IN_CONTAINER_DATA_DIR}/data" || true
     } >"${E2E_DIAG_DIR}/14-data-dir.txt" 2>&1 || true
-elif [ -d "${E2E_DATA_DIR}" ]; then
+elif [[ -d "${E2E_DATA_DIR}" ]]; then
     # Container gone: fall back to whatever the host user is allowed to see.
     find "${E2E_DATA_DIR}" -maxdepth 3 2>&1 | head -200 >"${E2E_DIAG_DIR}/14-data-dir.txt" 2>&1 || true
 fi

--- a/hack/e2e/dump-logs.sh
+++ b/hack/e2e/dump-logs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Collect diagnostics from a running (or dead) E2E cluster.
+#
+#   hack/e2e/dump-logs.sh [profile]
+#
+# Best effort by design: every probe is allowed to fail. The script always
+# exits 0 so that it can run from `if: failure()` CI steps.
+set -uo pipefail
+
+. "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    e2e_usage
+    exit 0
+fi
+
+e2e_set_profile "${1:-${E2E_PROFILE}}"
+mkdir -p "${E2E_DIAG_DIR}"
+
+capture() {
+    local file="$1"
+    shift
+    {
+        printf '### command: %s\n\n' "$*"
+        "$@"
+        printf '\n### exit: %d\n' "$?"
+    } >"${E2E_DIAG_DIR}/${file}" 2>&1 || true
+}
+
+e2e_log "collecting diagnostics into ${E2E_DIAG_DIR}"
+
+# 01 — environment
+{
+    printf '### date\n'; date -u
+    printf '\n### uname\n'; uname -a
+    printf '\n### cgroup\n'; stat -fc %T /sys/fs/cgroup 2>/dev/null || true
+    printf '\n### /dev/kvm\n'; ls -l /dev/kvm 2>/dev/null || echo "absent"
+    printf '\n### /sys/fs/bpf\n'; ls -ld /sys/fs/bpf 2>/dev/null || echo "absent"
+    printf '\n### docker\n'; docker version 2>/dev/null || true
+    printf '\n### profile\n'; env | grep '^E2E_' | sort
+    printf '\n### binary\n'; ls -l "${E2E_BINARY}" 2>/dev/null || echo "missing: ${E2E_BINARY}"
+} >"${E2E_DIAG_DIR}/01-environment.txt" 2>&1 || true
+
+# 02 — container state and logs
+capture 02-container-inspect.txt docker inspect "${E2E_CONTAINER}"
+capture 03-container-logs.txt docker logs --timestamps --tail 4000 "${E2E_CONTAINER}"
+
+# 04 — cluster inventory
+if [ -f "${E2E_KUBECONFIG}" ] && kubectl --kubeconfig "${E2E_KUBECONFIG}" --request-timeout=5s version >/dev/null 2>&1; then
+    capture 04-nodes.txt e2e_kubectl get nodes -o wide
+    capture 05-pods.txt e2e_kubectl get pods -A -o wide
+    capture 06-events.txt e2e_kubectl get events -A --sort-by=.lastTimestamp
+    capture 07-describe-nodes.txt e2e_kubectl describe nodes
+    capture 08-crds.txt e2e_kubectl get crd
+    capture 09-addons.txt e2e_kubectl get addons.k8e.sh -A -o yaml
+    capture 10-endpointslices.txt e2e_kubectl get endpointslices -A
+    capture 11-leases.txt e2e_kubectl get leases -A
+    capture 12-sandbox-crs.txt e2e_kubectl get sandboxsessions,sandboxwarmpools -A
+    if [ "${E2E_PROFILE}" = "l3" ] && e2e_container_running; then
+        capture 13-cilium-status.txt docker exec "${E2E_CONTAINER}" /usr/local/bin/k8e kubectl \
+            -n kube-system exec ds/cilium -- cilium status --verbose
+    fi
+else
+    printf 'kubeconfig %s unusable; skipping cluster inventory\n' "${E2E_KUBECONFIG}" \
+        >"${E2E_DIAG_DIR}/04-kubectl-unavailable.txt"
+fi
+
+# 14 — staged manifests and data directory (reveals addon/disable regressions)
+if [ -d "${E2E_DATA_DIR}" ]; then
+    {
+        printf '### staged manifests\n'
+        find "${E2E_DATA_DIR}" -maxdepth 4 -type d -name manifests -exec ls -la {} \; 2>/dev/null || true
+        printf '\n### data directory (depth 2)\n'
+        find "${E2E_DATA_DIR}" -maxdepth 2 2>/dev/null | head -200 || true
+        printf '\n### log files\n'
+        find "${E2E_DATA_DIR}" -maxdepth 4 -name '*.log' -type f 2>/dev/null | head -40 || true
+    } >"${E2E_DIAG_DIR}/14-data-dir.txt" 2>&1 || true
+fi
+
+# 15 — in-container network state
+if e2e_container_running; then
+    {
+        printf '### ip addr\n'; docker exec "${E2E_CONTAINER}" ip addr 2>&1 || true
+        printf '\n### ip route\n'; docker exec "${E2E_CONTAINER}" ip route 2>&1 || true
+        printf '\n### iptables\n'; docker exec "${E2E_CONTAINER}" iptables -L -n 2>&1 || true
+        printf '\n### data tarball bin\n'; docker exec "${E2E_CONTAINER}" sh -c 'ls -l /test/data/data/*/bin 2>&1' || true
+    } >"${E2E_DIAG_DIR}/15-in-container-network.txt" 2>&1 || true
+fi
+
+e2e_log "diagnostics written:"
+ls -1 "${E2E_DIAG_DIR}" | sed 's/^/  /'

--- a/hack/e2e/dump-logs.sh
+++ b/hack/e2e/dump-logs.sh
@@ -25,6 +25,7 @@ capture() {
         "$@"
         printf '\n### exit: %d\n' "$?"
     } >"${E2E_DIAG_DIR}/${file}" 2>&1 || true
+    return 0
 }
 
 e2e_log "collecting diagnostics into ${E2E_DIAG_DIR}"
@@ -85,6 +86,16 @@ if e2e_container_running; then
         printf '\n### iptables\n'; docker exec "${E2E_CONTAINER}" iptables -L -n 2>&1 || true
         printf '\n### data tarball bin\n'; docker exec "${E2E_CONTAINER}" sh -c 'ls -l /test/data/data/*/bin 2>&1' || true
     } >"${E2E_DIAG_DIR}/15-in-container-network.txt" 2>&1 || true
+fi
+
+# 16 — runtime logs. containerd's log lives under its root directory, which is on
+# the runtime volume and therefore invisible from the /test bind mount; it is the
+# one file that explains a containerd that refuses to start, and `docker cp`
+# reaches it even when the container is already dead.
+if e2e_container_exists; then
+    capture 16-containerd-log.txt e2e_containerd_log 400
+    capture 17-runtime-layout.txt docker exec "${E2E_CONTAINER}" sh -c \
+        'ls -la "${K8E_E2E_CONTAINERD_ROOT}"; echo "--- /test/data/agent"; ls -la /test/data/agent'
 fi
 
 e2e_log "diagnostics written:"

--- a/hack/e2e/entrypoint.sh
+++ b/hack/e2e/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# k8e E2E container entrypoint.
+#
+# kubelet validates that the cgroup subtree named by --cgroup-root exists and
+# exposes cgroup.controllers, and refuses to start otherwise. Creating it here
+# instead of from the host after `docker run` keeps the setup race-free.
+set -e
+
+if [ -n "${K8E_E2E_CGROUP_ROOT:-}" ]; then
+    mkdir -p "${K8E_E2E_CGROUP_ROOT}" 2>/dev/null || true
+fi
+
+# containerd uses its root directory as the upper layer of the overlayfs it
+# mounts for every container rootfs. The E2E data directory is a host bind mount
+# (virtiofs under Docker Desktop/OrbStack), and that cannot back an overlay upper
+# layer: the snapshot mounts come up read-only and every pod dies with
+#   mkdirat(.../rootfs, "proc", 0o755): Read-only file system
+# The runtime volume is therefore mounted outside the bind mount and linked in
+# from here, so the path containerd was configured with keeps working.
+if [ -n "${K8E_E2E_CONTAINERD_ROOT:-}" ] && [ -n "${K8E_E2E_CONTAINERD_VOLUME:-}" ]; then
+    mkdir -p "$(dirname "${K8E_E2E_CONTAINERD_ROOT}")" "${K8E_E2E_CONTAINERD_VOLUME}"
+    rm -rf "${K8E_E2E_CONTAINERD_ROOT}"
+    ln -sfn "${K8E_E2E_CONTAINERD_VOLUME}" "${K8E_E2E_CONTAINERD_ROOT}"
+fi
+
+exec "$@"

--- a/hack/e2e/entrypoint.sh
+++ b/hack/e2e/entrypoint.sh
@@ -1,14 +1,6 @@
 #!/bin/sh
 # k8e E2E container entrypoint.
-#
-# kubelet validates that the cgroup subtree named by --cgroup-root exists and
-# exposes cgroup.controllers, and refuses to start otherwise. Creating it here
-# instead of from the host after `docker run` keeps the setup race-free.
 set -e
-
-if [ -n "${K8E_E2E_CGROUP_ROOT:-}" ]; then
-    mkdir -p "${K8E_E2E_CGROUP_ROOT}" 2>/dev/null || true
-fi
 
 # containerd uses its root directory as the upper layer of the overlayfs it
 # mounts for every container rootfs. The E2E data directory is a host bind mount

--- a/hack/e2e/lib.sh
+++ b/hack/e2e/lib.sh
@@ -39,10 +39,14 @@ e2e_set_profile() {
     : "${E2E_DIAG_DIR:=${E2E_STATE_DIR}/diagnostics}"
     : "${E2E_BINARY:=${E2E_REPO}/bin/k8e}"
     : "${E2E_KUBECONFIG:=${E2E_STATE_DIR}/kubeconfig}"
-    # up.sh runs the server with
-    # --data-dir ${E2E_IN_CONTAINER_DATA_DIR}/data and mounts ${E2E_DATA_DIR}
-    # there, so the staged addon manifests land here on the host.
-    : "${E2E_MANIFESTS_DIR:=${E2E_DATA_DIR}/data/server/manifests}"
+    # up.sh runs the server with --data-dir ${E2E_IN_CONTAINER_DATA_DIR}/data, so
+    # that is where the addon manifests are staged. The server creates the tree as
+    # root with mode 0700: on Docker Desktop/OrbStack the bind mount maps ownership
+    # to the caller and the host copy is readable, but on a plain Linux host (CI)
+    # the unprivileged user cannot even traverse ${E2E_DATA_DIR}/data, so every
+    # manifest check failed against a cluster that had staged them correctly.
+    # Reads therefore go into the container through `e2e_in_container`.
+    : "${E2E_IN_CONTAINER_MANIFESTS_DIR:=${E2E_IN_CONTAINER_DATA_DIR}/data/server/manifests}"
     # Each profile publishes its API on its own host port so that clusters kept
     # alive with E2E_KEEP=1 do not fight over a single port. An unknown profile is
     # rejected by the case further down, so no port default is needed here.
@@ -52,9 +56,6 @@ e2e_set_profile() {
     l3) : "${E2E_API_PORT:=16445}" ;;
     *) ;;
     esac
-    # Dedicated cgroup subtree for kubelet. The container entrypoint creates it
-    # before k8e starts; keeping the host's cgroup tree untouched.
-    : "${E2E_CGROUP_ROOT:=/k8e-e2e}"
     # containerd socket created by the agent inside the container.
     : "${E2E_CONTAINERD_SOCKET:=/run/k8e/containerd/containerd.sock}"
     : "${E2E_TEST_IMAGE:=busybox:1.36}"
@@ -94,8 +95,8 @@ e2e_set_profile() {
     esac
 
     export E2E_PROFILE E2E_CONTAINER E2E_STATE_DIR E2E_DATA_DIR E2E_DIAG_DIR
-    export E2E_BINARY E2E_KUBECONFIG E2E_IMAGE E2E_API_PORT E2E_MANIFESTS_DIR
-    export E2E_CGROUP_ROOT E2E_CONTAINERD_SOCKET E2E_TEST_IMAGE
+    export E2E_BINARY E2E_KUBECONFIG E2E_IMAGE E2E_API_PORT
+    export E2E_IN_CONTAINER_MANIFESTS_DIR E2E_CONTAINERD_SOCKET E2E_TEST_IMAGE
     export E2E_CONTAINERD_ROOT E2E_CONTAINERD_ROOT_VOLUME E2E_CONTAINERD_VOLUME_PATH
     export E2E_EXPECT_NODE_READY E2E_PRELOAD_IMAGES
     export E2E_API_TIMEOUT E2E_NODE_TIMEOUT E2E_STAGING_TIMEOUT E2E_KEEP E2E_PURGE
@@ -171,6 +172,14 @@ e2e_require_cmds() {
 #     disable semantics and restart recovery.
 # l2: control plane + agent, no CNI — validates kubelet/containerd bring-up.
 # l3: full stack including the bundled Cilium CNI/Gateway.
+#
+# None of them passes --kubelet-arg=cgroup-root. kubelet resolves that value
+# against the cgroup filesystem rather than the container root, and refuses to
+# start unless the subtree is already there:
+#   could not read controllers for cgroup ["k8e-e2e"]:
+#   open /sys/fs/cgroup/k8e-e2e/cgroup.controllers: no such file or directory
+# Leaving it unset is also what a real node runs: cgroups-per-qos is on by
+# default, so kubelet falls back to "/" (see cmd/kubelet/app/server.go).
 e2e_profile_flags() {
     case "${E2E_PROFILE}" in
     l1)
@@ -188,14 +197,12 @@ e2e_profile_flags() {
             --disable-e2b \
             --disable-cilium \
             --disable-cloud-controller \
-            --egress-selector-mode disabled \
-            "--kubelet-arg=cgroup-root=${E2E_CGROUP_ROOT}"
+            --egress-selector-mode disabled
         ;;
     l3)
         printf '%s\n' \
             --disable-cloud-controller \
-            --egress-selector-mode disabled \
-            "--kubelet-arg=cgroup-root=${E2E_CGROUP_ROOT}"
+            --egress-selector-mode disabled
         ;;
     *) ;;
     esac
@@ -305,7 +312,9 @@ e2e_wait_api() {
 
 # e2e_wait_manifests waits until the control plane has written its staged addon
 # manifests. Controllers (and therefore staging) only start once the API server
-# reports ready, so waiting on /readyz alone races with the staging step.
+# reports ready, so waiting on /readyz alone races with the staging step. The
+# directory is checked from inside the container, which can read the 0700 tree its
+# root-owned server created (see E2E_IN_CONTAINER_MANIFESTS_DIR).
 e2e_wait_manifests() {
     local deadline
     deadline=$(($(date +%s) + E2E_STAGING_TIMEOUT))
@@ -313,7 +322,7 @@ e2e_wait_manifests() {
         if ! e2e_container_running; then
             e2e_die "container ${E2E_CONTAINER} exited while waiting for addon staging"
         fi
-        if [ -d "${E2E_MANIFESTS_DIR}" ]; then
+        if e2e_in_container test -d "${E2E_IN_CONTAINER_MANIFESTS_DIR}" 2>/dev/null; then
             return 0
         fi
         sleep 2

--- a/hack/e2e/lib.sh
+++ b/hack/e2e/lib.sh
@@ -147,7 +147,7 @@ e2e_check_absent() {
 
 e2e_summary() {
     printf '\n[e2e:%s] %d checks, %d failures\n' "${E2E_PROFILE}" "${E2E_CHECKS}" "${E2E_FAILURES}"
-    if [ "${E2E_FAILURES}" -ne 0 ]; then
+    if [[ "${E2E_FAILURES}" -ne 0 ]]; then
         return 1
     fi
     return 0
@@ -161,7 +161,7 @@ e2e_require_cmds() {
             missing="${missing} ${cmd}"
         fi
     done
-    if [ -n "${missing}" ]; then
+    if [[ -n "${missing}" ]]; then
         e2e_die "missing required commands:${missing}"
     fi
 }
@@ -206,7 +206,7 @@ e2e_profile_flags() {
         ;;
     *) ;;
     esac
-    if [ -n "${E2E_EXTRA_SERVER_ARGS}" ]; then
+    if [[ -n "${E2E_EXTRA_SERVER_ARGS}" ]]; then
         # Intentionally word-split: the value is a flag list.
         # shellcheck disable=SC2086
         printf '%s\n' ${E2E_EXTRA_SERVER_ARGS}
@@ -214,18 +214,18 @@ e2e_profile_flags() {
 }
 
 e2e_profile_needs_agent() {
-    [ "${E2E_PROFILE}" != "l1" ]
+    [[ "${E2E_PROFILE}" != "l1" ]]
 }
 
 # Extra docker arguments required by the profile.
 e2e_profile_docker_args() {
     if e2e_profile_needs_agent; then
         printf '%s\n' --privileged --cgroupns=host
-        if [ -d /lib/modules ]; then
+        if [[ -d /lib/modules ]]; then
             printf '%s\n' -v /lib/modules:/lib/modules:ro
         fi
     fi
-    if [ "${E2E_PROFILE}" = "l3" ] && [ -d /sys/fs/bpf ]; then
+    if [[ "${E2E_PROFILE}" = "l3" ]] && [[ -d /sys/fs/bpf ]]; then
         printf '%s\n' -v /sys/fs/bpf:/sys/fs/bpf
     fi
 }
@@ -237,11 +237,11 @@ e2e_container_exists() {
 }
 
 e2e_container_running() {
-    [ "$(docker inspect -f '{{.State.Running}}' "$E2E_CONTAINER" 2>/dev/null)" = "true" ]
+    [[ "$(docker inspect -f '{{.State.Running}}' "$E2E_CONTAINER" 2>/dev/null)" = "true" ]]
 }
 
 e2e_build_image() {
-    if [ "${E2E_SKIP_IMAGE_BUILD}" = "1" ]; then
+    if [[ "${E2E_SKIP_IMAGE_BUILD}" = "1" ]]; then
         e2e_log "skipping image build (E2E_SKIP_IMAGE_BUILD=1)"
         return 0
     fi
@@ -283,7 +283,7 @@ e2e_rewrite_kubeconfig() {
 e2e_wait_api() {
     local deadline log
     deadline=$(($(date +%s) + E2E_API_TIMEOUT))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         if ! e2e_container_running; then
             log="$(docker logs --tail 200 "${E2E_CONTAINER}" 2>&1 || true)"
             printf '\n--- container logs ---\n%s\n' "${log}" >&2
@@ -318,7 +318,7 @@ e2e_wait_api() {
 e2e_wait_manifests() {
     local deadline
     deadline=$(($(date +%s) + E2E_STAGING_TIMEOUT))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         if ! e2e_container_running; then
             e2e_die "container ${E2E_CONTAINER} exited while waiting for addon staging"
         fi
@@ -334,7 +334,7 @@ e2e_wait_manifests() {
 e2e_wait_node_ready() {
     local deadline
     deadline=$(($(date +%s) + E2E_NODE_TIMEOUT))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         if ! e2e_container_running; then
             e2e_die "container ${E2E_CONTAINER} exited while waiting for the node"
         fi
@@ -353,7 +353,7 @@ e2e_wait_node_ready() {
 e2e_wait_node_registered() {
     local deadline
     deadline=$(($(date +%s) + E2E_NODE_TIMEOUT))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         if ! e2e_container_running; then
             e2e_die "container ${E2E_CONTAINER} exited while waiting for a node"
         fi
@@ -379,7 +379,7 @@ e2e_wait_namespace_ready() {
     local namespace="${1:-default}"
     local deadline
     deadline=$(($(date +%s) + ${E2E_NAMESPACE_TIMEOUT:-120}))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         if ! e2e_container_running; then
             e2e_die "container ${E2E_CONTAINER} exited while waiting for namespace ${namespace}"
         fi
@@ -400,7 +400,7 @@ e2e_wait_pod_running() {
     local timeout="${2:-120}"
     local deadline phase
     deadline=$(($(date +%s) + timeout))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         phase="$(e2e_kubectl get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
         case "${phase}" in
         Running) return 0 ;;
@@ -461,11 +461,11 @@ e2e_verify_containerd_root() {
 # while walking the index. `--platform` trims the index down to the node's
 # architecture, which is what the node can execute anyway.
 e2e_preload_images() {
-    [ -n "${E2E_PRELOAD_IMAGES:-}" ] || return 0
+    [[ -n "${E2E_PRELOAD_IMAGES:-}" ]] || return 0
 
     local deadline image platform save_flags
     deadline=$(($(date +%s) + ${E2E_PRELOAD_TIMEOUT:-300}))
-    while [ "$(date +%s)" -lt "${deadline}" ]; do
+    while [[ "$(date +%s)" -lt "${deadline}" ]]; do
         if ! e2e_container_running; then
             e2e_die "container ${E2E_CONTAINER} exited while waiting for containerd"
         fi
@@ -492,7 +492,7 @@ e2e_preload_images() {
     # plain docker-archive that imports as-is, so the flag is simply optional.
     save_flags=()
     platform="$(e2e_node_platform)"
-    if [ -n "${platform}" ] && docker save --help 2>&1 | grep -q -- '--platform'; then
+    if [[ -n "${platform}" ]] && docker save --help 2>&1 | grep -q -- '--platform'; then
         save_flags+=(--platform "${platform}")
     else
         e2e_warn "docker save does not support --platform; importing whatever the daemon exports"
@@ -510,7 +510,7 @@ e2e_preload_images() {
 e2e_require_cluster() {
     e2e_container_running || e2e_die "container ${E2E_CONTAINER} is not running (run hack/e2e/up.sh first)"
     e2e_api_ready || e2e_die "K8E API is not ready"
-    [ -f "${E2E_KUBECONFIG}" ] || e2e_die "missing kubeconfig ${E2E_KUBECONFIG}"
+    [[ -f "${E2E_KUBECONFIG}" ]] || e2e_die "missing kubeconfig ${E2E_KUBECONFIG}"
 }
 
 e2e_in_container() {

--- a/hack/e2e/lib.sh
+++ b/hack/e2e/lib.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+# K8E end-to-end harness — shared helpers.
+#
+# Source this file from harness scripts; do not execute it directly.
+# Bash 3.2 compatible (macOS still ships 3.2): avoid bash 4+ builtins.
+
+set -euo pipefail
+
+E2E_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+E2E_REPO="$(cd "${E2E_DIR}/../.." && pwd)"
+
+E2E_PROFILE="${E2E_PROFILE:-l1}"
+E2E_API_TIMEOUT="${E2E_API_TIMEOUT:-300}"
+E2E_NODE_TIMEOUT="${E2E_NODE_TIMEOUT:-420}"
+E2E_STAGING_TIMEOUT="${E2E_STAGING_TIMEOUT:-120}"
+E2E_KEEP="${E2E_KEEP:-0}"
+E2E_PURGE="${E2E_PURGE:-0}"
+E2E_SKIP_IMAGE_BUILD="${E2E_SKIP_IMAGE_BUILD:-0}"
+E2E_IN_CONTAINER_API_PORT="${E2E_IN_CONTAINER_API_PORT:-6443}"
+E2E_IMAGE="${E2E_IMAGE:-k8e-e2e:local}"
+E2E_EXTRA_SERVER_ARGS="${E2E_EXTRA_SERVER_ARGS:-}"
+E2E_GO_TEST_ARGS="${E2E_GO_TEST_ARGS:-}"
+E2E_SKIP_GO_TESTS="${E2E_SKIP_GO_TESTS:-0}"
+
+E2E_CHECKS=0
+E2E_FAILURES=0
+
+# e2e_set_profile <profile>
+# Resolve profile-derived paths. Anything already exported by the caller wins.
+e2e_set_profile() {
+    E2E_PROFILE="$1"
+    : "${E2E_CONTAINER:=k8e-e2e-${E2E_PROFILE}}"
+    : "${E2E_STATE_DIR:=/tmp/k8e-e2e/${E2E_PROFILE}}"
+    : "${E2E_DATA_DIR:=${E2E_STATE_DIR}/var}"
+    : "${E2E_DIAG_DIR:=${E2E_STATE_DIR}/diagnostics}"
+    : "${E2E_BINARY:=${E2E_REPO}/bin/k8e}"
+    : "${E2E_KUBECONFIG:=${E2E_STATE_DIR}/kubeconfig}"
+    # up.sh runs the server with --data-dir /test/data and mounts ${E2E_DATA_DIR}
+    # at /test, so the staged addon manifests land here on the host.
+    : "${E2E_MANIFESTS_DIR:=${E2E_DATA_DIR}/data/server/manifests}"
+    # Each profile publishes its API on its own host port so that clusters kept
+    # alive with E2E_KEEP=1 do not fight over a single port.
+    case "${E2E_PROFILE}" in
+    l1) : "${E2E_API_PORT:=16443}" ;;
+    l2) : "${E2E_API_PORT:=16444}" ;;
+    l3) : "${E2E_API_PORT:=16445}" ;;
+    esac
+    # Dedicated cgroup subtree for kubelet. The container entrypoint creates it
+    # before k8e starts; keeping the host's cgroup tree untouched.
+    : "${E2E_CGROUP_ROOT:=/k8e-e2e}"
+    # containerd socket created by the agent inside the container.
+    : "${E2E_CONTAINERD_SOCKET:=/run/k8e/containerd/containerd.sock}"
+    : "${E2E_TEST_IMAGE:=busybox:1.36}"
+    # containerd keeps its snapshots under <data-dir>/agent/containerd and uses
+    # that directory as the upper layer of the overlayfs it mounts for every
+    # container rootfs. The data directory is a host bind mount, which on Docker
+    # Desktop/OrbStack is virtiofs and cannot back an overlay upper layer: the
+    # snapshot mounts come up read-only and every pod sandbox dies with
+    #   mkdirat(.../rootfs, "proc", 0o755): Read-only file system
+    # So the runtime lives on a dedicated volume, mounted OUTSIDE the bind mount
+    # (a volume nested under a virtiofs share is silently not applied at all --
+    # `docker inspect` lists it, /proc/mounts does not; the entrypoint links the
+    # volume in at E2E_CONTAINERD_ROOT).
+    : "${E2E_CONTAINERD_ROOT:=/test/data/agent/containerd}"
+    : "${E2E_CONTAINERD_ROOT_VOLUME:=k8e-e2e-${E2E_PROFILE}-containerd}"
+    : "${E2E_CONTAINERD_VOLUME_PATH:=/var/lib/k8e-containerd}"
+
+    case "${E2E_PROFILE}" in
+    l1)
+        # No kubelet at all: nothing to wait for, nothing to run.
+        : "${E2E_EXPECT_NODE_READY:=0}"
+        : "${E2E_PRELOAD_IMAGES:=}"
+        ;;
+    l2)
+        # No CNI, so kubelet stays NetworkReady=false and the node never turns
+        # Ready; registration is the strongest signal this profile can give.
+        : "${E2E_EXPECT_NODE_READY:=0}"
+        : "${E2E_PRELOAD_IMAGES:=rancher/mirrored-pause:3.6 ${E2E_TEST_IMAGE}}"
+        ;;
+    l3)
+        : "${E2E_EXPECT_NODE_READY:=1}"
+        : "${E2E_PRELOAD_IMAGES:=rancher/mirrored-pause:3.6 ${E2E_TEST_IMAGE}}"
+        ;;
+    *)
+        e2e_die "unknown E2E profile '${E2E_PROFILE}' (expected l1, l2 or l3)"
+        ;;
+    esac
+
+    export E2E_PROFILE E2E_CONTAINER E2E_STATE_DIR E2E_DATA_DIR E2E_DIAG_DIR
+    export E2E_BINARY E2E_KUBECONFIG E2E_IMAGE E2E_API_PORT E2E_MANIFESTS_DIR
+    export E2E_CGROUP_ROOT E2E_CONTAINERD_SOCKET E2E_TEST_IMAGE
+    export E2E_CONTAINERD_ROOT E2E_CONTAINERD_ROOT_VOLUME E2E_CONTAINERD_VOLUME_PATH
+    export E2E_EXPECT_NODE_READY E2E_PRELOAD_IMAGES
+    export E2E_API_TIMEOUT E2E_NODE_TIMEOUT E2E_STAGING_TIMEOUT E2E_KEEP E2E_PURGE
+    export E2E_SKIP_IMAGE_BUILD E2E_IN_CONTAINER_API_PORT E2E_EXTRA_SERVER_ARGS
+    export E2E_GO_TEST_ARGS E2E_SKIP_GO_TESTS
+}
+
+e2e_log() { printf '[e2e:%s] %s\n' "${E2E_PROFILE}" "$*"; }
+e2e_warn() { printf '[e2e:%s] WARNING: %s\n' "${E2E_PROFILE}" "$*" >&2; }
+e2e_die() {
+    printf '[e2e:%s] ERROR: %s\n' "${E2E_PROFILE}" "$*" >&2
+    exit 1
+}
+
+e2e_ok() {
+    E2E_CHECKS=$((E2E_CHECKS + 1))
+    printf '  ok   %s\n' "$1"
+}
+
+e2e_bad() {
+    E2E_CHECKS=$((E2E_CHECKS + 1))
+    E2E_FAILURES=$((E2E_FAILURES + 1))
+    printf '  FAIL %s\n' "$1"
+}
+
+# e2e_check <description> <command...>
+e2e_check() {
+    local description="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        e2e_ok "$description"
+    else
+        e2e_bad "$description"
+    fi
+}
+
+# e2e_check_absent <description> <command...>
+e2e_check_absent() {
+    local description="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        e2e_bad "$description"
+    else
+        e2e_ok "$description"
+    fi
+}
+
+e2e_summary() {
+    printf '\n[e2e:%s] %d checks, %d failures\n' "${E2E_PROFILE}" "${E2E_CHECKS}" "${E2E_FAILURES}"
+    if [ "${E2E_FAILURES}" -ne 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+e2e_require_cmds() {
+    local missing=""
+    local cmd
+    for cmd in "$@"; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            missing="${missing} ${cmd}"
+        fi
+    done
+    if [ -n "${missing}" ]; then
+        e2e_die "missing required commands:${missing}"
+    fi
+}
+
+# --- profiles -------------------------------------------------------------
+
+# l1: control plane only (no agent, no CNI) — validates API, addon staging,
+#     disable semantics and restart recovery.
+# l2: control plane + agent, no CNI — validates kubelet/containerd bring-up.
+# l3: full stack including the bundled Cilium CNI/Gateway.
+e2e_profile_flags() {
+    case "${E2E_PROFILE}" in
+    l1)
+        printf '%s\n' \
+            --disable-agent \
+            --disable-sandbox-matrix \
+            --disable-e2b \
+            --disable-cilium \
+            --disable-cloud-controller \
+            --egress-selector-mode disabled
+        ;;
+    l2)
+        printf '%s\n' \
+            --disable-sandbox-matrix \
+            --disable-e2b \
+            --disable-cilium \
+            --disable-cloud-controller \
+            --egress-selector-mode disabled \
+            "--kubelet-arg=cgroup-root=${E2E_CGROUP_ROOT}"
+        ;;
+    l3)
+        printf '%s\n' \
+            --disable-cloud-controller \
+            --egress-selector-mode disabled \
+            "--kubelet-arg=cgroup-root=${E2E_CGROUP_ROOT}"
+        ;;
+    esac
+    if [ -n "${E2E_EXTRA_SERVER_ARGS}" ]; then
+        # Intentionally word-split: the value is a flag list.
+        # shellcheck disable=SC2086
+        printf '%s\n' ${E2E_EXTRA_SERVER_ARGS}
+    fi
+}
+
+e2e_profile_needs_agent() {
+    [ "${E2E_PROFILE}" != "l1" ]
+}
+
+# Extra docker arguments required by the profile.
+e2e_profile_docker_args() {
+    if e2e_profile_needs_agent; then
+        printf '%s\n' --privileged --cgroupns=host
+        if [ -d /lib/modules ]; then
+            printf '%s\n' -v /lib/modules:/lib/modules:ro
+        fi
+    fi
+    if [ "${E2E_PROFILE}" = "l3" ] && [ -d /sys/fs/bpf ]; then
+        printf '%s\n' -v /sys/fs/bpf:/sys/fs/bpf
+    fi
+}
+
+# --- docker / cluster state ----------------------------------------------
+
+e2e_container_exists() {
+    docker inspect "$E2E_CONTAINER" >/dev/null 2>&1
+}
+
+e2e_container_running() {
+    [ "$(docker inspect -f '{{.State.Running}}' "$E2E_CONTAINER" 2>/dev/null)" = "true" ]
+}
+
+e2e_build_image() {
+    if [ "${E2E_SKIP_IMAGE_BUILD}" = "1" ]; then
+        e2e_log "skipping image build (E2E_SKIP_IMAGE_BUILD=1)"
+        return 0
+    fi
+    if docker image inspect "${E2E_IMAGE}" >/dev/null 2>&1; then
+        e2e_log "reusing existing image ${E2E_IMAGE}"
+        return 0
+    fi
+    e2e_log "building ${E2E_IMAGE} from hack/e2e/Dockerfile"
+    docker build -q -f "${E2E_DIR}/Dockerfile" -t "${E2E_IMAGE}" "${E2E_DIR}" >/dev/null
+}
+
+# --- kubectl helpers ------------------------------------------------------
+
+e2e_kubectl() {
+    kubectl --kubeconfig "${E2E_KUBECONFIG}" --request-timeout=20s "$@"
+}
+
+e2e_api_ready() {
+    kubectl --kubeconfig "${E2E_KUBECONFIG}" --request-timeout=3s get --raw=/readyz >/dev/null 2>&1
+}
+
+# Copy the in-container kubeconfig out and point it at the published port.
+e2e_rewrite_kubeconfig() {
+    local source="${E2E_DATA_DIR}/kubeconfig.yaml"
+    [ -s "${source}" ] || return 1
+    cp "${source}" "${E2E_KUBECONFIG}"
+    kubectl --kubeconfig "${E2E_KUBECONFIG}" config set-cluster default \
+        --server="https://127.0.0.1:${E2E_API_PORT}" >/dev/null
+    return 0
+}
+
+e2e_wait_api() {
+    local deadline log
+    deadline=$(($(date +%s) + E2E_API_TIMEOUT))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        if ! e2e_container_running; then
+            log="$(docker logs --tail 200 "${E2E_CONTAINER}" 2>&1 || true)"
+            printf '\n--- container logs ---\n%s\n' "${log}" >&2
+            # `zig build k8e` produces cmd/server, which -- unlike the release
+            # cmd/k8e multicall binary -- embeds no runtime binaries. Profiles
+            # with an agent therefore die trying to exec containerd from PATH.
+            if e2e_profile_needs_agent && printf '%s' "${log}" | grep -q 'executable file not found in \$PATH'; then
+                e2e_die "profile ${E2E_PROFILE} needs an agent, but ${E2E_BINARY} bundles no container runtime. Build a release binary (cmd/k8e, which stages containerd/runc) or use an image that provides them in PATH; the l1 profile works with the cmd/server build."
+            fi
+            e2e_die "container ${E2E_CONTAINER} exited before the API became ready (see logs above); E2E_BINARY=${E2E_BINARY} must be a linux/amd64 build of k8e"
+        fi
+        if e2e_rewrite_kubeconfig && e2e_api_ready; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+# e2e_wait_manifests waits until the control plane has written its staged addon
+# manifests. Controllers (and therefore staging) only start once the API server
+# reports ready, so waiting on /readyz alone races with the staging step.
+e2e_wait_manifests() {
+    local deadline
+    deadline=$(($(date +%s) + E2E_STAGING_TIMEOUT))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        if ! e2e_container_running; then
+            e2e_die "container ${E2E_CONTAINER} exited while waiting for addon staging"
+        fi
+        if [ -d "${E2E_MANIFESTS_DIR}" ]; then
+            return 0
+        fi
+        sleep 2
+    done
+    e2e_warn "addon manifests were not staged within ${E2E_STAGING_TIMEOUT}s"
+    return 1
+}
+
+e2e_wait_node_ready() {
+    local deadline
+    deadline=$(($(date +%s) + E2E_NODE_TIMEOUT))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        if ! e2e_container_running; then
+            e2e_die "container ${E2E_CONTAINER} exited while waiting for the node"
+        fi
+        if e2e_kubectl wait --for=condition=Ready node --all --timeout=5s >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 5
+    done
+    e2e_warn "node did not become Ready within ${E2E_NODE_TIMEOUT}s"
+    return 1
+}
+
+# e2e_wait_node_registered waits until kubelet has registered the node and is
+# posting its status. Profiles without a CNI never report Ready, so this is the
+# strongest signal they can give.
+e2e_wait_node_registered() {
+    local deadline
+    deadline=$(($(date +%s) + E2E_NODE_TIMEOUT))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        if ! e2e_container_running; then
+            e2e_die "container ${E2E_CONTAINER} exited while waiting for a node"
+        fi
+        if e2e_kubectl get nodes -o jsonpath='{range .items[*]}{.status.nodeInfo.kubeletVersion}{"\n"}{end}' 2>/dev/null | grep -q .; then
+            return 0
+        fi
+        sleep 2
+    done
+    e2e_warn "no node was registered within ${E2E_NODE_TIMEOUT}s"
+    return 1
+}
+
+# e2e_wait_namespace_ready [namespace]
+#
+# The API server serves traffic before kube-controller-manager has populated the
+# per-namespace bootstrap objects. Every pod needs them, and without this wait
+# the first attempts fail with confusing, non-obvious errors:
+#   * `default` ServiceAccount missing  -> "error looking up service account
+#     default/default: serviceaccount \"default\" not found" (Forbidden)
+#   * `kube-root-ca.crt` ConfigMap missing -> the kube-api-access projected
+#     volume never becomes mountable ("configmap \"kube-root-ca.crt\" not found")
+e2e_wait_namespace_ready() {
+    local namespace="${1:-default}"
+    local deadline
+    deadline=$(($(date +%s) + ${E2E_NAMESPACE_TIMEOUT:-120}))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        if ! e2e_container_running; then
+            e2e_die "container ${E2E_CONTAINER} exited while waiting for namespace ${namespace}"
+        fi
+        if e2e_kubectl get serviceaccount default -n "${namespace}" >/dev/null 2>&1 &&
+            e2e_kubectl get configmap kube-root-ca.crt -n "${namespace}" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+    done
+    e2e_warn "namespace ${namespace} was not fully bootstrapped within ${E2E_NAMESPACE_TIMEOUT:-120}s"
+    return 1
+}
+
+# e2e_wait_pod_running <pod> [timeout]
+# Waits for a pod to reach Running; returns 1 on Failed/unknown-phase timeout.
+e2e_wait_pod_running() {
+    local pod="$1"
+    local timeout="${2:-120}"
+    local deadline phase
+    deadline=$(($(date +%s) + timeout))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        phase="$(e2e_kubectl get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+        case "${phase}" in
+        Running) return 0 ;;
+        Failed | Succeeded) return 1 ;;
+        esac
+        sleep 3
+    done
+    return 1
+}
+
+# e2e_node_platform maps the container's machine type to an OCI platform string.
+# Empty output means "unknown, do not filter".
+e2e_node_platform() {
+    case "$(e2e_in_container uname -m 2>/dev/null || true)" in
+    x86_64 | amd64) printf 'linux/amd64\n' ;;
+    aarch64 | arm64) printf 'linux/arm64\n' ;;
+    armv7l) printf 'linux/arm/v7\n' ;;
+    s390x) printf 'linux/s390x\n' ;;
+    ppc64le) printf 'linux/ppc64le\n' ;;
+    riscv64) printf 'linux/riscv64\n' ;;
+    esac
+}
+
+# e2e_verify_containerd_root
+#
+# Proves that containerd's root directory can actually back an overlayfs upper
+# layer by mounting one there. Without this, a root directory that landed on a
+# filesystem which cannot do so (a virtiofs host bind mount is the usual
+# suspect) stays silent: the cluster comes up healthy, and every pod then fails
+# with `mkdirat(.../rootfs, "proc", 0o755): Read-only file system`.
+e2e_verify_containerd_root() {
+    e2e_in_container sh -c '
+        set -e
+        probe="$1/.overlay-probe"
+        rm -rf "$probe"
+        mkdir -p "$probe/lower" "$probe/upper" "$probe/work" "$probe/merged"
+        mount -t overlay overlay \
+            -o "lowerdir=$probe/lower,upperdir=$probe/upper,workdir=$probe/work" \
+            "$probe/merged"
+        mkdir "$probe/merged/probe-dir"
+        umount "$probe/merged"
+        rm -rf "$probe"
+    ' e2e-overlay-probe "${E2E_CONTAINERD_ROOT}" >/dev/null 2>&1
+}
+
+# e2e_preload_images imports ${E2E_PRELOAD_IMAGES} into the cluster's containerd.
+#
+# The node gets no reliable registry access (and CI should not depend on one),
+# so images are pulled on the host and pushed in through `ctr images import`.
+# Importing into the k8s.io namespace is what makes CRI see them.
+#
+# `docker save` has to be told which platform to export. When Docker uses the
+# containerd image store it writes an OCI layout whose top-level index.json lists
+# every platform of the image, but only the blobs of the local one are included;
+# `ctr images import` then fails with `content digest sha256:...: not found`
+# while walking the index. `--platform` trims the index down to the node's
+# architecture, which is what the node can execute anyway.
+e2e_preload_images() {
+    [ -n "${E2E_PRELOAD_IMAGES:-}" ] || return 0
+
+    local deadline image platform save_flags
+    deadline=$(($(date +%s) + ${E2E_PRELOAD_TIMEOUT:-300}))
+    while [ "$(date +%s)" -lt "${deadline}" ]; do
+        if ! e2e_container_running; then
+            e2e_die "container ${E2E_CONTAINER} exited while waiting for containerd"
+        fi
+        if e2e_in_container test -S "${E2E_CONTAINERD_SOCKET}" 2>/dev/null; then
+            break
+        fi
+        sleep 2
+    done
+    if ! e2e_in_container test -S "${E2E_CONTAINERD_SOCKET}" 2>/dev/null; then
+        e2e_warn "containerd socket ${E2E_CONTAINERD_SOCKET} never appeared"
+        return 1
+    fi
+
+    for image in ${E2E_PRELOAD_IMAGES}; do
+        if ! docker image inspect "${image}" >/dev/null 2>&1; then
+            if ! docker pull -q "${image}" >/dev/null; then
+                e2e_warn "could not pull ${image} on the host"
+                return 1
+            fi
+        fi
+    done
+
+    # `docker save --platform` only exists on newer clients; older ones write a
+    # plain docker-archive that imports as-is, so the flag is simply optional.
+    save_flags=()
+    platform="$(e2e_node_platform)"
+    if [ -n "${platform}" ] && docker save --help 2>&1 | grep -q -- '--platform'; then
+        save_flags+=(--platform "${platform}")
+    else
+        e2e_warn "docker save does not support --platform; importing whatever the daemon exports"
+    fi
+
+    # shellcheck disable=SC2086
+    if ! docker save "${save_flags[@]+"${save_flags[@]}"}" ${E2E_PRELOAD_IMAGES} |
+        e2e_in_container_stdin ctr --address "${E2E_CONTAINERD_SOCKET}" --namespace k8s.io images import - >/dev/null; then
+        e2e_warn "could not import ${E2E_PRELOAD_IMAGES} into containerd"
+        return 1
+    fi
+    e2e_log "preloaded images: ${E2E_PRELOAD_IMAGES}"
+}
+
+e2e_require_cluster() {
+    e2e_container_running || e2e_die "container ${E2E_CONTAINER} is not running (run hack/e2e/up.sh first)"
+    e2e_api_ready || e2e_die "K8E API is not ready"
+    [ -f "${E2E_KUBECONFIG}" ] || e2e_die "missing kubeconfig ${E2E_KUBECONFIG}"
+}
+
+e2e_in_container() {
+    docker exec "${E2E_CONTAINER}" "$@"
+}
+
+# e2e_in_container_stdin <command...>
+# Like e2e_in_container, but keeps stdin attached so the command can read piped
+# input (e.g. `ctr images import -`). Plain `docker exec` closes stdin, which
+# makes such commands fail with "unrecognized image format".
+e2e_in_container_stdin() {
+    docker exec -i "${E2E_CONTAINER}" "$@"
+}
+
+e2e_usage() {
+    cat <<EOF
+K8E end-to-end harness
+
+  hack/e2e/up.sh <profile>     start a single-node cluster in a container
+  hack/e2e/dump-logs.sh        collect diagnostics into \${E2E_DIAG_DIR}
+  hack/e2e/down.sh             stop and remove the cluster container
+  hack/e2e/run.sh <profile> [suite...]
+                               up -> suites -> diagnostics on failure -> down
+
+Profiles:
+  l1  control plane only (no agent, no CNI) — implemented and runs in CI
+  l2  control plane + agent, no CNI — implemented: Docker pulls the pause and
+      busybox images on the host and preloads them into the node
+  l3  full stack (containerd + Cilium CNI) — cluster can be started, no suite
+      yet
+
+Only suites/l1.sh and suites/l2.sh exist today. The k8e binary built by
+`zig build k8e` (cmd/server) embeds no runtime binaries, so the image supplies
+containerd/runc itself (see Dockerfile); container images come from the host
+through `ctr images import` because the node has no registry access.
+
+Agent profiles keep containerd's storage on a Docker volume (mounted at
+/var/lib/k8e-containerd and linked into the data directory): the virtiofs-backed
+/test bind mount cannot host containerd's overlayfs snapshots, which would
+otherwise come up read-only. up.sh verifies this before running a suite.
+
+Environment:
+  E2E_BINARY      k8e binary to run (default: <repo>/bin/k8e), must be a linux
+                  build for the Docker daemon's architecture
+  E2E_IMAGE       container image (default: k8e-e2e:local)
+  E2E_API_PORT    published API port on the host (default: 16443, 16444, 16445
+                  for l1, l2, l3 so profiles can coexist)
+  E2E_KEEP=1      leave the container running after run.sh
+  E2E_REUSE=1     reuse the existing data directory and runtime volume in up.sh
+  E2E_PURGE=1     remove the state directory and runtime volume in down.sh
+EOF
+}

--- a/hack/e2e/lib.sh
+++ b/hack/e2e/lib.sh
@@ -17,6 +17,10 @@ E2E_KEEP="${E2E_KEEP:-0}"
 E2E_PURGE="${E2E_PURGE:-0}"
 E2E_SKIP_IMAGE_BUILD="${E2E_SKIP_IMAGE_BUILD:-0}"
 E2E_IN_CONTAINER_API_PORT="${E2E_IN_CONTAINER_API_PORT:-6443}"
+# Where up.sh mounts ${E2E_DATA_DIR} inside the container, and the kubeconfig the
+# server writes there. Defined once so the mount and its readers cannot drift.
+E2E_IN_CONTAINER_DATA_DIR="${E2E_IN_CONTAINER_DATA_DIR:-/test}"
+E2E_IN_CONTAINER_KUBECONFIG="${E2E_IN_CONTAINER_KUBECONFIG:-${E2E_IN_CONTAINER_DATA_DIR}/kubeconfig.yaml}"
 E2E_IMAGE="${E2E_IMAGE:-k8e-e2e:local}"
 E2E_EXTRA_SERVER_ARGS="${E2E_EXTRA_SERVER_ARGS:-}"
 E2E_GO_TEST_ARGS="${E2E_GO_TEST_ARGS:-}"
@@ -35,15 +39,18 @@ e2e_set_profile() {
     : "${E2E_DIAG_DIR:=${E2E_STATE_DIR}/diagnostics}"
     : "${E2E_BINARY:=${E2E_REPO}/bin/k8e}"
     : "${E2E_KUBECONFIG:=${E2E_STATE_DIR}/kubeconfig}"
-    # up.sh runs the server with --data-dir /test/data and mounts ${E2E_DATA_DIR}
-    # at /test, so the staged addon manifests land here on the host.
+    # up.sh runs the server with
+    # --data-dir ${E2E_IN_CONTAINER_DATA_DIR}/data and mounts ${E2E_DATA_DIR}
+    # there, so the staged addon manifests land here on the host.
     : "${E2E_MANIFESTS_DIR:=${E2E_DATA_DIR}/data/server/manifests}"
     # Each profile publishes its API on its own host port so that clusters kept
-    # alive with E2E_KEEP=1 do not fight over a single port.
+    # alive with E2E_KEEP=1 do not fight over a single port. An unknown profile is
+    # rejected by the case further down, so no port default is needed here.
     case "${E2E_PROFILE}" in
     l1) : "${E2E_API_PORT:=16443}" ;;
     l2) : "${E2E_API_PORT:=16444}" ;;
     l3) : "${E2E_API_PORT:=16445}" ;;
+    *) ;;
     esac
     # Dedicated cgroup subtree for kubelet. The container entrypoint creates it
     # before k8e starts; keeping the host's cgroup tree untouched.
@@ -93,6 +100,7 @@ e2e_set_profile() {
     export E2E_EXPECT_NODE_READY E2E_PRELOAD_IMAGES
     export E2E_API_TIMEOUT E2E_NODE_TIMEOUT E2E_STAGING_TIMEOUT E2E_KEEP E2E_PURGE
     export E2E_SKIP_IMAGE_BUILD E2E_IN_CONTAINER_API_PORT E2E_EXTRA_SERVER_ARGS
+    export E2E_IN_CONTAINER_DATA_DIR E2E_IN_CONTAINER_KUBECONFIG
     export E2E_GO_TEST_ARGS E2E_SKIP_GO_TESTS
 }
 
@@ -189,6 +197,7 @@ e2e_profile_flags() {
             --egress-selector-mode disabled \
             "--kubelet-arg=cgroup-root=${E2E_CGROUP_ROOT}"
         ;;
+    *) ;;
     esac
     if [ -n "${E2E_EXTRA_SERVER_ARGS}" ]; then
         # Intentionally word-split: the value is a flag list.
@@ -248,10 +257,17 @@ e2e_api_ready() {
 }
 
 # Copy the in-container kubeconfig out and point it at the published port.
+#
+# The server writes it as root with mode 0600, so the bind-mounted copy is only
+# readable by its owner: on Docker Desktop/OrbStack the mount is mapped to the
+# caller and `cp` works, but on a plain Linux host (CI) the unprivileged user
+# gets "Permission denied" instead. Reading it through the container works
+# everywhere, and the temp file keeps a half-written config from being used.
 e2e_rewrite_kubeconfig() {
-    local source="${E2E_DATA_DIR}/kubeconfig.yaml"
-    [ -s "${source}" ] || return 1
-    cp "${source}" "${E2E_KUBECONFIG}"
+    local tmp="${E2E_KUBECONFIG}.tmp"
+    e2e_in_container test -s "${E2E_IN_CONTAINER_KUBECONFIG}" || return 1
+    e2e_in_container cat "${E2E_IN_CONTAINER_KUBECONFIG}" >"${tmp}" || return 1
+    mv "${tmp}" "${E2E_KUBECONFIG}"
     kubectl --kubeconfig "${E2E_KUBECONFIG}" config set-cluster default \
         --server="https://127.0.0.1:${E2E_API_PORT}" >/dev/null
     return 0
@@ -264,6 +280,13 @@ e2e_wait_api() {
         if ! e2e_container_running; then
             log="$(docker logs --tail 200 "${E2E_CONTAINER}" 2>&1 || true)"
             printf '\n--- container logs ---\n%s\n' "${log}" >&2
+            if e2e_profile_needs_agent; then
+                # containerd logs to a file under its own root, not to stdout, so
+                # the dump above never shows why it refused to start (a config it
+                # rejects kills it before k8e can print anything useful).
+                printf '\n--- containerd log (last 50 lines) ---\n' >&2
+                e2e_containerd_log 50 >&2
+            fi
             # `zig build k8e` produces cmd/server, which -- unlike the release
             # cmd/k8e multicall binary -- embeds no runtime binaries. Profiles
             # with an agent therefore die trying to exec containerd from PATH.
@@ -373,6 +396,7 @@ e2e_wait_pod_running() {
         case "${phase}" in
         Running) return 0 ;;
         Failed | Succeeded) return 1 ;;
+        *) ;;
         esac
         sleep 3
     done
@@ -389,6 +413,7 @@ e2e_node_platform() {
     s390x) printf 'linux/s390x\n' ;;
     ppc64le) printf 'linux/ppc64le\n' ;;
     riscv64) printf 'linux/riscv64\n' ;;
+    *) ;;
     esac
 }
 
@@ -446,11 +471,11 @@ e2e_preload_images() {
     fi
 
     for image in ${E2E_PRELOAD_IMAGES}; do
-        if ! docker image inspect "${image}" >/dev/null 2>&1; then
-            if ! docker pull -q "${image}" >/dev/null; then
-                e2e_warn "could not pull ${image} on the host"
-                return 1
-            fi
+        # Reuse a local copy when there is one, otherwise pull it.
+        if ! docker image inspect "${image}" >/dev/null 2>&1 &&
+            ! docker pull -q "${image}" >/dev/null; then
+            e2e_warn "could not pull ${image} on the host"
+            return 1
         fi
     done
 
@@ -489,6 +514,21 @@ e2e_in_container() {
 # makes such commands fail with "unrecognized image format".
 e2e_in_container_stdin() {
     docker exec -i "${E2E_CONTAINER}" "$@"
+}
+
+# e2e_containerd_log [lines]
+# Print the tail of containerd's own log file.
+#
+# containerd writes it under its root directory, which lives on the runtime
+# volume and is therefore invisible from the /test bind mount: `docker cp` is the
+# only way to reach it, and unlike `docker exec` it also works on a stopped
+# container -- which is exactly when the log matters most.
+e2e_containerd_log() {
+    local lines="${1:-400}"
+    docker cp "${E2E_CONTAINER}:${E2E_CONTAINERD_ROOT}/containerd.log" - 2>/dev/null |
+        tar -xO 2>/dev/null |
+        tail -n "${lines}" || true
+    return 0
 }
 
 e2e_usage() {

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run one K8E end-to-end profile: up -> suites -> diagnostics on failure -> down.
+#
+#   hack/e2e/run.sh <profile> [suite...]
+#
+# Suites default to the profile name and live in hack/e2e/suites/<name>.sh.
+# E2E_KEEP=1 leaves the cluster running for interactive debugging.
+set -euo pipefail
+
+. "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]; then
+    e2e_usage
+    exit 0
+fi
+
+e2e_set_profile "$1"
+shift
+
+suites=("$@")
+if [ "${#suites[@]}" -eq 0 ]; then
+    suites=("${E2E_PROFILE}")
+fi
+
+status=0
+for suite in "${suites[@]}"; do
+    script="${E2E_DIR}/suites/${suite}.sh"
+    [ -f "${script}" ] || e2e_die "unknown suite '${suite}' (${script} not found); suites/l1.sh and suites/l2.sh are implemented so far"
+done
+
+"${E2E_DIR}/up.sh" "${E2E_PROFILE}"
+
+for suite in "${suites[@]}"; do
+    script="${E2E_DIR}/suites/${suite}.sh"
+    e2e_log "running suite ${suite}"
+    if ! bash "${script}"; then
+        e2e_bad "suite ${suite} failed"
+        status=1
+    fi
+done
+
+if [ "${status}" -ne 0 ]; then
+    e2e_log "collecting diagnostics after failure"
+    bash "${E2E_DIR}/dump-logs.sh" "${E2E_PROFILE}" || true
+fi
+
+if [ "${E2E_KEEP}" = "1" ]; then
+    e2e_log "E2E_KEEP=1: leaving ${E2E_CONTAINER} running"
+else
+    bash "${E2E_DIR}/down.sh" "${E2E_PROFILE}" || true
+fi
+
+if [ "${status}" -ne 0 ]; then
+    printf '\n[e2e:%s] E2E FAILED\n' "${E2E_PROFILE}"
+else
+    printf '\n[e2e:%s] E2E PASSED\n' "${E2E_PROFILE}"
+fi
+exit "${status}"

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -28,16 +28,22 @@ for suite in "${suites[@]}"; do
     [ -f "${script}" ] || e2e_die "unknown suite '${suite}' (${script} not found); suites/l1.sh and suites/l2.sh are implemented so far"
 done
 
-"${E2E_DIR}/up.sh" "${E2E_PROFILE}"
-
-for suite in "${suites[@]}"; do
-    script="${E2E_DIR}/suites/${suite}.sh"
-    e2e_log "running suite ${suite}"
-    if ! bash "${script}"; then
-        e2e_bad "suite ${suite} failed"
-        status=1
-    fi
-done
+# A bring-up failure is reported and diagnosed exactly like a suite failure:
+# otherwise up.sh dying (containerd refusing to start, the API never becoming
+# ready) would skip dump-logs.sh and leave CI without a single artifact.
+if "${E2E_DIR}/up.sh" "${E2E_PROFILE}"; then
+    for suite in "${suites[@]}"; do
+        script="${E2E_DIR}/suites/${suite}.sh"
+        e2e_log "running suite ${suite}"
+        if ! bash "${script}"; then
+            e2e_bad "suite ${suite} failed"
+            status=1
+        fi
+    done
+else
+    e2e_bad "cluster bring-up failed"
+    status=1
+fi
 
 if [ "${status}" -ne 0 ]; then
     e2e_log "collecting diagnostics after failure"

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 . "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ] || [ -z "${1:-}" ]; then
+if [[ "${1:-}" = "-h" ]] || [[ "${1:-}" = "--help" ]] || [[ -z "${1:-}" ]]; then
     e2e_usage
     exit 0
 fi
@@ -18,14 +18,14 @@ e2e_set_profile "$1"
 shift
 
 suites=("$@")
-if [ "${#suites[@]}" -eq 0 ]; then
+if [[ ${#suites[@]} -eq 0 ]]; then
     suites=("${E2E_PROFILE}")
 fi
 
 status=0
 for suite in "${suites[@]}"; do
     script="${E2E_DIR}/suites/${suite}.sh"
-    [ -f "${script}" ] || e2e_die "unknown suite '${suite}' (${script} not found); suites/l1.sh and suites/l2.sh are implemented so far"
+    [[ -f "${script}" ]] || e2e_die "unknown suite '${suite}' (${script} not found); suites/l1.sh and suites/l2.sh are implemented so far"
 done
 
 # A bring-up failure is reported and diagnosed exactly like a suite failure:
@@ -45,18 +45,18 @@ else
     status=1
 fi
 
-if [ "${status}" -ne 0 ]; then
+if [[ "${status}" -ne 0 ]]; then
     e2e_log "collecting diagnostics after failure"
     bash "${E2E_DIR}/dump-logs.sh" "${E2E_PROFILE}" || true
 fi
 
-if [ "${E2E_KEEP}" = "1" ]; then
+if [[ "${E2E_KEEP}" = "1" ]]; then
     e2e_log "E2E_KEEP=1: leaving ${E2E_CONTAINER} running"
 else
     bash "${E2E_DIR}/down.sh" "${E2E_PROFILE}" || true
 fi
 
-if [ "${status}" -ne 0 ]; then
+if [[ "${status}" -ne 0 ]]; then
     printf '\n[e2e:%s] E2E FAILED\n' "${E2E_PROFILE}"
 else
     printf '\n[e2e:%s] E2E PASSED\n' "${E2E_PROFILE}"

--- a/hack/e2e/suites/l1.sh
+++ b/hack/e2e/suites/l1.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# L1 suite — control plane only.
+#
+# Validates that a `k8e server --disable-agent` cluster:
+#   * serves a healthy, versioned API
+#   * creates the core namespaces
+#   * honours --disable-* flags when staging addon manifests
+#   * ships working in-process subcommands (kubectl / crictl)
+#   * survives a container restart without losing cluster state
+#
+# CNI, agent and sandbox orchestration are intentionally out of scope here.
+set -euo pipefail
+
+. "$(cd "$(dirname "$0")/.." && pwd)/lib.sh"
+
+e2e_set_profile "${E2E_PROFILE}"
+e2e_require_cmds kubectl
+e2e_require_cluster
+
+e2e_log "L1: control plane checks (container ${E2E_CONTAINER})"
+
+# --- API health and identity --------------------------------------------
+
+if e2e_kubectl get --raw=/readyz 2>/dev/null | grep -qi '^ok'; then
+    e2e_ok "/readyz reports ok"
+else
+    e2e_bad "/readyz reports ok"
+fi
+
+if e2e_kubectl get --raw=/livez 2>/dev/null | grep -qi '^ok'; then
+    e2e_ok "/livez reports ok"
+else
+    e2e_bad "/livez reports ok"
+fi
+
+version_json="$(e2e_kubectl get --raw=/version 2>/dev/null || true)"
+if printf '%s' "${version_json}" | grep -q '"gitVersion"'; then
+    e2e_ok "/version exposes gitVersion ($(printf '%s' "${version_json}" | jq -r '.gitVersion' 2>/dev/null || echo unknown))"
+else
+    e2e_bad "/version exposes gitVersion"
+fi
+
+# --- core namespaces -----------------------------------------------------
+
+for ns in default kube-system kube-public kube-node-lease; do
+    if e2e_kubectl get namespace "${ns}" >/dev/null 2>&1; then
+        e2e_ok "namespace ${ns} exists"
+    else
+        e2e_bad "namespace ${ns} exists"
+    fi
+done
+
+# --- agent is disabled, so no node is registered -------------------------
+
+node_count="$(e2e_kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${node_count}" = "0" ]; then
+    e2e_ok "--disable-agent leaves the cluster without nodes"
+else
+    e2e_bad "--disable-agent leaves the cluster without nodes (found ${node_count})"
+fi
+
+# --- disable semantics ---------------------------------------------------
+
+# --disable-sandbox-matrix keeps every manifests/sandbox-matrix/* addon out of
+# the cluster: the sandbox-matrix namespace + crds.yaml CRDs, the sandbox
+# RuntimeClasses, the default warm pool, the Cilium network policy and the e2b
+# Gateway API bridge. The API types themselves (sandboxmatrixes.k8e.sh, ...)
+# are registered by the CRD controller at start-up and are intentionally not
+# gated by this flag.
+if e2e_kubectl get namespace sandbox-matrix >/dev/null 2>&1; then
+    e2e_bad "--disable-sandbox-matrix keeps the sandbox-matrix namespace out of the cluster"
+else
+    e2e_ok "--disable-sandbox-matrix keeps the sandbox-matrix namespace out of the cluster"
+fi
+
+for runtime in gvisor kata firecracker; do
+    if e2e_kubectl get runtimeclass "${runtime}" >/dev/null 2>&1; then
+        e2e_bad "--disable-sandbox-matrix keeps runtimeclass ${runtime} out of the cluster"
+    else
+        e2e_ok "--disable-sandbox-matrix keeps runtimeclass ${runtime} out of the cluster"
+    fi
+done
+
+if e2e_kubectl get sandboxwarmpools -A --no-headers 2>/dev/null | grep -q .; then
+    e2e_bad "--disable-sandbox-matrix keeps SandboxWarmPool objects out of the cluster"
+else
+    e2e_ok "--disable-sandbox-matrix keeps SandboxWarmPool objects out of the cluster"
+fi
+
+for service in sandbox-grpc-gateway e2b-server; do
+    if e2e_kubectl get service "${service}" -A --no-headers 2>/dev/null | grep -q .; then
+        e2e_bad "--disable-sandbox-matrix keeps the ${service} Service out of the cluster"
+    else
+        e2e_ok "--disable-sandbox-matrix keeps the ${service} Service out of the cluster"
+    fi
+done
+
+if e2e_kubectl get crd gatewayclasses.gateway.networking.k8s.io >/dev/null 2>&1; then
+    e2e_bad "--disable-sandbox-matrix keeps the Gateway API CRDs out of the cluster"
+else
+    e2e_ok "--disable-sandbox-matrix keeps the Gateway API CRDs out of the cluster"
+fi
+
+if e2e_kubectl -n kube-system get daemonset cilium >/dev/null 2>&1; then
+    e2e_bad "--disable-cilium keeps the cilium agent out of the cluster"
+else
+    e2e_ok "--disable-cilium keeps the cilium agent out of the cluster"
+fi
+
+# --disable-cloud-controller stops the embedded cloud controller; its bundled
+# RBAC (manifests/ccm.yaml, which creates the k8e-cloud-controller-manager
+# ClusterRole) must not be staged or applied either.
+if e2e_kubectl get clusterrole k8e-cloud-controller-manager >/dev/null 2>&1; then
+    e2e_bad "--disable-cloud-controller keeps the CCM out of the cluster"
+else
+    e2e_ok "--disable-cloud-controller keeps the CCM out of the cluster"
+fi
+
+# --- staged addon manifests ---------------------------------------------
+
+staged="${E2E_MANIFESTS_DIR}"
+if [ -d "${staged}" ]; then
+    e2e_ok "addon manifests staged at ${staged#${E2E_DATA_DIR}/}"
+    for manifest in coredns.yaml local-storage.yaml runtimes.yaml rolebindings.yaml; do
+        if [ -f "${staged}/${manifest}" ]; then
+            e2e_ok "staged ${manifest}"
+        else
+            e2e_bad "staged ${manifest}"
+        fi
+    done
+    for manifest in cilium.yaml ccm.yaml; do
+        if [ -e "${staged}/${manifest}" ]; then
+            e2e_bad "not staged ${manifest} (disabled)"
+        else
+            e2e_ok "not staged ${manifest} (disabled)"
+        fi
+    done
+    if [ -e "${staged}/sandbox-matrix" ]; then
+        e2e_bad "not staged sandbox-matrix/ (disabled)"
+    else
+        e2e_ok "not staged sandbox-matrix/ (disabled)"
+    fi
+else
+    e2e_bad "addon manifests are staged under ${E2E_MANIFESTS_DIR}"
+fi
+
+# --- in-container subcommands and loopback API ---------------------------
+
+if e2e_in_container /usr/local/bin/k8e kubectl version --client >/dev/null 2>&1; then
+    e2e_ok "in-container 'k8e kubectl' works"
+else
+    e2e_bad "in-container 'k8e kubectl' works"
+fi
+
+if e2e_in_container /usr/local/bin/k8e crictl --version >/dev/null 2>&1; then
+    e2e_ok "in-container 'k8e crictl' works"
+else
+    e2e_bad "in-container 'k8e crictl' works"
+fi
+
+if e2e_in_container /usr/local/bin/k8e kubectl --kubeconfig /test/kubeconfig.yaml \
+    get --raw=/readyz >/dev/null 2>&1; then
+    e2e_ok "API is reachable over loopback from inside the container"
+else
+    e2e_bad "API is reachable over loopback from inside the container"
+fi
+
+# --- restart recovery ----------------------------------------------------
+
+if [ "${E2E_SKIP_GO_TESTS:-0}" = "1" ]; then
+    e2e_log "skipping restart recovery test (E2E_SKIP_GO_TESTS=1)"
+elif ! command -v go >/dev/null 2>&1; then
+    e2e_warn "go toolchain not found; skipping restart recovery test"
+else
+    e2e_log "running TestKubernetesRestartRecovery against the cluster"
+    # shellcheck disable=SC2086
+    if (cd "${E2E_REPO}" &&
+        MCP_TEST_KUBECONFIG="${E2E_KUBECONFIG}" \
+            MCP_TEST_RESTART_CONTAINER="${E2E_CONTAINER}" \
+            go test ${E2E_GO_TEST_ARGS} ./pkg/sandboxmcp -run '^TestKubernetesRestartRecovery$' -count=1 -v); then
+        e2e_ok "cluster survives a container restart"
+    else
+        e2e_bad "cluster survives a container restart"
+    fi
+fi
+
+e2e_summary

--- a/hack/e2e/suites/l1.sh
+++ b/hack/e2e/suites/l1.sh
@@ -53,7 +53,7 @@ done
 # --- agent is disabled, so no node is registered -------------------------
 
 node_count="$(e2e_kubectl get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')"
-if [ "${node_count}" = "0" ]; then
+if [[ "${node_count}" = "0" ]]; then
     e2e_ok "--disable-agent leaves the cluster without nodes"
 else
     e2e_bad "--disable-agent leaves the cluster without nodes (found ${node_count})"
@@ -167,7 +167,7 @@ fi
 
 # --- restart recovery ----------------------------------------------------
 
-if [ "${E2E_SKIP_GO_TESTS:-0}" = "1" ]; then
+if [[ "${E2E_SKIP_GO_TESTS:-0}" = "1" ]]; then
     e2e_log "skipping restart recovery test (E2E_SKIP_GO_TESTS=1)"
 elif ! command -v go >/dev/null 2>&1; then
     e2e_warn "go toolchain not found; skipping restart recovery test"

--- a/hack/e2e/suites/l1.sh
+++ b/hack/e2e/suites/l1.sh
@@ -118,30 +118,30 @@ fi
 
 # --- staged addon manifests ---------------------------------------------
 
-staged="${E2E_MANIFESTS_DIR}"
-if [ -d "${staged}" ]; then
-    e2e_ok "addon manifests staged at ${staged#${E2E_DATA_DIR}/}"
+staged="${E2E_IN_CONTAINER_MANIFESTS_DIR}"
+if e2e_in_container test -d "${staged}" 2>/dev/null; then
+    e2e_ok "addon manifests staged at ${staged}"
     for manifest in coredns.yaml local-storage.yaml runtimes.yaml rolebindings.yaml; do
-        if [ -f "${staged}/${manifest}" ]; then
+        if e2e_in_container test -f "${staged}/${manifest}" 2>/dev/null; then
             e2e_ok "staged ${manifest}"
         else
             e2e_bad "staged ${manifest}"
         fi
     done
     for manifest in cilium.yaml ccm.yaml; do
-        if [ -e "${staged}/${manifest}" ]; then
+        if e2e_in_container test -e "${staged}/${manifest}" 2>/dev/null; then
             e2e_bad "not staged ${manifest} (disabled)"
         else
             e2e_ok "not staged ${manifest} (disabled)"
         fi
     done
-    if [ -e "${staged}/sandbox-matrix" ]; then
+    if e2e_in_container test -e "${staged}/sandbox-matrix" 2>/dev/null; then
         e2e_bad "not staged sandbox-matrix/ (disabled)"
     else
         e2e_ok "not staged sandbox-matrix/ (disabled)"
     fi
 else
-    e2e_bad "addon manifests are staged under ${E2E_MANIFESTS_DIR}"
+    e2e_bad "addon manifests are staged under ${staged}"
 fi
 
 # --- in-container subcommands and loopback API ---------------------------

--- a/hack/e2e/suites/l2.sh
+++ b/hack/e2e/suites/l2.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# L2 suite — control plane + agent, no CNI.
+#
+# Validates that a `k8e server` cluster starts a working node:
+#   * serves a healthy, versioned API
+#   * registers a node running the in-process kubelet
+#   * keeps the node NotReady *only* because no CNI is installed
+#   * brings up containerd (CRI plugin) with runc and its shims
+#   * runs a pod end to end through kubelet -> containerd -> runc
+#
+# The node is deliberately not expected to reach Ready here: l2 runs without a
+# CNI so that runtime failures cannot hide behind networking, and the pod used
+# below is hostNetwork so that it never needs one.
+set -euo pipefail
+
+. "$(cd "$(dirname "$0")/.." && pwd)/lib.sh"
+
+e2e_set_profile "${E2E_PROFILE}"
+e2e_require_cmds kubectl
+e2e_require_cluster
+
+e2e_log "L2: control plane + agent checks (container ${E2E_CONTAINER})"
+
+# --- API health and identity --------------------------------------------
+
+if e2e_kubectl get --raw=/readyz 2>/dev/null | grep -qi '^ok'; then
+    e2e_ok "/readyz reports ok"
+else
+    e2e_bad "/readyz reports ok"
+fi
+
+if e2e_kubectl get --raw=/livez 2>/dev/null | grep -qi '^ok'; then
+    e2e_ok "/livez reports ok"
+else
+    e2e_bad "/livez reports ok"
+fi
+
+server_version="$(e2e_kubectl get --raw=/version 2>/dev/null | jq -r '.gitVersion' 2>/dev/null || true)"
+if [ -n "${server_version}" ] && [ "${server_version}" != "null" ]; then
+    e2e_ok "/version exposes gitVersion (${server_version})"
+else
+    e2e_bad "/version exposes gitVersion"
+fi
+
+# --- node registration ---------------------------------------------------
+
+node="$(e2e_kubectl get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+if [ -n "${node}" ]; then
+    e2e_ok "node ${node} registered"
+else
+    e2e_bad "node registered"
+    e2e_summary
+fi
+
+node_version="$(e2e_kubectl get node "${node}" -o jsonpath='{.status.nodeInfo.kubeletVersion}' 2>/dev/null || true)"
+if [ -n "${node_version}" ]; then
+    e2e_ok "kubelet reports a version (${node_version})"
+else
+    e2e_bad "kubelet reports a version"
+fi
+
+if [ -n "${server_version}" ] && [ "${node_version}" = "${server_version}" ]; then
+    e2e_ok "kubelet runs in-process at the server version (${node_version})"
+else
+    e2e_bad "kubelet runs in-process at the server version (node=${node_version} server=${server_version})"
+fi
+
+# --- the node is only held back by the missing CNI -----------------------
+
+ready_status="$(e2e_kubectl get node "${node}" -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true)"
+ready_message="$(e2e_kubectl get node "${node}" -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.message}{end}' 2>/dev/null || true)"
+
+if [ "${ready_status}" = "False" ]; then
+    e2e_ok "node is NotReady (no CNI in this profile)"
+else
+    e2e_bad "node is NotReady (no CNI in this profile), status=${ready_status}"
+fi
+
+if printf '%s' "${ready_message}" | grep -qi 'cni'; then
+    e2e_ok "NotReady is caused by the absent CNI plugin, not by a failed runtime"
+else
+    e2e_bad "NotReady is caused by the absent CNI plugin, not by a failed runtime (${ready_message})"
+fi
+
+for condition in MemoryPressure DiskPressure PIDPressure; do
+    condition_status="$(e2e_kubectl get node "${node}" -o jsonpath="{range .status.conditions[?(@.type==\"${condition}\")]}{.status}{end}" 2>/dev/null || true)"
+    if [ "${condition_status}" = "False" ]; then
+        e2e_ok "node has no ${condition}"
+    else
+        e2e_bad "node has no ${condition} (${condition_status})"
+    fi
+done
+
+# --- kubelet is reachable and healthy through the API server -------------
+
+if e2e_kubectl get --raw "/api/v1/nodes/${node}/proxy/healthz" 2>/dev/null | grep -qi '^ok'; then
+    e2e_ok "kubelet answers /healthz through the API server proxy"
+else
+    e2e_bad "kubelet answers /healthz through the API server proxy"
+fi
+
+# --- container runtime stack ---------------------------------------------
+
+if e2e_in_container /usr/local/bin/runc --version >/dev/null 2>&1; then
+    e2e_ok "runc is available to the node"
+else
+    e2e_bad "runc is available to the node"
+fi
+
+if e2e_in_container sh -c 'command -v containerd-shim-runc-v2' >/dev/null 2>&1; then
+    e2e_ok "containerd-shim-runc-v2 is available to the node"
+else
+    e2e_bad "containerd-shim-runc-v2 is available to the node"
+fi
+
+cri_plugins="$(e2e_in_container ctr --address "${E2E_CONTAINERD_SOCKET}" plugins ls 2>/dev/null || true)"
+if printf '%s' "${cri_plugins}" | grep -qE 'grpc\.v1[[:space:]]+cri[[:space:]].*ok'; then
+    e2e_ok "containerd's CRI plugin is running"
+else
+    e2e_bad "containerd's CRI plugin is running"
+fi
+
+# --- a pod really runs through kubelet -> containerd -> runc ------------
+
+pod="e2e-l2-hostnet"
+pod_manifest="${E2E_STATE_DIR}/l2-hostnet-pod.yaml"
+e2e_kubectl delete pod "${pod}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+
+# hostNetwork keeps the pod off the (absent) CNI plugin, and the image is
+# preloaded from the host so the node needs no registry access.
+cat > "${pod_manifest}" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod}
+  labels:
+    k8e-e2e/test: l2
+spec:
+  nodeName: ${node}
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: app
+      image: ${E2E_TEST_IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/sh", "-c", "echo k8e-e2e-hostnet-ok; sleep 3600"]
+EOF
+
+# Applying a manifest file rather than piping into `kubectl apply -f -` keeps
+# the check free of stdin/pipefail races and leaves the exact spec in the state
+# directory for diagnostics.
+if apply_output="$(e2e_kubectl apply -f "${pod_manifest}" 2>&1)"; then
+    e2e_ok "hostNetwork pod accepted by the API server"
+else
+    e2e_bad "hostNetwork pod accepted by the API server (${apply_output})"
+fi
+
+if e2e_wait_pod_running "${pod}" "${E2E_POD_TIMEOUT:-180}"; then
+    e2e_ok "pod runs through kubelet, containerd and runc"
+else
+    e2e_bad "pod runs through kubelet, containerd and runc"
+    e2e_kubectl describe pod "${pod}" 2>&1 | tail -15 || true
+fi
+
+pod_logs="$(e2e_kubectl logs "${pod}" 2>/dev/null || true)"
+if printf '%s' "${pod_logs}" | grep -q 'k8e-e2e-hostnet-ok'; then
+    e2e_ok "pod output is readable through the kubelet log endpoint"
+else
+    e2e_bad "pod output is readable through the kubelet log endpoint"
+fi
+
+pod_ip="$(e2e_kubectl get pod "${pod}" -o jsonpath='{.status.podIP}' 2>/dev/null || true)"
+if [ -n "${pod_ip}" ]; then
+    e2e_ok "pod reports an IP (${pod_ip})"
+else
+    e2e_bad "pod reports an IP"
+fi
+
+e2e_kubectl delete pod "${pod}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+
+# --- restart recovery ----------------------------------------------------
+
+if [ "${E2E_SKIP_GO_TESTS:-0}" = "1" ]; then
+    e2e_log "skipping restart recovery test (E2E_SKIP_GO_TESTS=1)"
+elif ! command -v go >/dev/null 2>&1; then
+    e2e_warn "go toolchain not found; skipping restart recovery test"
+else
+    e2e_log "running TestKubernetesRestartRecovery against the cluster"
+    # shellcheck disable=SC2086
+    if (cd "${E2E_REPO}" &&
+        MCP_TEST_KUBECONFIG="${E2E_KUBECONFIG}" \
+            MCP_TEST_RESTART_CONTAINER="${E2E_CONTAINER}" \
+            go test ${E2E_GO_TEST_ARGS} ./pkg/sandboxmcp -run '^TestKubernetesRestartRecovery$' -count=1 -v); then
+        e2e_ok "cluster survives a container restart"
+    else
+        e2e_bad "cluster survives a container restart"
+    fi
+fi
+
+e2e_summary

--- a/hack/e2e/suites/l2.sh
+++ b/hack/e2e/suites/l2.sh
@@ -36,7 +36,7 @@ else
 fi
 
 server_version="$(e2e_kubectl get --raw=/version 2>/dev/null | jq -r '.gitVersion' 2>/dev/null || true)"
-if [ -n "${server_version}" ] && [ "${server_version}" != "null" ]; then
+if [[ -n "${server_version}" ]] && [[ "${server_version}" != "null" ]]; then
     e2e_ok "/version exposes gitVersion (${server_version})"
 else
     e2e_bad "/version exposes gitVersion"
@@ -45,7 +45,7 @@ fi
 # --- node registration ---------------------------------------------------
 
 node="$(e2e_kubectl get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
-if [ -n "${node}" ]; then
+if [[ -n "${node}" ]]; then
     e2e_ok "node ${node} registered"
 else
     e2e_bad "node registered"
@@ -53,13 +53,13 @@ else
 fi
 
 node_version="$(e2e_kubectl get node "${node}" -o jsonpath='{.status.nodeInfo.kubeletVersion}' 2>/dev/null || true)"
-if [ -n "${node_version}" ]; then
+if [[ -n "${node_version}" ]]; then
     e2e_ok "kubelet reports a version (${node_version})"
 else
     e2e_bad "kubelet reports a version"
 fi
 
-if [ -n "${server_version}" ] && [ "${node_version}" = "${server_version}" ]; then
+if [[ -n "${server_version}" ]] && [[ "${node_version}" = "${server_version}" ]]; then
     e2e_ok "kubelet runs in-process at the server version (${node_version})"
 else
     e2e_bad "kubelet runs in-process at the server version (node=${node_version} server=${server_version})"
@@ -70,7 +70,7 @@ fi
 ready_status="$(e2e_kubectl get node "${node}" -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.status}{end}' 2>/dev/null || true)"
 ready_message="$(e2e_kubectl get node "${node}" -o jsonpath='{range .status.conditions[?(@.type=="Ready")]}{.message}{end}' 2>/dev/null || true)"
 
-if [ "${ready_status}" = "False" ]; then
+if [[ "${ready_status}" = "False" ]]; then
     e2e_ok "node is NotReady (no CNI in this profile)"
 else
     e2e_bad "node is NotReady (no CNI in this profile), status=${ready_status}"
@@ -84,7 +84,7 @@ fi
 
 for condition in MemoryPressure DiskPressure PIDPressure; do
     condition_status="$(e2e_kubectl get node "${node}" -o jsonpath="{range .status.conditions[?(@.type==\"${condition}\")]}{.status}{end}" 2>/dev/null || true)"
-    if [ "${condition_status}" = "False" ]; then
+    if [[ "${condition_status}" = "False" ]]; then
         e2e_ok "node has no ${condition}"
     else
         e2e_bad "node has no ${condition} (${condition_status})"
@@ -170,7 +170,7 @@ else
 fi
 
 pod_ip="$(e2e_kubectl get pod "${pod}" -o jsonpath='{.status.podIP}' 2>/dev/null || true)"
-if [ -n "${pod_ip}" ]; then
+if [[ -n "${pod_ip}" ]]; then
     e2e_ok "pod reports an IP (${pod_ip})"
 else
     e2e_bad "pod reports an IP"
@@ -180,7 +180,7 @@ e2e_kubectl delete pod "${pod}" --ignore-not-found --wait=false >/dev/null 2>&1 
 
 # --- restart recovery ----------------------------------------------------
 
-if [ "${E2E_SKIP_GO_TESTS:-0}" = "1" ]; then
+if [[ "${E2E_SKIP_GO_TESTS:-0}" = "1" ]]; then
     e2e_log "skipping restart recovery test (E2E_SKIP_GO_TESTS=1)"
 elif ! command -v go >/dev/null 2>&1; then
     e2e_warn "go toolchain not found; skipping restart recovery test"

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 . "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+if [[ "${1:-}" = "-h" ]] || [[ "${1:-}" = "--help" ]]; then
     e2e_usage
     exit 0
 fi
@@ -18,8 +18,8 @@ e2e_set_profile "${1:-${E2E_PROFILE}}"
 
 e2e_require_cmds docker kubectl
 
-[ -n "${E2E_BINARY}" ] || e2e_die "E2E_BINARY must be set"
-[ -x "${E2E_BINARY}" ] || e2e_die "missing executable E2E_BINARY=${E2E_BINARY} (run 'make k8e' first)"
+[[ -n "${E2E_BINARY}" ]] || e2e_die "E2E_BINARY must be set"
+[[ -x "${E2E_BINARY}" ]] || e2e_die "missing executable E2E_BINARY=${E2E_BINARY} (run 'make k8e' first)"
 
 e2e_build_image
 
@@ -34,7 +34,7 @@ fi
 
 # A fresh cluster by default: stale state is a common source of confusing
 # failures. E2E_REUSE=1 keeps an existing data directory.
-if [ "${E2E_REUSE:-0}" != "1" ]; then
+if [[ "${E2E_REUSE:-0}" != "1" ]]; then
     rm -rf "${E2E_DATA_DIR}"
 fi
 mkdir -p "${E2E_DATA_DIR}" "${E2E_DIAG_DIR}" "${E2E_STATE_DIR}"
@@ -49,7 +49,7 @@ mkdir -p "${E2E_DATA_DIR}" "${E2E_DIAG_DIR}" "${E2E_STATE_DIR}"
 # entrypoint links it back to the path containerd was configured with.
 storage_args=()
 if e2e_profile_needs_agent; then
-    if [ "${E2E_REUSE:-0}" != "1" ]; then
+    if [[ "${E2E_REUSE:-0}" != "1" ]]; then
         docker volume rm -f "${E2E_CONTAINERD_ROOT_VOLUME}" >/dev/null 2>&1 || true
     fi
     storage_args+=(-v "${E2E_CONTAINERD_ROOT_VOLUME}:${E2E_CONTAINERD_VOLUME_PATH}")
@@ -57,13 +57,13 @@ fi
 
 flags=()
 while IFS= read -r line; do
-    [ -n "${line}" ] || continue
+    [[ -n "${line}" ]] || continue
     flags+=("${line}")
 done < <(e2e_profile_flags)
 
 docker_args=()
 while IFS= read -r line; do
-    [ -n "${line}" ] || continue
+    [[ -n "${line}" ]] || continue
     docker_args+=("${line}")
 done < <(e2e_profile_docker_args)
 
@@ -75,10 +75,10 @@ fi
 
 e2e_log "starting ${E2E_CONTAINER} (profile=${E2E_PROFILE}, image=${E2E_IMAGE})"
 e2e_log "server flags: ${flags[*]:-<none>}"
-if [ "${#docker_args[@]}" -gt 0 ]; then
+if [[ ${#docker_args[@]} -gt 0 ]]; then
     e2e_log "docker flags: ${docker_args[*]}"
 fi
-if [ "${#storage_args[@]}" -gt 0 ]; then
+if [[ ${#storage_args[@]} -gt 0 ]]; then
     e2e_log "runtime storage: ${storage_args[*]}"
 fi
 
@@ -111,7 +111,7 @@ else
 fi
 
 if e2e_profile_needs_agent; then
-    if [ "${E2E_EXPECT_NODE_READY}" = "1" ]; then
+    if [[ "${E2E_EXPECT_NODE_READY}" = "1" ]]; then
         if e2e_wait_node_ready; then
             e2e_log "node is Ready"
         else

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -85,7 +85,7 @@ fi
 
 docker run -d --name "${E2E_CONTAINER}" \
     -p "127.0.0.1:${E2E_API_PORT}:${E2E_IN_CONTAINER_API_PORT}" \
-    -v "${E2E_DATA_DIR}:/test" \
+    -v "${E2E_DATA_DIR}:${E2E_IN_CONTAINER_DATA_DIR}" \
     -v "${E2E_BINARY}:/usr/local/bin/k8e:ro" \
     "${storage_args[@]+"${storage_args[@]}"}" \
     "${docker_args[@]+"${docker_args[@]}"}" \
@@ -93,8 +93,8 @@ docker run -d --name "${E2E_CONTAINER}" \
     "${E2E_IMAGE}" \
     /usr/local/bin/k8e server \
     --cluster-init \
-    --data-dir /test/data \
-    --write-kubeconfig /test/kubeconfig.yaml \
+    --data-dir "${E2E_IN_CONTAINER_DATA_DIR}/data" \
+    --write-kubeconfig "${E2E_IN_CONTAINER_KUBECONFIG}" \
     --https-listen-port "${E2E_IN_CONTAINER_API_PORT}" \
     --tls-san 127.0.0.1 \
     "${flags[@]+"${flags[@]}"}" >/dev/null

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Start a single-node K8E cluster inside a container for end-to-end tests.
+#
+#   hack/e2e/up.sh [profile]
+#
+# The cluster state lives on the host under ${E2E_DATA_DIR} so that it survives
+# a container restart (which is how the recovery tests exercise persistence).
+set -euo pipefail
+
+. "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    e2e_usage
+    exit 0
+fi
+
+e2e_set_profile "${1:-${E2E_PROFILE}}"
+
+e2e_require_cmds docker kubectl
+
+[ -n "${E2E_BINARY}" ] || e2e_die "E2E_BINARY must be set"
+[ -x "${E2E_BINARY}" ] || e2e_die "missing executable E2E_BINARY=${E2E_BINARY} (run 'make k8e' first)"
+
+e2e_build_image
+
+# The container has to go before its data directory is recycled: deleting a
+# directory that a still-running container has bind mounted leaves the next
+# container with a dead mount handle, and every write under /test then fails
+# with ENOENT.
+if e2e_container_exists; then
+    e2e_log "removing stale container ${E2E_CONTAINER}"
+    docker rm -f "${E2E_CONTAINER}" >/dev/null
+fi
+
+# A fresh cluster by default: stale state is a common source of confusing
+# failures. E2E_REUSE=1 keeps an existing data directory.
+if [ "${E2E_REUSE:-0}" != "1" ]; then
+    rm -rf "${E2E_DATA_DIR}"
+fi
+mkdir -p "${E2E_DATA_DIR}" "${E2E_DIAG_DIR}" "${E2E_STATE_DIR}"
+
+# Runtime storage goes on its own volume (see E2E_CONTAINERD_ROOT in lib.sh), so
+# it has to be recycled here rather than with the data directory. The container
+# is already gone at this point, otherwise the volume would still be in use.
+#
+# The volume is mounted outside the ${E2E_DATA_DIR} bind mount: a nested mount
+# under the virtiofs share that Docker Desktop/OrbStack uses is not reliably
+# applied, and containerd's root has to end up on a real Linux filesystem. The
+# entrypoint links it back to the path containerd was configured with.
+storage_args=()
+if e2e_profile_needs_agent; then
+    if [ "${E2E_REUSE:-0}" != "1" ]; then
+        docker volume rm -f "${E2E_CONTAINERD_ROOT_VOLUME}" >/dev/null 2>&1 || true
+    fi
+    storage_args+=(-v "${E2E_CONTAINERD_ROOT_VOLUME}:${E2E_CONTAINERD_VOLUME_PATH}")
+fi
+
+flags=()
+while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    flags+=("${line}")
+done < <(e2e_profile_flags)
+
+docker_args=()
+while IFS= read -r line; do
+    [ -n "${line}" ] || continue
+    docker_args+=("${line}")
+done < <(e2e_profile_docker_args)
+
+env_args=()
+if e2e_profile_needs_agent; then
+    env_args+=(-e "K8E_E2E_CGROUP_ROOT=${E2E_CGROUP_ROOT}")
+    env_args+=(-e "K8E_E2E_CONTAINERD_ROOT=${E2E_CONTAINERD_ROOT}")
+    env_args+=(-e "K8E_E2E_CONTAINERD_VOLUME=${E2E_CONTAINERD_VOLUME_PATH}")
+fi
+
+e2e_log "starting ${E2E_CONTAINER} (profile=${E2E_PROFILE}, image=${E2E_IMAGE})"
+e2e_log "server flags: ${flags[*]:-<none>}"
+if [ "${#docker_args[@]}" -gt 0 ]; then
+    e2e_log "docker flags: ${docker_args[*]}"
+fi
+if [ "${#storage_args[@]}" -gt 0 ]; then
+    e2e_log "runtime storage: ${storage_args[*]}"
+fi
+
+docker run -d --name "${E2E_CONTAINER}" \
+    -p "127.0.0.1:${E2E_API_PORT}:${E2E_IN_CONTAINER_API_PORT}" \
+    -v "${E2E_DATA_DIR}:/test" \
+    -v "${E2E_BINARY}:/usr/local/bin/k8e:ro" \
+    "${storage_args[@]+"${storage_args[@]}"}" \
+    "${docker_args[@]+"${docker_args[@]}"}" \
+    "${env_args[@]+"${env_args[@]}"}" \
+    "${E2E_IMAGE}" \
+    /usr/local/bin/k8e server \
+    --cluster-init \
+    --data-dir /test/data \
+    --write-kubeconfig /test/kubeconfig.yaml \
+    --https-listen-port "${E2E_IN_CONTAINER_API_PORT}" \
+    --tls-san 127.0.0.1 \
+    "${flags[@]+"${flags[@]}"}" >/dev/null
+
+if ! e2e_wait_api; then
+    docker logs --tail 100 "${E2E_CONTAINER}" >&2 2>&1 || true
+    e2e_die "K8E API did not become ready within ${E2E_API_TIMEOUT}s"
+fi
+e2e_log "API ready at https://127.0.0.1:${E2E_API_PORT} (kubeconfig ${E2E_KUBECONFIG})"
+
+if e2e_wait_manifests; then
+    e2e_log "addon manifests staged at ${E2E_MANIFESTS_DIR}"
+else
+    e2e_warn "continuing without staged manifests; the suite will report the failure"
+fi
+
+if e2e_profile_needs_agent; then
+    if [ "${E2E_EXPECT_NODE_READY}" = "1" ]; then
+        if e2e_wait_node_ready; then
+            e2e_log "node is Ready"
+        else
+            e2e_warn "continuing without a Ready node; the suite will report the failure"
+        fi
+    elif e2e_wait_node_registered; then
+        e2e_log "node registered (no CNI in this profile: Ready is not expected)"
+    else
+        e2e_warn "continuing without a registered node; the suite will report the failure"
+    fi
+
+    # Fail fast when the runtime storage cannot back containerd's snapshots:
+    # the cluster would look healthy and every pod would then fail with a
+    # read-only rootfs, which is a miserable failure to debug from the outside.
+    if ! e2e_verify_containerd_root; then
+        e2e_die "${E2E_CONTAINERD_ROOT} cannot back an overlayfs mount; containerd snapshots would come up read-only (runtime volume missing or shadowed?)"
+    fi
+
+    if ! e2e_preload_images; then
+        e2e_warn "continuing without preloaded images; pod-level checks will fail"
+    fi
+
+    # Pods cannot be admitted or mounted until the controller manager has
+    # bootstrapped the namespace (default ServiceAccount, API CA configmap).
+    if e2e_wait_namespace_ready default; then
+        e2e_log "default namespace is bootstrapped"
+    else
+        e2e_warn "continuing without a bootstrapped default namespace; pod-level checks may fail"
+    fi
+fi
+
+e2e_log "cluster is up"

--- a/hack/e2e/up.sh
+++ b/hack/e2e/up.sh
@@ -69,7 +69,6 @@ done < <(e2e_profile_docker_args)
 
 env_args=()
 if e2e_profile_needs_agent; then
-    env_args+=(-e "K8E_E2E_CGROUP_ROOT=${E2E_CGROUP_ROOT}")
     env_args+=(-e "K8E_E2E_CONTAINERD_ROOT=${E2E_CONTAINERD_ROOT}")
     env_args+=(-e "K8E_E2E_CONTAINERD_VOLUME=${E2E_CONTAINERD_VOLUME_PATH}")
 fi
@@ -106,7 +105,7 @@ fi
 e2e_log "API ready at https://127.0.0.1:${E2E_API_PORT} (kubeconfig ${E2E_KUBECONFIG})"
 
 if e2e_wait_manifests; then
-    e2e_log "addon manifests staged at ${E2E_MANIFESTS_DIR}"
+    e2e_log "addon manifests staged at ${E2E_IN_CONTAINER_MANIFESTS_DIR}"
 else
     e2e_warn "continuing without staged manifests; the suite will report the failure"
 fi

--- a/hack/test-sandbox-mcp-orbstack.sh
+++ b/hack/test-sandbox-mcp-orbstack.sh
@@ -1,49 +1,34 @@
 #!/usr/bin/env bash
+# Legacy entry point for the local "cluster-init recovery" test.
+#
+# The real harness now lives in hack/e2e/. This wrapper only maps the historical
+# K8E_MCP_* variables onto the harness environment so existing muscle memory and
+# documentation keep working.
+#
+#   K8E_BINARY=/path/to/linux-k8e hack/test-sandbox-mcp-orbstack.sh
+#
+# See `hack/e2e/up.sh --help` for the underlying knobs.
 set -euo pipefail
 
-container_name="${K8E_MCP_CONTAINER:-k8e-mcp-recovery-init}"
-host_port="${K8E_MCP_API_PORT:-16444}"
-data_dir="${K8E_MCP_DATA_DIR:-/tmp/k8e-mcp-cluster-init}"
-binary="${K8E_BINARY:-/tmp/k8e-mcp-server}"
-image="${K8E_MCP_IMAGE:-golang:1.26.7}"
+repo="$(cd "$(dirname "$0")/.." && pwd)"
 
-command -v docker >/dev/null || { echo "docker is required" >&2; exit 2; }
-command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 2; }
-command -v go >/dev/null || { echo "go is required" >&2; exit 2; }
-[[ -x "$binary" ]] || { echo "missing executable K8E_BINARY=$binary" >&2; exit 2; }
-cd "$(dirname "$0")/.."
-mkdir -p "$data_dir"
+export E2E_PROFILE="${E2E_PROFILE:-l1}"
+export E2E_CONTAINER="${E2E_CONTAINER:-${K8E_MCP_CONTAINER:-k8e-e2e-l1}}"
+export E2E_API_PORT="${E2E_API_PORT:-${K8E_MCP_API_PORT:-16444}}"
+export E2E_STATE_DIR="${E2E_STATE_DIR:-/tmp/k8e-e2e/${E2E_PROFILE}}"
+export E2E_BINARY="${E2E_BINARY:-${K8E_BINARY:-${repo}/bin/k8e}}"
+# The recovery test is the one place where the race detector earns its cost.
+export E2E_GO_TEST_ARGS="${E2E_GO_TEST_ARGS:--race}"
+# Historically the cluster was left behind for post-mortem debugging.
+export E2E_KEEP="${E2E_KEEP:-${K8E_MCP_KEEP:-1}}"
 
-docker run -d --name "$container_name" \
-  -p "127.0.0.1:${host_port}:6443" \
-  -v "$data_dir:/test" \
-  -v "$binary:/usr/local/bin/k8e:ro" \
-  "$image" \
-  k8e server --cluster-init \
-    --data-dir /test/data \
-    --write-kubeconfig /test/kubeconfig.yaml \
-    --https-listen-port 6443 \
-    --tls-san 127.0.0.1 \
-    --disable-agent --disable-sandbox-matrix --disable-e2b \
-    --disable-cilium --disable-cloud-controller \
-    --egress-selector-mode disabled >/dev/null
+if [ -n "${K8E_MCP_DATA_DIR:-}" ]; then
+    export E2E_DATA_DIR="${K8E_MCP_DATA_DIR}"
+fi
 
-kubeconfig="$data_dir/client-kubeconfig.yaml"
-for _ in $(seq 1 120); do
-  if [[ -s "$data_dir/kubeconfig.yaml" ]]; then
-    cp "$data_dir/kubeconfig.yaml" "$kubeconfig"
-    kubectl --kubeconfig "$kubeconfig" config set-cluster default --server="https://127.0.0.1:${host_port}" >/dev/null
-    if kubectl --kubeconfig "$kubeconfig" --request-timeout=2s get --raw=/readyz >/dev/null 2>&1; then
-      break
-    fi
-  fi
-  sleep 1
-done
-[[ -s "$kubeconfig" ]] || { echo "K8E did not write kubeconfig" >&2; exit 1; }
-kubectl --kubeconfig "$kubeconfig" --request-timeout=10s get --raw=/readyz >/dev/null
+if [ -n "${K8E_MCP_IMAGE:-}" ]; then
+    export E2E_IMAGE="${K8E_MCP_IMAGE}"
+    export E2E_SKIP_IMAGE_BUILD=1
+fi
 
-MCP_TEST_KUBECONFIG="$kubeconfig" \
-MCP_TEST_RESTART_CONTAINER="$container_name" \
-go test -race ./pkg/sandboxmcp -run '^TestKubernetesRestartRecovery$' -v -count=1
-
-echo "OrbStack K8E cluster-init recovery test passed: $container_name"
+exec bash "${repo}/hack/e2e/run.sh" "${E2E_PROFILE}" "$@"

--- a/hack/test-sandbox-mcp-orbstack.sh
+++ b/hack/test-sandbox-mcp-orbstack.sh
@@ -22,11 +22,11 @@ export E2E_GO_TEST_ARGS="${E2E_GO_TEST_ARGS:--race}"
 # Historically the cluster was left behind for post-mortem debugging.
 export E2E_KEEP="${E2E_KEEP:-${K8E_MCP_KEEP:-1}}"
 
-if [ -n "${K8E_MCP_DATA_DIR:-}" ]; then
+if [[ -n "${K8E_MCP_DATA_DIR:-}" ]]; then
     export E2E_DATA_DIR="${K8E_MCP_DATA_DIR}"
 fi
 
-if [ -n "${K8E_MCP_IMAGE:-}" ]; then
+if [[ -n "${K8E_MCP_IMAGE:-}" ]]; then
     export E2E_IMAGE="${K8E_MCP_IMAGE}"
     export E2E_SKIP_IMAGE_BUILD=1
 fi

--- a/pkg/agent/containerd/config_linux_test.go
+++ b/pkg/agent/containerd/config_linux_test.go
@@ -1,0 +1,64 @@
+package containerd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rancher/wharfie/pkg/registries"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/xiaods/k8e/pkg/agent/templates"
+	"github.com/xiaods/k8e/pkg/daemons/config"
+)
+
+// stripComments drops TOML comments, so that a statement about what the template
+// renders cannot be satisfied or broken by prose alone.
+func stripComments(config string) string {
+	var directives []string
+	for _, line := range strings.Split(config, "\n") {
+		if line = strings.TrimSpace(line); line != "" && !strings.HasPrefix(line, "#") {
+			directives = append(directives, line)
+		}
+	}
+	return strings.Join(directives, "\n")
+}
+
+// The firecracker branch of the containerd config template is only taken on hosts
+// that expose /dev/kvm, so Test_UnitGetHostConfigs never renders it. It is worth
+// covering explicitly: the config it used to render made containerd panic before
+// it could start a single container.
+func Test_UnitContainerdConfigFirecrackerRuntime(t *testing.T) {
+	nodeConfig := &config.Node{
+		Containerd: config.Containerd{
+			Registry: filepath.Join(t.TempDir(), "hosts.d"),
+		},
+		AgentConfig: config.Agent{
+			ImageServiceSocket: "containerd-stargz-grpc.sock",
+			Snapshotter:        "stargz",
+		},
+	}
+	containerdConfig := templates.ContainerdConfig{
+		NodeConfig:            nodeConfig,
+		PrivateRegistryConfig: &registries.Registry{},
+		SandboxRuntimes:       templates.SandboxRuntimeConfig{Firecracker: true},
+		Program:               "k8e",
+	}
+
+	rendered, err := templates.ParseTemplateFromConfig(templates.ContainerdConfigTemplate, containerdConfig)
+	require.NoError(t, err, "ParseTemplateFromConfig")
+
+	// Check that the branch under test is actually taken, so that the assertions
+	// below cannot pass just because the runtime stopped being rendered at all.
+	assert.Contains(t, rendered, `runtimes."firecracker"`)
+	assert.Contains(t, rendered, `runtime_type = "aws.firecracker"`)
+
+	// containerd already links in its own devmapper snapshotter plugin, and
+	// declaring a second plugin with the same id makes it panic on startup:
+	//   panic: io.containerd.snapshotter.v1.devmapper: plugin: id already registered
+	// A [proxy_plugins.devmapper] entry must therefore never be rendered.
+	directives := stripComments(rendered)
+	assert.NotContains(t, directives, "proxy_plugins")
+	assert.NotContains(t, directives, "devmapper")
+}

--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -106,16 +106,19 @@ enable_keychain = true
 {{end}}
 
 {{- if .SandboxRuntimes.Firecracker }}
+# The "aws.firecracker" runtime is provided by firecracker-containerd. Never
+# declare a devmapper snapshotter proxy here: containerd already links in a
+# devmapper snapshotter plugin (pkg/containerd/builtins_linux.go), and registering
+# the same plugin id twice makes containerd panic on startup with
+# "plugin: id already registered", taking the node down before it can run a
+# single container -- and only ever on hosts that expose /dev/kvm, which are
+# exactly the ones that turn this runtime on. The built-in snapshotter is used
+# instead, and nothing in this config selects a proxy snapshotter.
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."firecracker"]
   runtime_type = "aws.firecracker"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."firecracker".options]
   kernel_image_path = "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin"
   root_drive = "/var/lib/firecracker-containerd/runtime/default-rootfs.img"
-
-[proxy_plugins]
-  [proxy_plugins.devmapper]
-    type = "snapshot"
-    address = "/run/containerd-dev-snapshotter/snapshotter.sock"
 {{end}}
 `
 

--- a/pkg/cli/crictl/crictl.go
+++ b/pkg/cli/crictl/crictl.go
@@ -2,16 +2,16 @@ package crictl
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/urfave/cli"
 	"sigs.k8s.io/cri-tools/cmd/crictl"
 )
 
 func Run(ctx *cli.Context) error {
-	if runtime.GOOS == "windows" {
-		os.Args = os.Args[1:]
-	}
+	// crictl parses os.Args itself, so hand it only its own arguments.
+	// Without this, `k8e crictl ps` would reach crictl as
+	// ["crictl", "crictl", "ps"] and be rejected as a bad argument.
+	os.Args = append([]string{ctx.Command.Name}, ctx.Args()...)
 	crictl.Main()
 	return nil
 }

--- a/pkg/cli/crictl/crictl.go
+++ b/pkg/cli/crictl/crictl.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/cri-tools/cmd/crictl"
 )
 
+// Run executes the embedded crictl against the container runtime socket.
 func Run(ctx *cli.Context) error {
 	// crictl parses os.Args itself, so hand it only its own arguments.
 	// Without this, `k8e crictl ps` would reach crictl as

--- a/pkg/cli/ctr/ctr.go
+++ b/pkg/cli/ctr/ctr.go
@@ -1,11 +1,17 @@
 package ctr
 
 import (
+	"os"
+
 	"github.com/urfave/cli"
 	"github.com/xiaods/k8e/pkg/ctr"
 )
 
 func Run(ctx *cli.Context) error {
+	// ctr parses os.Args itself, so hand it only its own arguments.
+	// Without this, `k8e ctr namespaces ls` would reach ctr with the extra
+	// wrapping "ctr" token and be rejected as a bad argument.
+	os.Args = append([]string{ctx.Command.Name}, ctx.Args()...)
 	ctr.Main()
 	return nil
 }

--- a/pkg/cli/ctr/ctr.go
+++ b/pkg/cli/ctr/ctr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/xiaods/k8e/pkg/ctr"
 )
 
+// Run executes the embedded ctr against the containerd socket.
 func Run(ctx *cli.Context) error {
 	// ctr parses os.Args itself, so hand it only its own arguments.
 	// Without this, `k8e ctr namespaces ls` would reach ctr with the extra

--- a/pkg/cli/kubectl/kubectl.go
+++ b/pkg/cli/kubectl/kubectl.go
@@ -1,11 +1,18 @@
 package kubectl
 
 import (
+	"os"
+
 	"github.com/urfave/cli"
 	"github.com/xiaods/k8e/pkg/kubectl"
 )
 
 func Run(ctx *cli.Context) error {
+	// kubectl parses os.Args itself, so hand it only its own arguments.
+	// Without this, `k8e kubectl get pods` would reach kubectl as
+	// ["kubectl", "kubectl", "get", "pods"] and fail with
+	// `unknown command "kubectl" for "kubectl"`.
+	os.Args = append([]string{ctx.Command.Name}, ctx.Args()...)
 	kubectl.Main()
 	return nil
 }

--- a/pkg/cli/kubectl/kubectl.go
+++ b/pkg/cli/kubectl/kubectl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/xiaods/k8e/pkg/kubectl"
 )
 
+// Run executes the embedded kubectl against the cluster's kubeconfig.
 func Run(ctx *cli.Context) error {
 	// kubectl parses os.Args itself, so hand it only its own arguments.
 	// Without this, `k8e kubectl get pods` would reach kubectl as

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -61,6 +61,36 @@ func validateSandboxFlags(cfg *cmds.Server) error {
 	return nil
 }
 
+// applyBundleDisables marks the components that are switched off by a dedicated
+// flag -- rather than by --disable=<name> -- as both skipped and disabled, so
+// that the manifests they bundle are neither staged nor applied:
+//
+//   - cilium (--disable-cilium): its chart and CRDs come from the k8e manifests.
+//   - ccm (--disable-cloud-controller): ccm.yaml only carries RBAC for the
+//     embedded cloud controller, and staging it would leave a cluster-role
+//     grant behind for a component that never runs.
+//   - sandbox-matrix (--disable-sandbox-matrix): manifests/sandbox-matrix ships
+//     the CRDs, RuntimeClasses, default warm pool, network policy and Gateway
+//     API bridge for the sandbox stack, none of which is reconciled once the
+//     matrix is off, leaving orphaned CRDs and an ownerless SandboxWarmPool.
+//
+// Kept out of run() because that function's cyclomatic complexity is already at
+// its limit; this is self-contained flag wiring.
+func applyBundleDisables(controlConfig *config.Control, cfg *cmds.Server) {
+	if cfg.DisableCilium {
+		controlConfig.Skips["cilium"] = true
+		controlConfig.Disables["cilium"] = true
+	}
+	if cfg.DisableCCM {
+		controlConfig.Skips["ccm"] = true
+		controlConfig.Disables["ccm"] = true
+	}
+	if cfg.DisableSandboxMatrix {
+		controlConfig.Skips["sandbox-matrix"] = true
+		controlConfig.Disables["sandbox-matrix"] = true
+	}
+}
+
 func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
 	var err error
 	// Validate build env
@@ -370,28 +400,7 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.Skips[disable] = true
 		serverConfig.ControlConfig.Disables[disable] = true
 	}
-	if cfg.DisableCilium {
-		serverConfig.ControlConfig.Skips["cilium"] = true
-		serverConfig.ControlConfig.Disables["cilium"] = true
-	}
-	// The bundled ccm.yaml manifest only contains RBAC for the embedded cloud
-	// controller. When the controller is disabled (--disable-cloud-controller,
-	// equivalent to --disable=ccm) its RBAC must not be staged or applied
-	// either, otherwise the cluster keeps a cluster-role grant for a component
-	// that never runs.
-	if cfg.DisableCCM {
-		serverConfig.ControlConfig.Skips["ccm"] = true
-		serverConfig.ControlConfig.Disables["ccm"] = true
-	}
-	// manifests/sandbox-matrix/* ships the CRDs, RuntimeClasses, default warm
-	// pool, network policy and Gateway API bridge for the sandbox stack. With
-	// --disable-sandbox-matrix no controller reconciles those objects, so the
-	// whole directory must be skipped instead of leaving orphaned CRDs and a
-	// SandboxWarmPool without an owner.
-	if cfg.DisableSandboxMatrix {
-		serverConfig.ControlConfig.Skips["sandbox-matrix"] = true
-		serverConfig.ControlConfig.Disables["sandbox-matrix"] = true
-	}
+	applyBundleDisables(&serverConfig.ControlConfig, cfg)
 	serverConfig.ControlConfig.CiliumDNSProxyEnabled = cfg.CiliumDNSProxyEnabled
 
 	tlsMinVersionArg := getArgValueFromList("tls-min-version", serverConfig.ControlConfig.ExtraAPIArgs)

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -91,6 +91,8 @@ func applyBundleDisables(controlConfig *config.Control, cfg *cmds.Server) {
 	}
 }
 
+// run starts the k8e server: it resolves the runtime configuration, brings up the
+// control plane and blocks until it is shut down.
 func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
 	var err error
 	// Validate build env

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -93,6 +93,8 @@ func applyBundleDisables(controlConfig *config.Control, cfg *cmds.Server) {
 
 // run starts the k8e server: it resolves the runtime configuration, brings up the
 // control plane and blocks until it is shut down.
+//
+// skipcq: GO-R1005
 func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomControllers, controllers server.CustomControllers) error {
 	var err error
 	// Validate build env

--- a/pkg/cli/server/server.go
+++ b/pkg/cli/server/server.go
@@ -374,6 +374,24 @@ func run(app *cli.Context, cfg *cmds.Server, leaderControllers server.CustomCont
 		serverConfig.ControlConfig.Skips["cilium"] = true
 		serverConfig.ControlConfig.Disables["cilium"] = true
 	}
+	// The bundled ccm.yaml manifest only contains RBAC for the embedded cloud
+	// controller. When the controller is disabled (--disable-cloud-controller,
+	// equivalent to --disable=ccm) its RBAC must not be staged or applied
+	// either, otherwise the cluster keeps a cluster-role grant for a component
+	// that never runs.
+	if cfg.DisableCCM {
+		serverConfig.ControlConfig.Skips["ccm"] = true
+		serverConfig.ControlConfig.Disables["ccm"] = true
+	}
+	// manifests/sandbox-matrix/* ships the CRDs, RuntimeClasses, default warm
+	// pool, network policy and Gateway API bridge for the sandbox stack. With
+	// --disable-sandbox-matrix no controller reconciles those objects, so the
+	// whole directory must be skipped instead of leaving orphaned CRDs and a
+	// SandboxWarmPool without an owner.
+	if cfg.DisableSandboxMatrix {
+		serverConfig.ControlConfig.Skips["sandbox-matrix"] = true
+		serverConfig.ControlConfig.Disables["sandbox-matrix"] = true
+	}
 	serverConfig.ControlConfig.CiliumDNSProxyEnabled = cfg.CiliumDNSProxyEnabled
 
 	tlsMinVersionArg := getArgValueFromList("tls-min-version", serverConfig.ControlConfig.ExtraAPIArgs)

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -30,6 +30,8 @@ func createRootlessConfig(argsMap map[string]string, controllers map[string]bool
 	logrus.Fatal("delegated cgroup v2 controllers are required for rootless.")
 }
 
+// applyRuntimeSocketArgs points kubelet and cadvisor at the container runtime and
+// image service sockets.
 func applyRuntimeSocketArgs(argsMap map[string]string, cfg *config.Agent) {
 	if cfg.RuntimeSocket == "" {
 		return

--- a/pkg/daemons/agent/agent_linux.go
+++ b/pkg/daemons/agent/agent_linux.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 
+	cadvisorcontainerd "github.com/google/cadvisor/lib/container/containerd"
 	"github.com/moby/sys/userns"
 	"github.com/sirupsen/logrus"
 	"github.com/xiaods/k8e/pkg/cgroups"
@@ -35,7 +36,12 @@ func applyRuntimeSocketArgs(argsMap map[string]string, cfg *config.Agent) {
 	}
 	argsMap["serialize-image-pulls"] = "false"
 	if strings.Contains(cfg.RuntimeSocket, "containerd") {
-		argsMap["containerd"] = cfg.RuntimeSocket
+		// cadvisor needs the containerd endpoint to collect container stats. The
+		// kubelet used to expose this as a --containerd flag, but stopped
+		// registering it in v1.37, so the flag now makes kubelet fail to parse
+		// its own arguments ("unknown flag: --containerd") and the agent never
+		// comes up. Set the cadvisor flag value directly instead.
+		*cadvisorcontainerd.ArgContainerdEndpoint = strings.TrimPrefix(cfg.RuntimeSocket, socketPrefix)
 	}
 	// cadvisor wants the containerd CRI socket without the prefix, but kubelet wants it with the prefix
 	if strings.HasPrefix(cfg.RuntimeSocket, socketPrefix) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,3 +9,11 @@ sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/d
 # carries name/description/parameters/output/execute); the structural
 # similarity is API boilerplate, not copy-paste duplication.
 sonar.cpd.exclusions=plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/**,**/package-lock.json,**/pnpm-lock.yaml
+
+# The E2E image is a throwaway single-node control plane: it has to run as root
+# to start kubelet and containerd and to write their state under /var/lib, so
+# docker:S6471 ("the base image runs with root as the default user") does not
+# apply. Everything else in the file is still analysed.
+sonar.issue.ignore.multicriteria=e2eDockerfileRunsAsRoot
+sonar.issue.ignore.multicriteria.e2eDockerfileRunsAsRoot.ruleKey=docker:S6471
+sonar.issue.ignore.multicriteria.e2eDockerfileRunsAsRoot.resourceKey=hack/e2e/Dockerfile

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,16 +2,8 @@
 sonar.projectKey=xiaods_k8e
 
 # Exclude generated protobuf code and lock files (generated/mechanical —
-# never counted for duplication or issue analysis), plus the E2E image: it is a
-# throwaway single-node control plane that has to run as root to start kubelet and
-# containerd and to write their state under /var/lib, so docker:S6471 ("the base
-# image runs with root as the default user") is a permanent false positive there
-# and would keep the new-code security rating at B.
-#
-# sonar.issue.ignore.multicriteria is not the tool for it here: SonarCloud runs
-# this project's analysis in automatic mode, which does not apply those rules
-# (verified -- the issue stayed open in the PR after they were added).
-sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go,**/package-lock.json,**/pnpm-lock.yaml,hack/e2e/Dockerfile
+# never counted for duplication or issue analysis)
+sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go,**/package-lock.json,**/pnpm-lock.yaml
 
 # dsh plugin tools follow the framework-mandated defineTool shape (each tool
 # carries name/description/parameters/output/execute); the structural

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,18 +2,18 @@
 sonar.projectKey=xiaods_k8e
 
 # Exclude generated protobuf code and lock files (generated/mechanical —
-# never counted for duplication or issue analysis)
-sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go,**/package-lock.json,**/pnpm-lock.yaml
+# never counted for duplication or issue analysis), plus the E2E image: it is a
+# throwaway single-node control plane that has to run as root to start kubelet and
+# containerd and to write their state under /var/lib, so docker:S6471 ("the base
+# image runs with root as the default user") is a permanent false positive there
+# and would keep the new-code security rating at B.
+#
+# sonar.issue.ignore.multicriteria is not the tool for it here: SonarCloud runs
+# this project's analysis in automatic mode, which does not apply those rules
+# (verified -- the issue stayed open in the PR after they were added).
+sonar.exclusions=pkg/sandboxmatrix/grpc/pb/**,pkg/apis/**,pkg/generated/**,pkg/deploy/zz_generated_bindata.go,**/package-lock.json,**/pnpm-lock.yaml,hack/e2e/Dockerfile
 
 # dsh plugin tools follow the framework-mandated defineTool shape (each tool
 # carries name/description/parameters/output/execute); the structural
 # similarity is API boilerplate, not copy-paste duplication.
 sonar.cpd.exclusions=plugins/deepseek-harness/packages/dsh-k8e-sandbox-tool/**,**/package-lock.json,**/pnpm-lock.yaml
-
-# The E2E image is a throwaway single-node control plane: it has to run as root
-# to start kubelet and containerd and to write their state under /var/lib, so
-# docker:S6471 ("the base image runs with root as the default user") does not
-# apply. Everything else in the file is still analysed.
-sonar.issue.ignore.multicriteria=e2eDockerfileRunsAsRoot
-sonar.issue.ignore.multicriteria.e2eDockerfileRunsAsRoot.ruleKey=docker:S6471
-sonar.issue.ignore.multicriteria.e2eDockerfileRunsAsRoot.resourceKey=hack/e2e/Dockerfile


### PR DESCRIPTION
## Summary

Adds a container-based E2E harness with two profiles, runs both in CI, and fixes the defects those profiles surfaced. The 1.37 upgrade landed on unit tests plus a single OrbStack recovery script; broken CLI plumbing, a removed kubelet flag, the manifests of disabled components and a containerd config that only breaks on KVM hosts all slipped through it.

## What changed

### The harness (`hack/e2e/`)

| Profile | Scope | Checks |
|---------|-------|--------|
| `l1` | control plane only (no agent, no kubelet) | 30 |
| `l2` | control plane + agent: containerd, CRI shims, runc, a real pod | 20 |

`up.sh`/`down.sh` own the container lifecycle, `run.sh <profile>` drives one run (up → suite → diagnostics on failure → down), `lib.sh` carries the shared helpers, `dump-logs.sh` collects diagnostics, `suites/` holds the checks, and `build-linux.sh` builds a linux binary from macOS with the same tags as `zig build k8e`. Entry points: `make e2e E2E_PROFILE=l1|l2` or `hack/e2e/run.sh l2`.

State lives on the host under `${E2E_DATA_DIR}` so a run can be inspected after the container is gone. Two things must not live there, and both fail silently if they do:

- **containerd's snapshot storage.** The virtiofs share behind a Docker Desktop/OrbStack bind mount cannot back an overlayfs upper layer: the cluster comes up healthy and every pod then dies with `mkdirat(.../rootfs, "proc", 0o755): Read-only file system`. The runtime gets a Docker volume linked in by the container entrypoint, and a nested volume mount under the share turned out not to be applied at all (`docker inspect` lists it, `/proc/mounts` does not), so the volume is mounted outside the bind mount. `up.sh` probes for this capability and fails with one clear message instead of leaving a healthy-looking cluster behind.
- **registry access.** The node has none, so images are pulled on the host and imported into containerd; the list comes from `E2E_PRELOAD_IMAGES`.

`hack/test-sandbox-mcp-orbstack.sh` becomes a thin wrapper mapping the historical `K8E_MCP_*` variables onto the harness.

### Defects found and fixed

1. **CLI** — `k8e kubectl …`, `k8e ctr …` and `k8e crictl …` passed the command line through unchanged, so each embedded tool parsed its own name twice: `k8e kubectl get pods` failed with `unknown command "kubectl" for "kubectl"`.
2. **kubelet flags** — 1.37 dropped `--containerd`. Injecting it made kubelet reject its own arguments (`unknown flag: --containerd`) and the agent never came up; cadvisor's endpoint is now set directly.
3. **disabled components** — `--disable-cloud-controller` still staged `ccm.yaml`, and `--disable-sandbox-matrix` still staged the whole `manifests/sandbox-matrix/` tree (CRDs, RuntimeClasses, warm pool, network policy, Gateway API bridge) with no controller to own those objects.
4. **CI** — the `e2e-l1` and `e2e-l2` jobs run the profiles on every push.

## Verification

Performed on **linux/arm64** (OrbStack container) with `bin/k8e-linux-arm64` built from this tree:

| Check | Result |
|-------|--------|
| `hack/e2e/run.sh l1` | 30 checks, 0 failures |
| `hack/e2e/run.sh l2` | 20 checks, 0 failures (repeated runs) |
| pod through kubelet → containerd → runc | Running, output readable through the kubelet log endpoint |
| cluster restart recovery (l1 + l2) | pass |
| `make e2e E2E_PROFILE=l2` (the CI entry point) | pass |
| overlay probe | fails on the virtiofs share, passes on the runtime volume |
| `bash -n` on every harness script | clean |
| workflow YAML | parses; job list verified |

---

## Follow-up: the first CI runs of the new jobs

The new jobs found one more product defect plus several harness defects, and two static-analysis gates turned red on the new code. All of it is fixed in the commits after `58641be`.

### Round 1

| Failing check | Root cause | Fix |
|---------------|------------|-----|
| `E2E L2` (6m) | k8e's containerd config template declared a `[proxy_plugins.devmapper]` snapshotter proxy. containerd already links in a devmapper snapshotter plugin, so registering the same plugin id twice panics at startup (`plugin: id already registered`) and containerd exits 2 before starting a container. The branch is only rendered when `/dev/kvm` exists — i.e. on a KVM host and on the CI runner, but not on Docker Desktop/OrbStack, which is why it passed locally. | Dropped the declaration: nothing in the config selects a proxy snapshotter, the built-in one is used instead. Regression test added. |
| `E2E L1` (11m) | `e2e_rewrite_kubeconfig` read the kubeconfig off the bind mount, but the server writes it as root/0600. The macOS bind-mount mapping hid that; on Linux the runner user got `Permission denied` until the 300s API wait expired. | Read it with `docker exec cat` (root in the container) into a temp file, then rename. |
| (why the failures were opaque) | `up.sh` dying meant `run.sh` never called `dump-logs.sh`, so both jobs uploaded **no** artifact and the containerd panic was never shown. | A bring-up failure is now diagnosed like a suite failure, and the diagnostics/CI log include containerd's own log via `docker cp` (it lives on the runtime volume, and `docker cp` works on an exited container). |
| `SonarCloud` | 5 vulnerabilities on new code: 2× `docker:S6506` (curl not pinned to HTTPS), 2× `githubactions:S7637` (third-party action not pinned to a SHA), 1× `docker:S6471` (base image runs as root). One MINOR vulnerability alone caps the security rating at B, and the gate requires A. | Pin both curls with `--proto/--proto-redir`; pin `mlugg/setup-zig` to the commit behind `v2`; keep `hack/e2e/Dockerfile` out of the analysis, since that container has to run as root. |
| `DeepSource: Go` | `run()` grew past its complexity limit (`GO-R1005`, 76 → 77) from the new flag wiring. | The wiring moves into a documented `applyBundleDisables` helper, so `run()` is back at its previous complexity. |

### Round 2

Both E2E jobs got past the round-1 failures — containerd starts with `Snapshotter: overlayfs`, the kubeconfig is readable — and then hit two more harness bugs. Both are invisible on a macOS bind mount and only reproduce on a plain Linux host; both are fixed in `7c99632`:

| Failing check | Root cause | Fix |
|---------------|------------|-----|
| `E2E L2` (6m) | kubelet refused to start: `could not read controllers for cgroup ["k8e-e2e"]: open /sys/fs/cgroup/k8e-e2e/cgroup.controllers: no such file or directory`. The profile passed `--kubelet-arg=cgroup-root=/k8e-e2e`, and kubelet resolves that value against the **cgroup filesystem**, not the container root — the entrypoint only created `/k8e-e2e` in the container's own root, which kubelet never looks at. | Drop the override, so kubelet uses its default root `/` — what a real node runs, since `cgroups-per-qos` is on by default (`cmd/kubelet/app/server.go`). The entrypoint block and the `K8E_E2E_CGROUP_ROOT` plumbing disappear with it. |
| `E2E L1` (11m) | API, addons and restart recovery all worked, but the staging checks read the manifests through the host bind mount. The server creates the data tree as root/0700, so the unprivileged runner cannot even traverse `${E2E_DATA_DIR}/data` — `[ -d …/server/manifests ]` is false while the container log shows `Applied manifest at "/test/data/server/manifests/rolebindings.yaml"`. Docker Desktop/OrbStack map ownership to the caller, which is why it passed locally. | The manifest checks and the data-directory diagnostics go through `e2e_in_container`, the same idea as the kubeconfig fix. `hack/e2e/entrypoint.sh` also joins the `bash -n` list. |
| `SonarCloud` | Neither `sonar.issue.ignore.multicriteria` nor `sonar.exclusions` in `sonar-project.properties` had any effect: this project is analysed by SonarQube Cloud's **automatic analysis**, which ignores that file entirely (it reads `.sonarcloud.properties`, and does not support per-issue ignoring at all). The single MINOR `docker:S6471` vulnerability therefore kept the new-code security rating at B. | Put the exclusion where automatic analysis reads it: a new `.sonarcloud.properties`, mirroring the settings of the ignored file and excluding `hack/e2e/Dockerfile`. Quality Gate now passes with 0 vulnerabilities on new code. |

### Round 3

The last red check was DeepSource, and it was reporting an *introduced* issue rather than anything wrong with the change. Its page shows Documentation Coverage for the run at 0.2% against a 39.0% threshold, but that banner is what `main` shows too (39.2%) and it does not fail the analysis: the failing part was `GO-R1005` on `run()`.

| Failing check | Root cause | Fix |
|---------------|------------|-----|
| `DeepSource: Go` | `.deepsource.toml` already ignores `GO-R1005` for `pkg/cli/server/server.go` (added by #558, which is why `main` passes), but that ignore is matched against the finding as it was recorded and does not follow the value it is keyed on when the function is edited — this PR edits `run()`, so DeepSource reported the rule again at complexity 74. | `skipcq: GO-R1005`, DeepSource's in-code suppression for exactly this rule, on the declaration the finding points at. The analysis now passes with 0 issues introduced; `run()` itself is untouched and less complex than on `main` (74 vs 76). |

The declarations this PR adds or modifies (`crictl.Run`, `ctr.Run`, `kubectl.Run`, the kubelet socket wiring, the server entry point) also picked up the doc comments they were missing while the coverage metric was being investigated.

Verification of the environment-dependent bugs, all on linux/arm64:


| Check | Result |
|-------|--------|
| `l2` with `/dev/null` bind-mounted over `/dev/kvm` (forces the Firecracker branch) | 20 checks, 0 failures; generated config has `runtimes."firecracker"` and no `proxy_plugins` |
| same host, old template restored | reproduces `panic: io.containerd.snapshotter.v1.devmapper: plugin: id already registered` and containerd exits 2 — the exact CI failure |
| `go test ./pkg/agent/containerd/` (new test + existing ones, run inside the E2E image) | pass |
| `hack/e2e/run.sh l1` | 30 checks, 0 failures — includes the container-side staging check |
| `hack/e2e/run.sh l2` | 20 checks, 0 failures — kubelet starts on its default cgroup root, no `--kubelet-arg=cgroup-root` in the profile flags |
| CI run of the fixed tree (`411f37c4d`) | `E2E L1`, `E2E L2`, `Build & Test (linux/amd64)` and `Cross-compile check` all green — the two bugs above only reproduced on the CI runner |
| Final commit `d7a9414` | every check green: `Build & Test`, `Cross-compile check`, `E2E L1`, `E2E L2`, `MCP API Key and HTTPS interoperability`, `SonarCloud Code Analysis`, `DeepSource: Go`, `security/snyk` |

