### PR TITLE
fix(control): drop removed legacy cloud controllers from kube-controller-manager

### DIFF
--- a/pkg/daemons/control/server.go
+++ b/pkg/daemons/control/server.go
@@ -118,7 +118,10 @@ func controllerManager(ctx context.Context, cfg *config.Control) error {
 	}
 	if !cfg.DisableCCM {
 		argsMap["configure-cloud-routes"] = "false"
-		argsMap["controllers"] = argsMap["controllers"] + ",-service,-route,-cloud-node-lifecycle"
+		// The legacy cloud controllers (service-lb-controller, node-route-controller and
+		// cloud-node-lifecycle-controller) were removed from kube-controller-manager in
+		// Kubernetes 1.32, so they must not be disabled here: passing them causes
+		// "is not in the list of known controllers" and aborts startup.
 	}
 
 	if cfg.VLevel != 0 {


### PR DESCRIPTION
## Problem

Starting `k8e` on a fresh node fails immediately with:

```
Error: ["service" is not in the list of known controllers, "route" is not in the list of known controllers, "cloud-node-lifecycle" is not in the list of known controllers]
Usage:
  kube-controller-manager [flags]
```

## Root cause

`controllerManager()` appends a disable list to `--controllers` when the embedded CCM is enabled:

```go
if !cfg.DisableCCM {
    argsMap["configure-cloud-routes"] = "false"
    argsMap["controllers"] = argsMap["controllers"] + ",-service,-route,-cloud-node-lifecycle"
}
```

Kubernetes **1.32 removed the legacy cloud provider integration from kube-controller-manager** — the `service-lb-controller`, `node-route-controller` and `cloud-node-lifecycle-controller` no longer exist there. k8e is pinned to `k8s.io/kubernetes v1.37.0-k3s1`, so disabling controllers that are not in the known-controllers list makes flag validation fail and aborts startup.

Reference: `pkg/controller/{cloud,service,route}` no longer exist under `cmd/kube-controller-manager`, and the controller descriptors in `cmd/kube-controller-manager/app/controller_descriptor.go` have no `service` / `route` / `cloud-node-lifecycle` entries (not even as aliases).

## Fix

The controllers are gone from kube-controller-manager, so there is nothing left to disable. Drop the stale disable list and keep `configure-cloud-routes=false`, which is still a valid KCM flag.

This matches upstream k3s (`k3s-io/k3s` `pkg/daemons/control/server.go`), which only sets `configure-cloud-routes` for this case.

## Verification

- `go build ./pkg/daemons/control/` passes.
- Confirmed the pinned `k8s.io/kubernetes v1.37.0-k3s1` known-controller list no longer contains these names.
- Confirmed the CCM side still registers `route` / `cloud-node` / `cloud-node-lifecycle` via `k8s.io/cloud-provider/names.CCMControllerAliases()`, so the embedded `cloudControllerManager()` arguments (`*,-route`) remain valid.
